### PR TITLE
Fix the iOS release build: iOS has no USB, so do not name USBManager there

### DIFF
--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -279,12 +279,22 @@ Two mechanical traps when adding `QML_ELEMENT` to a header:
   guard passes, and the next member access dereferences null. `USBManager` and `UsbScaleManager`
   hit exactly this: three bindings in `SettingsConnectionsTab.qml` would have thrown on iOS, and
   a `visible:` gate does not save you, because an invisible element's bindings still evaluate.
+  - **`USBManager` and `UsbScaleManager` are no longer the live example — they are unregistered on
+    iOS again** (#1696). Registering them there meant naming the types, naming them meant including
+    headers that include `<QSerialPort>`, and iOS builds no part of `src/usb/` and links no
+    SerialPort module — it broke the iOS release build outright. So for those two on iOS the name
+    does not resolve at all: `typeof` is `"undefined"` and a bare reference is a **ReferenceError**,
+    not a truthy wrapper. Both failure modes are real; which one you get depends on whether the
+    TYPE is registered on that platform, and that is the question to answer before writing a guard.
   - Fix: guard on the **condition**, not on the name's existence — the file's own
-    `readonly property bool usbAvailable: Qt.platform.os !== "ios"`, or a plain truthiness test
-    (`X ? X.member : ...`), both of which are correct for a null singleton *and* an absent one.
-  - Use `decenzaOptionalSingleton()` (not `decenzaPublishedSingleton()`) for a name whose instance
-    legitimately does not exist on some builds; the loud helper would `qCritical` on every launch
-    of the platform that is behaving correctly.
+    `readonly property bool usbAvailable: Qt.platform.os !== "ios"`. A plain truthiness test
+    (`X ? X.member : ...`) is correct only for a registered-but-null singleton; on an unregistered
+    name the bare `X` throws before the `?` is reached, so it is not a substitute.
+  - Use `decenzaOptionalSingleton()` (not `decenzaPublishedSingleton()`) only where the type is
+    registered on a build that cannot publish an instance — `GHCSimulator` is the one such case
+    left; the loud helper would `qCritical` on every launch of the platform that is behaving
+    correctly. Where the registration and the publish share one `#ifdef`, use the loud form: a null
+    there is a real defect, not a platform.
   - Grep for `typeof <Name>` before migrating. If there are none, check anyway for
     `Qt.platform.os` tests near the uses — those are the same guard written a different way, and
     they are the ones that stay correct.
@@ -478,7 +488,14 @@ So the name passes both halves of the usual guard and the first method call thro
 
 **Guard the member you are about to use, or use a platform check** (`Qt.platform.os !== "ios"`),
 which short-circuits before the member read — that is why `USBManager`'s call sites were never
-affected while `GHCSimulator`'s were. `GHCSimulator` is registered wherever `DECENZA_SIMULATOR` is
+affected while `GHCSimulator`'s were.
+
+The member guard is right for *this* case and wrong for its mirror image: a type that is **not
+registered on the build at all** (`USBManager` and `UsbScaleManager` on iOS, since #1696). There
+the name resolves to nothing and Qt throws — `qv4qmlcontext.cpp:552-553` ends the lookup with
+`engine->throwReferenceError(name->toQString())` — so the bare name in `X.doThing !== undefined`
+throws before the member is reached. A platform check is the one idiom correct in both cases; use
+it whenever a `#ifdef` decides whether the type exists. `GHCSimulator` is registered wherever `DECENZA_SIMULATOR` is
 defined (every desktop config) but instanced only on a **debug** Windows/macOS build, so the broken
 guard passed — and threw on every window activation — on Linux, on Release desktop and on mobile
 Debug, while working on exactly the two configurations it gets tested on.

--- a/src/core/contextsingletons_qml.h
+++ b/src/core/contextsingletons_qml.h
@@ -43,8 +43,11 @@
 // §4 and the LIFETIME note below for how each obstacle was actually removed.
 //
 // "Inside `#ifndef Q_OS_IOS`" used to be listed here as a blocker for USBManager and
-// UsbScaleManager. It was a real obstacle but a small one, and it is gone: see
-// decenzaOptionalSingleton() below. "Types already registered uncreatable in their own headers"
+// UsbScaleManager. decenzaOptionalSingleton() below removes it for the INSTANCE — a name may be
+// registered on a build that never publishes one. It does not remove it for the TYPE: on iOS these
+// two are not registered at all, because naming them means including headers that include
+// <QSerialPort>, which that platform does not build or link. See the note above USBManagerForeign.
+// "Types already registered uncreatable in their own headers"
 // was listed as a blocker too — that one was simply wrong. Only SteamHealthTracker was ever in
 // that shape, and the registration just moved here.
 //
@@ -92,8 +95,14 @@
 #include "../models/flowcalibrationmodel.h"
 #include "../ble/scaledeviceproxy.h"
 #include "../ble/refractometers/refractometerproxy.h"
+// iOS has no USB path at all: CMakeLists.txt builds none of src/usb/ there and does not
+// find_package or link Qt6::SerialPort, while usbmanager.h/usbscalemanager.h include <QSerialPort>
+// on every platform except Android. Including them here unguarded broke the iOS release build with
+// `fatal error: 'QSerialPort' file not found` — see the note above USBManagerForeign below.
+#ifndef Q_OS_IOS
 #include "../usb/usbmanager.h"
 #include "../usb/usbscalemanager.h"
+#endif
 
 // Guarded on DECENZA_SIMULATOR, which is what ghcsimulator.h itself guards on: the class drives
 // DE1Simulator and cannot exist without it. True for every desktop configuration and for Debug on
@@ -135,9 +144,12 @@ T* decenzaPublishedSingleton(T* instance, QJSEngine* engine, const char* qmlName
 // The same publish, for a name whose instance legitimately does not exist on some builds.
 //
 // decenzaPublishedSingleton() treats a null instance as always a defect, which is right for a
-// name main() unconditionally owns and wrong for one behind a platform guard: USBManager and
-// UsbScaleManager are declared inside `#ifndef Q_OS_IOS`, so on iOS there is nothing to publish
-// and a qCritical on every launch would be noise reporting the intended state.
+// name main() unconditionally owns and wrong for one whose object is optional on a build that does
+// register the type — a qCritical on every launch would be noise reporting the intended state.
+//
+// USBManager and UsbScaleManager were the original callers and remain so, but note that on iOS
+// they are not registered at ALL now (see the note above USBManagerForeign), so this template is
+// not what covers them there.
 //
 // CRITICAL, AND NOT WHAT THIS COMMENT USED TO SAY: a null instance does NOT make the name read as
 // `undefined` in QML. It used to claim that, and every `typeof X !== "undefined"` guard written
@@ -482,17 +494,29 @@ public:
     }
 };
 
-// USBManager and UsbScaleManager are declared inside `#ifndef Q_OS_IOS` in main.cpp, so on iOS
-// there is no instance and create() returns null — hence decenzaOptionalSingleton() rather than
+// USBManager and UsbScaleManager are declared inside `#ifndef Q_OS_IOS` in main.cpp, so where the
+// types exist at all there may still be no instance — hence decenzaOptionalSingleton() rather than
 // the loud form. That guard was the whole reason these two stayed context properties.
 //
-// Registering them does NOT make the name resolve to an object on iOS, and it must not: the QML
-// side guards every use (`Qt.platform.os !== "ios"`, `typeof USBManager !== "undefined"`) and
-// those guards stay. What it buys is that the MEMBER is checked everywhere — `USBManager.de1Connected`
-// and `UsbScaleManager.scaleConnected` are typed now, on every platform including iOS, so a
-// misspelling fails the build rather than reading undefined on the one platform that has the object.
+// The pair is NOT registered on iOS. This comment used to claim the opposite — that the member was
+// "typed now, on every platform including iOS" — and that is what broke the v2.0.1 iOS build: the
+// types cannot be named on iOS without including their headers, the headers include <QSerialPort>,
+// and iOS builds no part of src/usb/ and links no SerialPort module. Typing them there was never
+// one `#include` away; it needs an iOS-buildable USB header, which is work with no payoff on a
+// platform that has no USB.
+//
+// Consequence, and it is the pre-#1687 behaviour restored: on iOS the NAMES do not resolve, so
+// evaluating one is a ReferenceError, not `undefined`. Every call site already short-circuits on
+// `Qt.platform.os` before the read (SettingsConnectionsTab's `usbAvailable`, main.qml:1576,
+// ScaleWeightItem.qml:61) — keep it that way, and never guard these two by the member alone.
+//
+// Nothing is lost on the qmllint gate, which runs on Linux where both types are registered.
+//
+// This defect is the six-platform rule in CI_CD.md, in the smallest possible form: the include
+// compiled on five platforms, and only a tag push ever compiles the sixth.
 
 // 8 references across 1 QML file.
+#ifndef Q_OS_IOS
 struct USBManagerForeign
 {
     Q_GADGET
@@ -523,6 +547,7 @@ public:
         return decenzaOptionalSingleton(s_singletonInstance, engine, "UsbScaleManager");
     }
 };
+#endif // !Q_OS_IOS
 
 // 3 references in main.qml, plus GHCSimulatorWindow.qml which its own engine loads.
 //

--- a/src/core/contextsingletons_qml.h
+++ b/src/core/contextsingletons_qml.h
@@ -34,7 +34,9 @@
 // The 30 context properties live when this file was created accounted for 943 such warnings. The
 // names registered BELOW are now ALL 943 — 660 in the first batch (#1680), plus
 // SteamHealthTracker, FlowCalibrationModel, ProfileStorage and McpServer, plus USBManager and
-// UsbScaleManager, and finally GHCSimulator, ScaleDevice and Refractometer. Update this figure
+// UsbScaleManager (everywhere but iOS — see below), and finally GHCSimulator, ScaleDevice and
+// Refractometer. The figure is unchanged by the iOS exclusion, because the gate that counts runs
+// on Linux, where both are registered. Update this figure
 // when you add an entry; it is the one number in this file that goes stale silently.
 //
 // NONE remain. `setContextProperty()` has no live call in main.cpp. The three that were listed
@@ -43,10 +45,11 @@
 // §4 and the LIFETIME note below for how each obstacle was actually removed.
 //
 // "Inside `#ifndef Q_OS_IOS`" used to be listed here as a blocker for USBManager and
-// UsbScaleManager. decenzaOptionalSingleton() below removes it for the INSTANCE — a name may be
-// registered on a build that never publishes one. It does not remove it for the TYPE: on iOS these
-// two are not registered at all, because naming them means including headers that include
-// <QSerialPort>, which that platform does not build or link. See the note above USBManagerForeign.
+// UsbScaleManager, and it is still one — for the TYPE. On iOS these two are not registered at all,
+// because naming them means including headers that include <QSerialPort>, which that platform does
+// not build or link. What #1687 did remove is the blocker for a name whose INSTANCE is optional;
+// that is decenzaOptionalSingleton() below, and GHCSimulator is what it covers. See the note above
+// USBManagerForeign.
 // "Types already registered uncreatable in their own headers"
 // was listed as a blocker too — that one was simply wrong. Only SteamHealthTracker was ever in
 // that shape, and the registration just moved here.
@@ -126,7 +129,8 @@ T* decenzaPublishedSingleton(T* instance, QJSEngine* engine, const char* qmlName
     // Checked, not asserted. QT_FORCE_ASSERTS is only defined for sanitizer builds
     // (CMakeLists.txt), so Q_ASSERT compiles out of a shipped Release — and this is the one
     // condition where that matters: with the instance unpublished, create() returns null, every
-    // reference to the name reads undefined, and nothing says why.
+    // MEMBER READ on the name reads undefined, and nothing says why. (The name itself stays a
+    // truthy object — see the note on decenzaOptionalSingleton() below.)
     if (!instance) {
         qCritical("%s: QML asked for the singleton before main() published it. Every binding on "
                   "this name will be undefined. Publish it before QQmlEngine::load().", qmlName);
@@ -147,9 +151,10 @@ T* decenzaPublishedSingleton(T* instance, QJSEngine* engine, const char* qmlName
 // name main() unconditionally owns and wrong for one whose object is optional on a build that does
 // register the type — a qCritical on every launch would be noise reporting the intended state.
 //
-// USBManager and UsbScaleManager were the original callers and remain so, but note that on iOS
-// they are not registered at ALL now (see the note above USBManagerForeign), so this template is
-// not what covers them there.
+// GHCSimulator is the only caller. USBManager and UsbScaleManager were the original two and are
+// not any more: their registration and their publish are now behind the SAME `#ifndef Q_OS_IOS`,
+// so there is no build where the type exists and the instance does not, and a null there would be
+// a real publish-order defect that this quiet form would hide. They use the loud form.
 //
 // CRITICAL, AND NOT WHAT THIS COMMENT USED TO SAY: a null instance does NOT make the name read as
 // `undefined` in QML. It used to claim that, and every `typeof X !== "undefined"` guard written
@@ -168,10 +173,19 @@ T* decenzaPublishedSingleton(T* instance, QJSEngine* engine, const char* qmlName
 // and `if (X)` both PASS, and the first method call throws
 // `TypeError: Property '...' of object [object Object] is not a function`.
 //
-// Guard the MEMBER, never the name:
+// Guard the MEMBER, never the name — for THIS case, which is: the type is registered on the build
+// and the instance may be missing.
 //
 //     if (X.doThing !== undefined) X.doThing()        // correct
 //     if (typeof X !== "undefined" && X) X.doThing()  // passes, then throws
+//
+// The other case is the opposite and needs the opposite guard: a type NOT registered on the build
+// at all (USBManager and UsbScaleManager on iOS). The name then resolves to nothing, and
+// qv4qmlcontext.cpp:552-553 ends the lookup with `engine->throwReferenceError(name->toQString())`
+// — so the bare `X` in `X.doThing !== undefined` throws before the member is reached. Guard the
+// PLATFORM there. (`typeof X` happens to be honest in this case: Runtime::TypeofName::call clears
+// the exception on purpose, qv4runtime.cpp:1746-1754, "typeof doesn't throw". Do not rely on that
+// asymmetry — one idiom that is right in both cases is the platform check.)
 //
 // A platform check (`Qt.platform.os !== "ios"`) is also fine, because it short-circuits before the
 // member read — that is why the USB pair's call sites were never affected by this.
@@ -494,9 +508,10 @@ public:
     }
 };
 
-// USBManager and UsbScaleManager are declared inside `#ifndef Q_OS_IOS` in main.cpp, so where the
-// types exist at all there may still be no instance — hence decenzaOptionalSingleton() rather than
-// the loud form. That guard was the whole reason these two stayed context properties.
+// USBManager and UsbScaleManager are declared inside `#ifndef Q_OS_IOS` in main.cpp, and these two
+// structs are behind the same guard, so the type and the instance appear and disappear together.
+// That is why they take decenzaPublishedSingleton() and not the quiet decenzaOptionalSingleton():
+// a null instance here is no longer a platform, it is a publish-order defect, and it should say so.
 //
 // The pair is NOT registered on iOS. This comment used to claim the opposite — that the member was
 // "typed now, on every platform including iOS" — and that is what broke the v2.0.1 iOS build: the
@@ -506,14 +521,19 @@ public:
 // platform that has no USB.
 //
 // Consequence, and it is the pre-#1687 behaviour restored: on iOS the NAMES do not resolve, so
-// evaluating one is a ReferenceError, not `undefined`. Every call site already short-circuits on
-// `Qt.platform.os` before the read (SettingsConnectionsTab's `usbAvailable`, main.qml:1576,
-// ScaleWeightItem.qml:61) — keep it that way, and never guard these two by the member alone.
+// evaluating one throws a ReferenceError (qv4qmlcontext.cpp:552-553) rather than reading
+// `undefined`. Every call site is either short-circuited on `Qt.platform.os` before the read
+// (SettingsConnectionsTab's `usbAvailable`, main.qml:1576, ScaleWeightItem.qml:61) or unreachable
+// behind one — the Disconnect handler at SettingsConnectionsTab.qml:622 names USBManager bare, and
+// is safe only because the ColumnLayout at :541 is invisible on iOS, so the handler never runs.
+// Keep it that way, and never guard these two by the member alone.
 //
 // Nothing is lost on the qmllint gate, which runs on Linux where both types are registered.
 //
 // This defect is the six-platform rule in CI_CD.md, in the smallest possible form: the include
-// compiled on five platforms, and only a tag push ever compiles the sixth.
+// compiled on five platforms, and no PR-time job compiles the sixth. Checking it before merge is
+// one command — `gh workflow run ios-release.yml --ref <branch> -f upload_to_appstore=false` —
+// which is how this fix was verified.
 
 // 8 references across 1 QML file.
 #ifndef Q_OS_IOS
@@ -528,7 +548,7 @@ public:
     inline static USBManager* s_singletonInstance = nullptr;
     static USBManager* create(QQmlEngine*, QJSEngine* engine)
     {
-        return decenzaOptionalSingleton(s_singletonInstance, engine, "USBManager");
+        return decenzaPublishedSingleton(s_singletonInstance, engine, "USBManager");
     }
 };
 
@@ -544,7 +564,7 @@ public:
     inline static UsbScaleManager* s_singletonInstance = nullptr;
     static UsbScaleManager* create(QQmlEngine*, QJSEngine* engine)
     {
-        return decenzaOptionalSingleton(s_singletonInstance, engine, "UsbScaleManager");
+        return decenzaPublishedSingleton(s_singletonInstance, engine, "UsbScaleManager");
     }
 };
 #endif // !Q_OS_IOS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3506,9 +3506,9 @@ int main(int argc, char *argv[])
 #ifndef Q_OS_IOS
     // The objects, the Foreign structs and the types themselves are all absent on iOS — that
     // platform builds no part of src/usb/ and links no SerialPort module. So the QML names do not
-    // resolve there and evaluating one is a ReferenceError; every call site short-circuits on
-    // Qt.platform.os before the read. See the note above USBManagerForeign in
-    // contextsingletons_qml.h.
+    // resolve there and evaluating one is a ReferenceError; every call site is short-circuited on
+    // Qt.platform.os before the read, or unreachable behind one. See the note above
+    // USBManagerForeign in contextsingletons_qml.h.
     USBManagerForeign::s_singletonInstance = &usbManager;
     UsbScaleManagerForeign::s_singletonInstance = &usbScaleManager;
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3504,9 +3504,11 @@ int main(int argc, char *argv[])
     LibrarySharingForeign::s_singletonInstance = &librarySharing;
     ShotHistoryExporterForeign::s_singletonInstance = &shotHistoryExporter;
 #ifndef Q_OS_IOS
-    // On iOS these two are never published and their create() returns null, so QML reads the name
-    // as undefined — which is what every call site there already guards for. See
-    // decenzaOptionalSingleton() in contextsingletons_qml.h for why that is not an error.
+    // The objects, the Foreign structs and the types themselves are all absent on iOS — that
+    // platform builds no part of src/usb/ and links no SerialPort module. So the QML names do not
+    // resolve there and evaluating one is a ReferenceError; every call site short-circuits on
+    // Qt.platform.os before the read. See the note above USBManagerForeign in
+    // contextsingletons_qml.h.
     USBManagerForeign::s_singletonInstance = &usbManager;
     UsbScaleManagerForeign::s_singletonInstance = &usbScaleManager;
 #endif


### PR DESCRIPTION
## What broke

The v2.0.1 iOS build (run 30431019346) failed:

```
src/usb/usbmanager.h:8:10: fatal error: 'QSerialPort' file not found
```

#1687 added `#include "../usb/usbmanager.h"` and `usbscalemanager.h` to `contextsingletons_qml.h` unguarded, so `USBManager` and `UsbScaleManager` could be registered as QML singletons. Both headers include `<QSerialPort>` on every platform except Android, and iOS builds no file under `src/usb/` and neither `find_package()`s nor links `Qt6::SerialPort` (CMakeLists.txt:104, :776, :1088).

Five platforms compiled it. Only a tag push ever compiles the sixth — the six-platform evidence rule in `CI_CD.md`, in its smallest form.

## Fix

Guard the two includes and the two `*Foreign` structs with `#ifndef Q_OS_IOS`. This restores the pre-#1687 iOS behaviour: the names do not resolve there. Every call site already short-circuits on `Qt.platform.os` before the member read — `SettingsConnectionsTab.usbAvailable`, `main.qml:1576`, `ScaleWeightItem.qml:61` — so no QML changes are needed, and none were made.

The qmllint gate runs on Linux, where both types are still registered, so no baseline moves.

Typing these two on iOS was never one `#include` away, which is what the comment being replaced asserted. It needs an iOS-buildable USB header — work with no payoff on a platform with no USB path. Three comments repeating that claim are corrected, including `main.cpp`'s, which also still said an unpublished singleton reads as `undefined` in QML (the same header disproves that a few lines up).

## Verification

- Full local suite via Qt Creator: **108 passed, 0 failed, 0 skipped**, no warnings.
- iOS build-only workflow dispatched on this branch: https://github.com/Kulitorum/Decenza/actions/runs/30432101785 — this is the check that matters; not merging until it is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)