### PR TITLE
Recover AOT compilation in Settings, Theme and IdlePage

### DIFF
--- a/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
+++ b/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
@@ -185,13 +185,18 @@ earlier draft said the swappable device handles "realistically cannot" be typed,
 because `ScaleDevice` and `Refractometer` are reassigned at 11 sites as hardware
 connects and disconnects, while the stable globals were the fixable ones. Measured:
 
-| | draft prediction | actual, now |
-|---|---|---|
-| `ScaleDevice`, `Refractometer` | unfixable | **0 skips** |
-| `AccessibilityManager` | fixable | **0 skips** |
-| `MainController` | fixable | 313 -> 152 |
-| `Settings` | fixable | 595 -> **539** |
-| `TranslationManager` | fixable | 1831 -> **1790** |
+| | draft prediction | after the cleanup | after #1698 |
+|---|---|---|---|
+| `ScaleDevice`, `Refractometer` | unfixable | **0 skips** | 0 |
+| `AccessibilityManager` | fixable | **0 skips** | 0 |
+| `MainController` | fixable | 313 -> 152 | **shadowable-base share fixed** |
+| `Settings` | fixable | 595 -> 539 | **shadowable-base share fixed** |
+| `TranslationManager` | fixable | 1831 -> **1790** | 1787 — permanent, see below |
+
+The middle column is the state the prediction was judged against; do not read it as
+current. #1698 then took the *shadowable-base* cause from 574 skips to 72 project-wide,
+which is the part of `Settings`/`MainController` that was fixable at all. Their residual
+skips now sit in other causes (untyped calls, unresolved ids), counted in the table above.
 
 The swappable ones went to zero because swapping moved *behind* a stable singleton
 that re-points its internals — mutability was never the obstacle, dynamic scoping

--- a/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
+++ b/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
@@ -110,38 +110,71 @@ It is not qmlcachegen — it is compiling what qmlcachegen emits: **2.0M lines**
 generated C++ across 216 files, every one containing AOT-compiled functions. Any
 lever aimed at this cost should target the generated C++, not the tool.
 
-## AOT coverage, and why it is only 45 %
+## AOT coverage, and the two levers that moved it
 
-**Re-measured 2026-07-29**, after the QML cleanup (#1665, #1688, #1690, #1695)
-took `setContextProperty` to zero and qmllint to 222/222. The previous numbers,
-and the prediction built on them, are kept below because the prediction turned
-out to be **wrong in both directions** and that is the useful part.
+**Re-measured 2026-07-29** after the QML cleanup (#1665, #1688, #1690, #1695) and
+again after #1698 (`FINAL` on the settings/controller accessors, type annotations
+in `Theme.qml` and `IdlePage.qml`).
 
 ```
-total bindings/functions  29097
-  AOT compiled            13017  (44.7%)
-  skipped -> interpreter  14665  (50.4%)
-  partial                  1415  ( 4.9%)
+                          post-cleanup      post-#1698
+total bindings/functions       29097           29097
+  AOT compiled            13017 (44.7%)   17631 (60.6%)
+  skipped -> interpreter  14665 (50.4%)   10051 (34.5%)
+  partial                  1415 ( 4.9%)    1415 ( 4.9%)
 ```
+
+**Read the measurement warning below before trusting any number you take
+yourself.** #1698 reported +1.7 points for days because every intermediate
+measurement was taken against a build that had recompiled only the two edited
+QML files. The other 213 units' `.aotstats` still described the *previous* state,
+so the change looked local. The real figure only appeared once a `Q_OBJECT`
+header edit invalidated `Decenza.qmltypes` and forced all 215 units to
+regenerate. **Before believing an AOT number, check that the `.aotstats` files
+are newer than your edit:**
+
+```bash
+find <build>/.rcc/qmlcache -name '*.aotstats' -newer <the file you changed> | wc -l
+```
+
+If that is not ~216, you are reading the last build, not this one.
+
+**The untyped-function cascade is the whole story.** Annotating ~32 functions in
+`Theme.qml` alone took `call to untyped JavaScript function` from **4,681 skips to
+499** — because `Theme.*` is called from every file in the app, so typing one
+file unblocked roughly 4,200 call sites elsewhere. This is the 8:1 ratio
+described below, paying off in the direction the ratio predicted. The `FINAL`
+work, by contrast, was worth 429 skips: real, but an order of magnitude smaller.
 
 Grouped by root cause:
 
 | Skips | Share | Cause |
 |---|---|---|
-| 4681 | 31.9 % | call to untyped JS function |
-| 2751 | 18.8 % | unresolved id / model role |
-| 2694 | 18.4 % | member on unresolved type |
-| 2186 | 14.9 % | other |
-| 1787 | 12.2 % | `TranslationManager.translate` — callable `Q_PROPERTY` |
-| 566 | 3.9 % | untyped function definition |
+| 2753 | 27.4 % | unresolved id / model role |
+| 2681 | 26.7 % | member on unresolved type |
+| 1787 | 17.8 % | `TranslationManager.translate` — callable `Q_PROPERTY` |
+| 1729 | 17.2 % | other |
+| 530 | 5.3 % | untyped function definition |
+| 499 | 5.0 % | call to untyped JS function (was 4681 / 31.9 %) |
+| 72 | 0.7 % | shadowable base type (was 574) |
 | **0** | — | **context property** (was 3351 / 19.0 %) |
 
-**Untyped JS functions (32 %) — unchanged, and now the whole story.** Of 1,111
-`function` declarations under `qml/`, **13** carry a return-type annotation and
-**15** a typed parameter. qmlcachegen will not compile an untyped function, and
-will not compile a *call* to one either — so 566 untyped definitions poison 4,681
-call sites, an 8:1 cascade. This is the one lever that would move the number, and
-nothing in the cleanup touched it.
+**Untyped JS functions — was 32 %, now 5 %, and still the best lever.** Of 1,111
+`function` declarations under `qml/`, **46** now carry a return-type annotation and
+**51** a typed parameter (13 and 15 before #1698). qmlcachegen will not compile an
+untyped function, and will not compile a *call* to one either, so definitions poison
+call sites at roughly 8:1. #1698 spent that ratio deliberately: ~32 annotations in
+`Theme.qml` plus 11 in `IdlePage.qml` cut the bucket from 4,681 to 499.
+
+**The remaining 530 untyped definitions are NOT all free to annotate.** Seven in
+`Theme.qml` (`tempUnitSuffix`, `cToDisplay`, …) are unannotated deliberately —
+annotating them made qmlcachegen produce a function returning `undefined` at
+runtime, and the mechanism is unexplained. See the comment at `qml/Theme.qml:406`.
+Annotations also change runtime semantics, not just codegen: a `string` parameter
+converts `undefined` to the literal `"undefined"` (`qv4jscall_p.h:337` ->
+`qv4runtime.cpp:618`), which silently defeats an `if (!x) return ""` guard. Optional
+parameters and guarded ones must be `var`, which coerces nothing
+(`qv4jscall_p.h:331`).
 
 **Context properties: gone.** `src/main.cpp` now contains zero `setContextProperty`
 calls and 23 QML singletons (`src/core/contextsingletons_qml.h`). The entire
@@ -172,13 +205,15 @@ that did not exist when it was written:
   `CLAUDE.md`). qmlcachegen cannot compile a call through a callable property. This
   is a **priced tradeoff, not a defect**: correct reactive translation costs 12 % of
   all AOT skips. Do not "fix" it without reading `tst_translationreactivity.cpp`.
-- **`Settings` (539) and `MainController` (152).** `Cannot use shadowable base type
-  for further lookups: Settings::theme with type SettingsTheme`. The 12 domain
-  sub-objects that `CLAUDE.md` mandates (`Settings.<domain>.<prop>`) are non-final
-  QObject-derived properties, so qmlcachegen refuses to chain a lookup through them
-  — a subclass could shadow the member. This one is genuinely fixable, by making
-  the domain types or the properties `FINAL`, and it is the largest remaining
-  self-inflicted bucket.
+- **`Settings` (539) and `MainController` (152) — FIXED in #1698, 574 -> 72.**
+  `Cannot use shadowable base type for further lookups: Settings::theme with type
+  SettingsTheme`. The 12 domain sub-objects that `CLAUDE.md` mandates
+  (`Settings.<domain>.<prop>`) were non-final `QObject`-derived properties, so
+  qmlcachegen refused to chain a lookup through them — a subclass could shadow the
+  member. `FINAL` on the accessors is the fix (`qqmljsshadowcheck.cpp:197-198`), and
+  `SETTINGS.md` now requires it on every new domain accessor. The 72 left are
+  scattered across `AIManager`, `DataMigrationClient` and friends, plus two on
+  `QQuickWindow` that are Qt's own.
 
 **The remaining third is largely downstream**, as before: `Could not find property
 "text"` (432), `"clicked"` (441), and `Cannot retrieve a non-object type by ID`

--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -88,6 +88,8 @@ KeyboardAwareContainer {
 
 Never override FINAL properties on Qt types. Qt 6.10+ marks some `Popup`/`Dialog` properties as FINAL (e.g., `message`, `title`). Declaring `property string message` on a Dialog will prevent the component from loading. Use a different name (e.g., `resultMessage`), or use the inherited property directly if it already exists on the base type.
 
+**This is not the same rule as `SETTINGS.md`'s "always add `FINAL`".** Two different things share the keyword: *don't shadow someone else's* `FINAL` property (this section), and *do mark your own* `Q_PROPERTY` final when QML chains a lookup through it, so qmlcachegen will AOT-compile it (`SETTINGS.md`, and `src/core/settings.h`). They never conflict — one is about a base type you don't own, the other about a property you declare.
+
 ## `elide` is silently ignored on `Text.RichText` — use `Text.StyledText`
 
 Qt applies `elide` to `Text.PlainText` and `Text.StyledText`, but **not `Text.RichText`** (a `QTextDocument`-backed format). A label with `textFormat: Text.RichText` and `elide: Text.ElideRight` does not truncate — it overruns its width and hard-clips mid-glyph with no ellipsis, which shows up on wider/fallback system fonts (issue #1469). Default to `Text.StyledText` for any HTML-ish label; it supports the tags we use (`<b> <i> <font color> <a href> <img> <br>`) and is lighter than RichText. Reserve `Text.RichText` for the rare label that genuinely needs `QTextDocument`-only features (tables, CSS blocks) — we currently have none. For inline emoji, `Theme.replaceEmojiWithImg` emits `<img align="middle">`, which StyledText honors (it ignores the CSS `style=` attribute). `TextEdit.RichText` (editable fields) is unaffected — this is about read-only `Text`.

--- a/docs/CLAUDE_MD/SETTINGS.md
+++ b/docs/CLAUDE_MD/SETTINGS.md
@@ -22,7 +22,7 @@ The split was tricky to get right — the rules below capture every gotcha that 
 
 Edit `src/core/settings_<domain>.h` and `.cpp`. Add:
 
-1. `Q_PROPERTY(...)` line in the header
+1. `Q_PROPERTY(... FINAL)` line in the header — include `FINAL`; see step 3 of "Adding a new domain" below for why omitting it silently costs AOT compilation
 2. Getter + setter declarations in the header
 3. NOTIFY signal in `signals:` section
 4. Getter/setter bodies in the `.cpp`, reading/writing through `m_settings.value(...)` / `m_settings.setValue(...)` with the domain's existing key prefix (e.g. `mqtt/`, `theme/`)
@@ -36,7 +36,8 @@ Full checklist (8 steps — missing one will silently break things):
 1. **Create `src/core/settings_<domain>.h` + `.cpp`**. Inherit `QObject`, own a `mutable AppSettings m_settings` (default-constructed — `AppSettings` names the store, see `src/core/appsettings.h`), declare properties + getters + setters + NOTIFY signals.
 2. **Add `#include "settings_<domain>.h"` to `src/core/settings.h`** with the other eleven.
    *(This reverses earlier guidance, which said never to include it. See "Why the includes are back" below — the short version is that avoiding it required erasing the property type, which blinded qmllint, `qmlcachegen` and the language server to 1,310 QML call sites.)*
-3. **Add `Q_PROPERTY(Settings<Domain>* <domain> READ <domain> CONSTANT)` to `Settings`** — the CONCRETE type, never `QObject*`. This is what lets every tool follow `Settings.<domain>.<prop>` through to the property.
+3. **Add `Q_PROPERTY(Settings<Domain>* <domain> READ <domain> CONSTANT FINAL)` to `Settings`** — the CONCRETE type, never `QObject*`. This is what lets every tool follow `Settings.<domain>.<prop>` through to the property.
+   *`FINAL` is required, not stylistic: without it `qmlcachegen` will not compile ANY chained lookup through the accessor. A non-final property could be shadowed by a subclass, so the base degrades to `var` and the next lookup off it fails with "Cannot use shadowable base type for further lookups" (`qqmljsshadowcheck.cpp:248`; `:197-198` is the final-property escape). Omitting it silently costs AOT compilation everywhere `Settings.<domain>.<prop>` is read — no error, no warning.*
 4. **Add typed inline accessor in header**: `Settings<Domain>* <domain>() const { return m_<domain>; }`. C++ callers use this (they include `settings_<domain>.h` themselves).
 5. *(No `QObject*` accessor. The `Q_PROPERTY` READs the typed accessor from step 4 directly — the old `<domain>QObject()` pair existed only to support the erased property type and has been deleted.)*
 6. **Construct in `Settings::Settings()` member-init list**: `, m_<domain>(new Settings<Domain>(this))`. Add the `#include "settings_<domain>.h"` in `settings.cpp`.

--- a/docs/CLAUDE_MD/SETTINGS.md
+++ b/docs/CLAUDE_MD/SETTINGS.md
@@ -22,7 +22,7 @@ The split was tricky to get right — the rules below capture every gotcha that 
 
 Edit `src/core/settings_<domain>.h` and `.cpp`. Add:
 
-1. `Q_PROPERTY(... FINAL)` line in the header — include `FINAL`; see step 3 of "Adding a new domain" below for why omitting it silently costs AOT compilation
+1. `Q_PROPERTY(... FINAL)` line in the header — include `FINAL`; see step 3 of "Adding a new domain" below for why omitting it silently costs AOT compilation. It is load-bearing on anything QML then reads a property *off* (`Settings.brew.x`, or `foo.length` on a string), and inert otherwise — these classes apply it uniformly rather than tracking which properties are currently chained. Not to be confused with `QML_GOTCHAS.md`'s "never override FINAL properties on Qt types", which is about shadowing a base type you don't own.
 2. Getter + setter declarations in the header
 3. NOTIFY signal in `signals:` section
 4. Getter/setter bodies in the `.cpp`, reading/writing through `m_settings.value(...)` / `m_settings.setValue(...)` with the domain's existing key prefix (e.g. `mqtt/`, `theme/`)

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -55,7 +55,7 @@ QtObject {
     // Convert emoji character to pre-rendered SVG image path.
     // Passes through qrc:/icons/... paths unchanged.
     // Returns "" when no asset is bundled — see _emojiAssetPath.
-    function emojiToImage(emoji) {
+    function emojiToImage(emoji: string): string {
         if (!emoji) return ""
         if (emoji.indexOf("qrc:") === 0) return emoji
         var cps = []
@@ -79,7 +79,7 @@ QtObject {
     // fixed at build time, so unlike Settings.theme.effectiveFontSizes there is nothing for
     // a binding to re-evaluate. See src/core/emojiassets.h.
     property bool _warnedNoEmojiAssets: false
-    function _emojiAssetPath(cps) {
+    function _emojiAssetPath(cps: var): string {
         if (!cps || cps.length === 0) return ""
         if (typeof EmojiAssets === "undefined") {
             // Distinct from "this emoji isn't bundled". If EmojiAssets is unresolvable, EVERY
@@ -122,7 +122,7 @@ QtObject {
     // Check if a Unicode code point is an emoji that would trigger Apple Color Emoji
     // font rendering (sbix PNG decoding on macOS, CBDT/CBLC on Android).
     // Returns true for characters that need to be rendered as images, not text glyphs.
-    function _isEmoji(cp) {
+    function _isEmoji(cp: int): bool {
         // Emoticons
         if (cp >= 0x1F600 && cp <= 0x1F64F) return true
         // Misc Symbols & Pictographs
@@ -163,7 +163,7 @@ QtObject {
     // renders from Apple Color Emoji ONLY because of the trailing U+FE0F — which is exactly
     // the colour-glyph path that crashes the render thread. The variation selector is the
     // signal, so use it rather than trying to enumerate every base character.
-    function _isEmojiPresentation(text, i, cp) {
+    function _isEmojiPresentation(text: string, i: int, cp: int): bool {
         var next = i + (cp > 0xFFFF ? 2 : 1)
         if (next >= text.length || text.codePointAt(next) !== 0xFE0F) return false
         // Bound it, but be honest about how loose the bound is: `cp >= 0xA9` is EVERY
@@ -194,7 +194,7 @@ QtObject {
     // screensaver authors, GitHub release notes -- cannot inject tags into the
     // RichText/StyledText renderer. Getting this wrong should fail visibly (raw
     // tags on screen), not silently.
-    function replaceEmojiWithImg(text, pixelSize, allowMarkup) {
+    function replaceEmojiWithImg(text: string, pixelSize: var, allowMarkup: var): string {
         if (!text) return ""
         var size = pixelSize || 16
         var result = ""
@@ -265,7 +265,7 @@ QtObject {
 
     // Strip emoji Unicode characters from a string entirely.
     // Use for plain-text Text elements where <img> tags aren't supported.
-    function stripEmoji(text) {
+    function stripEmoji(text: string): string {
         if (!text) return ""
         var result = ""
         var i = 0
@@ -283,7 +283,7 @@ QtObject {
     // Strip HTML tags and emoji from a string for accessible names.
     // Use on text that has been through replaceEmojiWithImg() to get
     // a clean plain-text string for TalkBack/VoiceOver.
-    function toAccessibleText(html) {
+    function toAccessibleText(html: string): string {
         if (!html) return ""
         // Decode entities as well as stripping tags. Callers now pass MarkdownRenderer output,
         // where QTextDocument::toHtml() has escaped & < > " and emitted &nbsp; — without this a
@@ -315,7 +315,7 @@ QtObject {
     //
     // CONTRACT: content only. Never interpolate untrusted text into an attribute value —
     // that needs quote escaping, which escaping > never provided anyway.
-    function escapeHtml(s) {
+    function escapeHtml(s: var): string {
         return String(s)
             .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
@@ -324,7 +324,7 @@ QtObject {
     // 6-digit hex (#rrggbb) for StyledText/RichText <font color> spans. The
     // point is STRIPPING ALPHA (Qt parses #AARRGGBB fine): a user-customized
     // translucent theme color would otherwise render the span see-through.
-    function colorToHex(c) {
+    function colorToHex(c: color): string {
         function h(x) { var s = Math.round(x * 255).toString(16); return s.length < 2 ? "0" + s : s }
         return "#" + h(c.r) + h(c.g) + h(c.b)
     }
@@ -336,7 +336,7 @@ QtObject {
     readonly property string bulletSep: " <font size=\"+1\"><b>·</b></font> "
 
     // Join already-computed text parts with bulletSep, HTML-escaping each part.
-    function joinWithBullet(parts) {
+    function joinWithBullet(parts: var): string {
         var sep = bulletSep
         var out = []
         for (var i = 0; i < parts.length; i++) {
@@ -349,7 +349,7 @@ QtObject {
     // Truncate a UTF-16 string at `cap` code units and append an ellipsis,
     // backing off one unit if cap would split a surrogate pair so we
     // don't emit an orphaned high surrogate to the accessibility tree.
-    function _truncateWithEllipsis(s, cap) {
+    function _truncateWithEllipsis(s: string, cap: int): string {
         if (s.length <= cap) return s
         var c = s.charCodeAt(cap - 1)
         var cut = (c >= 0xD800 && c <= 0xDBFF) ? cap - 1 : cap
@@ -365,7 +365,7 @@ QtObject {
     // nested or malformed spans (e.g. ***bold-italic***, unclosed **bold) —
     // those pass through partially un-stripped, which is acceptable for an
     // accessibility hint.
-    function stripMarkdown(text, maxLen) {
+    function stripMarkdown(text: string, maxLen: var): string {
         if (!text) return ""
         var cap = maxLen ?? 2000
         var s = text
@@ -392,7 +392,7 @@ QtObject {
     // strings (log output, crash dumps) don't flood the accessibility
     // tree. Default cap: 2000 characters. For Markdown-formatted content,
     // use stripMarkdown instead so formatting chars aren't read literally.
-    function capAccessibleText(text, maxLen) {
+    function capAccessibleText(text: string, maxLen: var): string {
         if (!text) return ""
         var cap = maxLen ?? 2000
         return _truncateWithEllipsis(text, cap)
@@ -416,10 +416,10 @@ QtObject {
     }
 
     // Helper function to scale values
-    function scaled(value) { return Math.round(value * scale) }
+    function scaled(value: real): int { return Math.round(value * scale) }
 
     // Scale without page multiplier (for UI that should stay constant size across pages)
-    function scaledBase(value) {
+    function scaledBase(value: real): int {
         return Math.round(value * scale / (pageScaleMultiplier || 1.0))
     }
 
@@ -427,7 +427,7 @@ QtObject {
     // otherwise returns the normal color value. Called from web theme editor.
     // QML's binding engine tracks Settings.theme.flashColorName and Settings.theme.flashPhase
     // reads inside this function, so all color bindings re-evaluate on flash changes.
-    function _c(name, value) {
+    function _c(name: string, value: var): var {
         if (Settings.theme.flashColorName === name && Settings.theme.flashPhase > 0) {
             return Settings.theme.flashPhase % 2 === 1 ? "#ff0000" : "#000000"
         }
@@ -516,7 +516,7 @@ QtObject {
     // The fallback branch is therefore now a should-never-happen guard, kept because without
     // it an undefined reaches the engine as an opaque "Unable to assign [undefined] to QColor"
     // warning — or, at _flatInsetTint, as a hard "Qt.colorEqual(): Invalid arguments" Error.
-    function _derivedOr(key, fallback) {
+    function _derivedOr(key: string, fallback: var): var {
         var derived = Settings.theme.derivedBackgroundColors
         if (derived[key] === undefined) {
             console.warn("Theme: derivedBackgroundColors." + key + " unexpectedly undefined"
@@ -625,7 +625,7 @@ QtObject {
     // opacity so the wallpaper shows through. Use this instead of hand-rolling
     // Qt.rgba(...) at each call site — keeps every scrim in the app at the same
     // translucency level tuned by backgroundScrimAlpha above.
-    function scrimColor(baseColor) {
+    function scrimColor(baseColor: color): color {
         return Qt.rgba(baseColor.r, baseColor.g, baseColor.b, backgroundScrimAlpha)
     }
 
@@ -649,7 +649,7 @@ QtObject {
 
     // WCAG 2.x relative luminance: sRGB channels linearised, then weighted. Not the same
     // as the cheaper BT.601 brightness weights — see contrastColorFor.
-    function _relativeLuminance(c) {
+    function _relativeLuminance(c: color): real {
         function linearise(channel) {
             return channel <= 0.03928 ? channel / 12.92
                                       : Math.pow((channel + 0.055) / 1.055, 2.4)
@@ -857,16 +857,16 @@ QtObject {
     //   "standard"  - transparent background, normal text (default, today's look)
     //   "surface"   - surface fill, normal text
     //   "accentBar" - accent fill + contrast text + bold values (the PR #1364 look)
-    function zoneBackgroundColor(style) {
+    function zoneBackgroundColor(style: string): color {
         if (style === "accentBar") return primaryColor
         if (style === "surface")   return surfaceColor
         return "transparent"
     }
-    function zoneTextColor(style) {
+    function zoneTextColor(style: string): color {
         if (style === "accentBar") return primaryContrastColor
         return textColor
     }
-    function zoneValueBold(style) {
+    function zoneValueBold(style: string): bool {
         return style === "accentBar"
     }
     // Fill for a small tappable value chip (the Ratio/Grind pills) sitting in a
@@ -875,7 +875,7 @@ QtObject {
     // inset chip on a surfaceColor zone, and a raised surface chip on the
     // transparent standard zone (where a bare zoneTextColor fill would otherwise
     // be a jarring white capsule in dark mode).
-    function zoneChipColor(style) {
+    function zoneChipColor(style: string): color {
         if (style === "accentBar") return primaryContrastColor
         if (style === "surface")   return insetBackgroundColor
         return surfaceColor
@@ -911,7 +911,7 @@ QtObject {
     // Shared tracking color logic: proportional thresholds with floor values
     // so low goals (e.g. 0.5 mL/s flow) don't trigger red on tiny deltas.
     // isPressure: true for pressure tracking, false for flow tracking.
-    function trackingColor(delta, goal, isPressure) {
+    function trackingColor(delta: real, goal: real, isPressure: var): color {
         var floorGood = isPressure ? 0.8 : 0.4
         var floorWarn = isPressure ? 1.8 : 0.8
         var threshGood = Math.max(floorGood, goal * 0.25)
@@ -923,7 +923,7 @@ QtObject {
 
     // Translucent, pastel-tinted overlay text color derived from a tracking color.
     // Lightens toward white for readability over dark backgrounds.
-    function tintedOverlayColor(baseColor, alpha) {
+    function tintedOverlayColor(baseColor: color, alpha: real): color {
         return Qt.rgba(0.7 + baseColor.r * 0.3, 0.7 + baseColor.g * 0.3, 0.7 + baseColor.b * 0.3, alpha)
     }
 

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -55,7 +55,7 @@ QtObject {
     // Convert emoji character to pre-rendered SVG image path.
     // Passes through qrc:/icons/... paths unchanged.
     // Returns "" when no asset is bundled — see _emojiAssetPath.
-    function emojiToImage(emoji: string): string {
+    function emojiToImage(emoji: var): string {
         if (!emoji) return ""
         if (emoji.indexOf("qrc:") === 0) return emoji
         var cps = []
@@ -194,7 +194,7 @@ QtObject {
     // screensaver authors, GitHub release notes -- cannot inject tags into the
     // RichText/StyledText renderer. Getting this wrong should fail visibly (raw
     // tags on screen), not silently.
-    function replaceEmojiWithImg(text: string, pixelSize: var, allowMarkup: var): string {
+    function replaceEmojiWithImg(text: var, pixelSize: var, allowMarkup: var): string {
         if (!text) return ""
         var size = pixelSize || 16
         var result = ""
@@ -265,7 +265,7 @@ QtObject {
 
     // Strip emoji Unicode characters from a string entirely.
     // Use for plain-text Text elements where <img> tags aren't supported.
-    function stripEmoji(text: string): string {
+    function stripEmoji(text: var): string {
         if (!text) return ""
         var result = ""
         var i = 0
@@ -283,7 +283,7 @@ QtObject {
     // Strip HTML tags and emoji from a string for accessible names.
     // Use on text that has been through replaceEmojiWithImg() to get
     // a clean plain-text string for TalkBack/VoiceOver.
-    function toAccessibleText(html: string): string {
+    function toAccessibleText(html: var): string {
         if (!html) return ""
         // Decode entities as well as stripping tags. Callers now pass MarkdownRenderer output,
         // where QTextDocument::toHtml() has escaped & < > " and emitted &nbsp; — without this a
@@ -349,6 +349,12 @@ QtObject {
     // Truncate a UTF-16 string at `cap` code units and append an ellipsis,
     // backing off one unit if cap would split a surrogate pair so we
     // don't emit an orphaned high surrogate to the accessibility tree.
+    //
+    // `cap: int` is only safe because BOTH callers resolve `maxLen ?? 2000` into a real
+    // number before calling. Forward an optional maxLen straight through and int coerces
+    // undefined to 0: `s.length <= 0` is false, charCodeAt(-1) is NaN, cut is 0, and every
+    // string becomes a bare ellipsis. That exact bug was hit and reverted on the `maxLen`
+    // parameters below, which is why they are `var`. Keep the `??` at the call site.
     function _truncateWithEllipsis(s: string, cap: int): string {
         if (s.length <= cap) return s
         var c = s.charCodeAt(cap - 1)
@@ -365,7 +371,7 @@ QtObject {
     // nested or malformed spans (e.g. ***bold-italic***, unclosed **bold) —
     // those pass through partially un-stripped, which is acceptable for an
     // accessibility hint.
-    function stripMarkdown(text: string, maxLen: var): string {
+    function stripMarkdown(text: var, maxLen: var): string {
         if (!text) return ""
         var cap = maxLen ?? 2000
         var s = text
@@ -392,7 +398,7 @@ QtObject {
     // strings (log output, crash dumps) don't flood the accessibility
     // tree. Default cap: 2000 characters. For Markdown-formatted content,
     // use stripMarkdown instead so formatting chars aren't read literally.
-    function capAccessibleText(text: string, maxLen: var): string {
+    function capAccessibleText(text: var, maxLen: var): string {
         if (!text) return ""
         var cap = maxLen ?? 2000
         return _truncateWithEllipsis(text, cap)
@@ -403,6 +409,16 @@ QtObject {
     // tst_temperaturedisplay). These wrappers read Settings.app.temperatureUnit in
     // JS — that read is what makes bindings re-evaluate on a unit toggle (property
     // reads inside C++ methods are invisible to the QML binding engine).
+    //
+    // DO NOT ADD TYPE ANNOTATIONS TO THESE SEVEN. They are the only unannotated
+    // functions left in this file and that is deliberate, not an oversight. Annotating
+    // them (`tempUnitSuffix(): string` etc.) made qmlcachegen compile tempUnitSuffix()
+    // into something that returns undefined, which showed up in the running app as
+    //     RecipeEditorPage.qml:435: Unable to assign [undefined] to QString
+    // on `suffix: Theme.tempUnitSuffix()`. The C++ side is not at fault —
+    // TemperatureDisplay::unitSuffix(bool) returns QString (src/profile/temperaturedisplay.h:92).
+    // The mechanism is NOT understood, so the annotations were reverted rather than
+    // worked around. If you want them compiled, reproduce that failure first.
     function tempIsFahrenheit() { return Settings.app.temperatureUnit === "fahrenheit" }
     function tempUnitSuffix() { return TemperatureDisplay.unitSuffix(tempIsFahrenheit()) }
     function cToDisplay(celsius) { return TemperatureDisplay.cToDisplay(celsius, tempIsFahrenheit()) }

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -411,7 +411,11 @@ QtObject {
     // reads inside C++ methods are invisible to the QML binding engine).
     //
     // DO NOT ADD TYPE ANNOTATIONS TO THESE SEVEN. They are the only unannotated
-    // functions left in this file and that is deliberate, not an oversight. Annotating
+    // TOP-LEVEL functions left in this file (the nested helpers `h` in colorToHex and
+    // `linearise` in _relativeLuminance are also unannotated, but they are private
+    // closures inside already-annotated parents and never reached from outside, so they
+    // do not participate in the untyped-call cascade). Leaving these seven is
+    // deliberate, not an oversight. Annotating
     // them (`tempUnitSuffix(): string` etc.) made qmlcachegen compile tempUnitSuffix()
     // into something that returns undefined, which showed up in the running app as
     //     RecipeEditorPage.qml:435: Unable to assign [undefined] to QString

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -115,12 +115,12 @@ Page {
     // screen honors the same options LayoutPreview shows. Zones must be wired explicitly:
     // an unpassed option silently falls back to the zone component's default, which is how
     // the top/bottom bars ignored distribution/alignment/style before.
-    function zoneOpts(zone) {
+    function zoneOpts(zone: string): var {
         return (layoutConfig.zoneOptions && layoutConfig.zoneOptions[zone]) || ({})
     }
 
     // Per-zone item size ("compact" | "large"); bars grow to fit large items.
-    function zoneItemSize(zone) {
+    function zoneItemSize(zone: string): string {
         return zoneOpts(zone).itemSize || "compact"
     }
 
@@ -154,7 +154,7 @@ Page {
     // idlePage coords) and height. Slides content only by the overlap (0 when the
     // content doesn't reach the popup), bounded, in the direction set by which
     // half of the page the popup sits in.
-    function requestPanelClearance(panelTop, panelHeight) {
+    function requestPanelClearance(panelTop: real, panelHeight: real) {
         var panelBottom = panelTop + panelHeight
         if ((panelTop + panelBottom) / 2 >= idlePage.height / 2) {
             var up = idlePage._idleContentBottom - panelTop + Theme.spacingSmall
@@ -207,7 +207,7 @@ Page {
     // for the outward selection/focus rings, so pack against the same width or a
     // page that fits here would need a third row there.
     readonly property real _pillRingOutset: Theme.scaled(3) + Theme.focusMargin
-    function _pillPagesFor(widths, availWidth) {
+    function _pillPagesFor(widths: var, availWidth: real): var {
         availWidth = Math.max(0, availWidth - 2 * _pillRingOutset)
         var sizes = PillFit.packPageSizes(widths, Theme.scaled(12), availWidth, 2)
         if (sizes.length <= 1)
@@ -217,14 +217,14 @@ Page {
         return PillFit.packPageSizes(widths, Theme.scaled(12),
                                      Math.max(0, availWidth - 2 * Theme.scaled(48)), 2)
     }
-    function _pillPageStart(sizes, pageIndex) {
+    function _pillPageStart(sizes: var, pageIndex: int): int {
         var idx = Math.max(0, Math.min(pageIndex, sizes.length - 1))
         var start = 0
         for (var p = 0; p < idx; ++p)
             start += sizes[p]
         return start
     }
-    function _pillPageSlice(list, sizes, pageIndex) {
+    function _pillPageSlice(list: var, sizes: var, pageIndex: int): var {
         if (!list || list.length === 0)
             return []
         var idx = Math.max(0, Math.min(pageIndex, sizes.length - 1))
@@ -243,7 +243,7 @@ Page {
     // navigation, so without it the freeze would still be engaged on the way
     // back from e.g. the Recipes page and anything created there would be held
     // at the tail of the list instead of appearing MRU-first.
-    function _orderFrozen(row) {
+    function _orderFrozen(row: var): bool {
         return activePresetFunction === row && StackView.status === StackView.Active
     }
     // Which MRU row is open, so the close edge can be detected in one place.
@@ -254,7 +254,7 @@ Page {
     property bool _bagOrderLiftPending: false
     property bool _equipmentOrderLiftPending: false
     property bool _recipeOrderLiftPending: false
-    function _liftOrderFreeze(row) {
+    function _liftOrderFreeze(row: var) {
         if (row === "recipes") {
             _recipeOrderLiftPending = true
             MainController.recipeStorage.requestInventory()
@@ -282,7 +282,7 @@ Page {
     readonly property int beanPageCount: Math.max(1, _beanPageSizes.length)
     readonly property var visibleBags: _pillPageSlice(inventoryBags, _beanPageSizes, beanPageIndex)
 
-    function bagLabel(bag) {
+    function bagLabel(bag: var): string {
         if (!bag) return ""
         var coffee = bag.coffeeName || ""
         return coffee.length > 0 ? coffee : (bag.roasterName || "")
@@ -320,7 +320,7 @@ Page {
     readonly property int equipmentPageCount: Math.max(1, _equipmentPageSizes.length)
     readonly property var visibleEquipment: _pillPageSlice(inventoryEquipment, _equipmentPageSizes, equipmentPageIndex)
 
-    function equipmentLabel(pkg) {
+    function equipmentLabel(pkg: var): string {
         if (!pkg) return ""
         if (pkg.name && String(pkg.name).length > 0) return String(pkg.name)
         return [pkg.grinderBrand || "", pkg.grinderModel || ""]
@@ -430,7 +430,7 @@ Page {
     // (shared with the compact RecipesItem so both layouts behave identically —
     // the recipe analogue of the profile pills' Settings.app.selectedFavoriteProfile).
     // See tryStartRecipe() below for the two-tap select-then-start handler.
-    function tryStartRecipe(recipe) {
+    function tryStartRecipe(recipe: var) {
         var alreadySelected = (recipe.id === MainController.selectedRecipeId)
         if (!alreadySelected) {
             MainController.activateRecipe(recipe.id)  // sets selectedRecipeId synchronously

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -88,12 +88,20 @@ class MainController : public QObject {
 
     // Non-profile QML properties (profile properties are on ProfileManager)
     //
-    // FINAL on every sub-object accessor below is load-bearing, not decoration: without it
-    // qmlcachegen will not compile a chained lookup like `MainController.aiManager.x`, because
-    // a subclass could shadow the member. It degrades the base to `var` and reports "Cannot use
-    // shadowable base type for further lookups" (`qqmljsshadowcheck.cpp:196-198` — a final
-    // property is the only thing that returns NotShadowable). Nothing subclasses MainController.
-    // Keep FINAL on any accessor added here, or it silently drops out of AOT.
+    // FINAL on the pointer-typed sub-object accessors below is load-bearing, not decoration:
+    // without it qmlcachegen will not compile a chained lookup like `MainController.aiManager.x`,
+    // because a subclass could shadow the member. The read itself still works — it degrades to
+    // `var` with a qmlCompiler log line (qqmljsshadowcheck.cpp:203-205) — and it is the NEXT
+    // lookup off that base that fails with "Cannot use shadowable base type for further lookups"
+    // (:248). Marking the property final is what makes the member NotShadowable here
+    // (:197-198); that file has other NotShadowable paths, but none that apply to a plain
+    // singleton's property.
+    //
+    // That is also why the scalar leaf properties further down (currentFrameName,
+    // filteredGoalPressure, selectedRecipeId, …) are deliberately NOT final: nothing chains off
+    // them, so they never reach the shadow check. Keep FINAL on any accessor added here whose
+    // value gets a property read on it, or every chained lookup through it silently drops out
+    // of AOT. Nothing subclasses MainController today.
     Q_PROPERTY(VisualizerUploader* visualizer READ visualizer CONSTANT FINAL)
     Q_PROPERTY(VisualizerImporter* visualizerImporter READ visualizerImporter CONSTANT FINAL)
     Q_PROPERTY(BeanBaseClient* beanbase READ beanbase CONSTANT FINAL)

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -87,21 +87,28 @@ class MainController : public QObject {
     QML_SINGLETON
 
     // Non-profile QML properties (profile properties are on ProfileManager)
-    Q_PROPERTY(VisualizerUploader* visualizer READ visualizer CONSTANT)
-    Q_PROPERTY(VisualizerImporter* visualizerImporter READ visualizerImporter CONSTANT)
-    Q_PROPERTY(BeanBaseClient* beanbase READ beanbase CONSTANT)
-    Q_PROPERTY(AIManager* aiManager READ aiManager CONSTANT)
-    Q_PROPERTY(LiveSteamCoach* liveSteamCoach READ liveSteamCoach CONSTANT)
-    Q_PROPERTY(ShotDataModel* shotDataModel READ shotDataModel CONSTANT)
-    Q_PROPERTY(SteamDataModel* steamDataModel READ steamDataModel CONSTANT)
-    Q_PROPERTY(SteamHealthTracker* steamHealthTracker READ steamHealthTracker CONSTANT)
+    //
+    // FINAL on every sub-object accessor below is load-bearing, not decoration: without it
+    // qmlcachegen will not compile a chained lookup like `MainController.aiManager.x`, because
+    // a subclass could shadow the member. It degrades the base to `var` and reports "Cannot use
+    // shadowable base type for further lookups" (`qqmljsshadowcheck.cpp:196-198` — a final
+    // property is the only thing that returns NotShadowable). Nothing subclasses MainController.
+    // Keep FINAL on any accessor added here, or it silently drops out of AOT.
+    Q_PROPERTY(VisualizerUploader* visualizer READ visualizer CONSTANT FINAL)
+    Q_PROPERTY(VisualizerImporter* visualizerImporter READ visualizerImporter CONSTANT FINAL)
+    Q_PROPERTY(BeanBaseClient* beanbase READ beanbase CONSTANT FINAL)
+    Q_PROPERTY(AIManager* aiManager READ aiManager CONSTANT FINAL)
+    Q_PROPERTY(LiveSteamCoach* liveSteamCoach READ liveSteamCoach CONSTANT FINAL)
+    Q_PROPERTY(ShotDataModel* shotDataModel READ shotDataModel CONSTANT FINAL)
+    Q_PROPERTY(SteamDataModel* steamDataModel READ steamDataModel CONSTANT FINAL)
+    Q_PROPERTY(SteamHealthTracker* steamHealthTracker READ steamHealthTracker CONSTANT FINAL)
     Q_PROPERTY(QString currentFrameName READ currentFrameName NOTIFY frameChanged)
     Q_PROPERTY(double filteredGoalPressure READ filteredGoalPressure NOTIFY goalsChanged)
     Q_PROPERTY(double filteredGoalFlow READ filteredGoalFlow NOTIFY goalsChanged)
-    Q_PROPERTY(ShotHistoryStorage* shotHistory READ shotHistory CONSTANT)
-    Q_PROPERTY(CoffeeBagStorage* bagStorage READ bagStorage CONSTANT)
-    Q_PROPERTY(EquipmentStorage* equipmentStorage READ equipmentStorage CONSTANT)
-    Q_PROPERTY(RecipeStorage* recipeStorage READ recipeStorage CONSTANT)
+    Q_PROPERTY(ShotHistoryStorage* shotHistory READ shotHistory CONSTANT FINAL)
+    Q_PROPERTY(CoffeeBagStorage* bagStorage READ bagStorage CONSTANT FINAL)
+    Q_PROPERTY(EquipmentStorage* equipmentStorage READ equipmentStorage CONSTANT FINAL)
+    Q_PROPERTY(RecipeStorage* recipeStorage READ recipeStorage CONSTANT FINAL)
     // The active recipe's full row (empty map = none). Refreshed on
     // activation, on external edits to the active row, and cleared on
     // deactivation. QML reads name/steam fields from here; the id itself
@@ -149,18 +156,18 @@ class MainController : public QObject {
     // always re-converges to activeRecipeId, so the highlight never ends
     // disagreeing with the active recipe.
     Q_PROPERTY(qint64 selectedRecipeId READ selectedRecipeId NOTIFY selectedRecipeIdChanged)
-    Q_PROPERTY(UnifiedBeanSearchModel* beanSearch READ beanSearch CONSTANT)
-    Q_PROPERTY(ShotImporter* shotImporter READ shotImporter CONSTANT)
-    Q_PROPERTY(ProfileConverter* profileConverter READ profileConverter CONSTANT)
-    Q_PROPERTY(ProfileImporter* profileImporter READ profileImporter CONSTANT)
-    Q_PROPERTY(ShotComparisonModel* shotComparison READ shotComparison CONSTANT)
-    Q_PROPERTY(ShotServer* shotServer READ shotServer CONSTANT)
-    Q_PROPERTY(MqttClient* mqttClient READ mqttClient CONSTANT)
-    Q_PROPERTY(UpdateChecker* updateChecker READ updateChecker CONSTANT)
-    Q_PROPERTY(FirmwareUpdater* firmwareUpdater READ firmwareUpdater CONSTANT)
-    Q_PROPERTY(ShotReporter* shotReporter READ shotReporter CONSTANT)
-    Q_PROPERTY(DataMigrationClient* dataMigration READ dataMigration CONSTANT)
-    Q_PROPERTY(DatabaseBackupManager* backupManager READ backupManager CONSTANT)
+    Q_PROPERTY(UnifiedBeanSearchModel* beanSearch READ beanSearch CONSTANT FINAL)
+    Q_PROPERTY(ShotImporter* shotImporter READ shotImporter CONSTANT FINAL)
+    Q_PROPERTY(ProfileConverter* profileConverter READ profileConverter CONSTANT FINAL)
+    Q_PROPERTY(ProfileImporter* profileImporter READ profileImporter CONSTANT FINAL)
+    Q_PROPERTY(ShotComparisonModel* shotComparison READ shotComparison CONSTANT FINAL)
+    Q_PROPERTY(ShotServer* shotServer READ shotServer CONSTANT FINAL)
+    Q_PROPERTY(MqttClient* mqttClient READ mqttClient CONSTANT FINAL)
+    Q_PROPERTY(UpdateChecker* updateChecker READ updateChecker CONSTANT FINAL)
+    Q_PROPERTY(FirmwareUpdater* firmwareUpdater READ firmwareUpdater CONSTANT FINAL)
+    Q_PROPERTY(ShotReporter* shotReporter READ shotReporter CONSTANT FINAL)
+    Q_PROPERTY(DataMigrationClient* dataMigration READ dataMigration CONSTANT FINAL)
+    Q_PROPERTY(DatabaseBackupManager* backupManager READ backupManager CONSTANT FINAL)
     Q_PROPERTY(qint64 lastSavedShotId READ lastSavedShotId NOTIFY lastSavedShotIdChanged)
     Q_PROPERTY(bool sawSettling READ isSawSettling NOTIFY sawSettlingChanged)
 

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -97,11 +97,18 @@ class MainController : public QObject {
     // (:197-198); that file has other NotShadowable paths, but none that apply to a plain
     // singleton's property.
     //
-    // That is also why the scalar leaf properties further down (currentFrameName,
-    // filteredGoalPressure, selectedRecipeId, …) are deliberately NOT final: nothing chains off
-    // them, so they never reach the shadow check. Keep FINAL on any accessor added here whose
-    // value gets a property read on it, or every chained lookup through it silently drops out
-    // of AOT. Nothing subclasses MainController today.
+    // The scalar leaf properties further down (currentFrameName, filteredGoalPressure,
+    // selectedRecipeId, …) are left non-final because it buys nothing THERE, not because they
+    // are exempt from the check. They are not: every property read goes through
+    // checkShadowing() and its isFinal() test, and a non-final one degrades to `var` just the
+    // same. What they never reach is checkBaseType()'s hard error at :248, because no QML
+    // chains a further lookup off them today. Add a binding that does — say
+    // `MainController.currentFrameName.length` — and that property needs FINAL too.
+    //
+    // So the rule is about the VALUE being used as a lookup base, not about pointer vs scalar.
+    // settings.h applies FINAL uniformly to every property rather than tracking which ones are
+    // currently chained; that is inert where it is not needed and immune to this trap.
+    // Nothing subclasses MainController today.
     Q_PROPERTY(VisualizerUploader* visualizer READ visualizer CONSTANT FINAL)
     Q_PROPERTY(VisualizerImporter* visualizerImporter READ visualizerImporter CONSTANT FINAL)
     Q_PROPERTY(BeanBaseClient* beanbase READ beanbase CONSTANT FINAL)

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -42,7 +42,7 @@
 // too. The domain SPLIT still does its job — implementations stay in their own .cpp files, and a
 // narrow consumer taking Settings<Domain>* still rebuilds only on its own header — and the
 // recompile win that motivated the split is unaffected by declaring the façade's property types
-// honestly. See openspec/changes/fix-qmllint-usability/design.md D2a for the full measurement.
+// honestly. See openspec/changes/archive/2026-07-29-fix-qmllint-usability/design.md D2a for the full measurement.
 //
 // C++ callers may still use the typed accessors (e.g. `settings->mqtt()`); they no longer need
 // to include the domain header themselves.
@@ -74,14 +74,26 @@ class Settings : public QObject {
     // runtime while still compiling clean.
     //
     // FINAL is not decoration. Without it qmlcachegen refuses to compile any chained lookup
-    // through these accessors — `Settings.theme.x` degrades the base to `var` and bails with
-    // "Cannot use shadowable base type for further lookups", because a subclass could in
-    // principle shadow the member. `qqmljsshadowcheck.cpp:196-198` returns NotShadowable for a
-    // final property and that is the only escape. It cost 574 AOT skips across 89 files, 97 of
-    // them on `theme` alone; Theme.qml is read on every page construction, so this was the one
-    // warm bucket. Nothing subclasses Settings and no QML redeclares these names — FINAL states
-    // a fact that was already true. Do not drop it to make room for a subclass without
-    // re-reading that trade.
+    // through these accessors — `Settings.theme.x` degrades the base to `var`, and the NEXT
+    // lookup off that base fails with "Cannot use shadowable base type for further lookups"
+    // (qqmljsshadowcheck.cpp:248), because a subclass could in principle shadow the member.
+    // For a plain (non-extended) singleton, marking the property final is what makes the
+    // member NotShadowable — qqmljsshadowcheck.cpp:197-198. It is not the only path to
+    // NotShadowable in that file (an extended singleton takes :176, for instance), but it is
+    // the one available here.
+    //
+    // Measured: these twelve accessors accounted for 429 of the project's 574 shadowable-base
+    // skips, and FINAL on them recovered 394 AOT-compiled bindings. Note `Settings.theme` (the
+    // SettingsTheme domain object) is not `qml/Theme.qml` (the styling singleton) despite the
+    // shared word — the bucket concentrates there because Theme.qml holds 85 of the repo's 174
+    // `Settings.theme.` reads. Whether that is worth anything at runtime is a separate
+    // question; docs/CLAUDE_MD/BUILD_PERFORMANCE.md is where the AOT numbers and the
+    // "is AOT worth it here" argument live.
+    //
+    // QML cannot shadow these names structurally: Settings is QML_SINGLETON and every domain
+    // type is QML_UNCREATABLE (settings_qml.h), so no QML type can derive from them. The C++
+    // side is an audit rather than a guarantee — nothing subclasses Settings today. Do not drop
+    // FINAL to make room for a subclass without re-reading that trade.
     Q_PROPERTY(SettingsMqtt* mqtt READ mqtt CONSTANT FINAL)
     Q_PROPERTY(SettingsAutoWake* autoWake READ autoWake CONSTANT FINAL)
     Q_PROPERTY(SettingsHardware* hardware READ hardware CONSTANT FINAL)

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -82,13 +82,19 @@ class Settings : public QObject {
     // NotShadowable in that file (an extended singleton takes :176, for instance), but it is
     // the one available here.
     //
-    // Measured: these twelve accessors accounted for 429 of the project's 574 shadowable-base
-    // skips, and FINAL on them recovered 394 AOT-compiled bindings. Note `Settings.theme` (the
-    // SettingsTheme domain object) is not `qml/Theme.qml` (the styling singleton) despite the
-    // shared word — the bucket concentrates there because Theme.qml holds 85 of the repo's 174
-    // `Settings.theme.` reads. Whether that is worth anything at runtime is a separate
-    // question; docs/CLAUDE_MD/BUILD_PERFORMANCE.md is where the AOT numbers and the
-    // "is AOT worth it here" argument live.
+    // Measured, and the three numbers reconcile like this: the project had 574 shadowable-base
+    // skips; FINAL on these twelve accessors removed 429 of them, FINAL on the remaining
+    // settings properties removed 73 more (429 + 73 = 502), leaving 72 that live on other
+    // classes entirely. The 429 skips yielded only +394 AOT-compiled bindings, because 35 of
+    // them then failed for a DIFFERENT reason — removing a skip reason is not the same as the
+    // binding compiling, which is the single most misleading thing about this metric.
+    //
+    // Note `Settings.theme` (the SettingsTheme domain object) is not `qml/Theme.qml` (the
+    // styling singleton) despite the shared word — the bucket concentrates there because
+    // Theme.qml holds 88 of the 174 `Settings.theme.` reads under qml/ (both counted as
+    // occurrences: `grep -o 'Settings\.theme\.[A-Za-z0-9_]*'`). Whether any of this is worth
+    // anything at runtime is a separate question; docs/CLAUDE_MD/BUILD_PERFORMANCE.md holds the
+    // AOT numbers and the "is AOT worth it here" argument.
     //
     // QML cannot shadow these names structurally: Settings is QML_SINGLETON and every domain
     // type is QML_UNCREATABLE (settings_qml.h), so no QML type can derive from them. The C++

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -72,43 +72,53 @@ class Settings : public QObject {
     // qmlRegisterUncreatableType<> calls in main.cpp, which qmltyperegistrar cannot see).
     // Without it QML can't discover the type and chained access resolves to `undefined` at
     // runtime while still compiling clean.
-    Q_PROPERTY(SettingsMqtt* mqtt READ mqtt CONSTANT)
-    Q_PROPERTY(SettingsAutoWake* autoWake READ autoWake CONSTANT)
-    Q_PROPERTY(SettingsHardware* hardware READ hardware CONSTANT)
-    Q_PROPERTY(SettingsAI* ai READ ai CONSTANT)
-    Q_PROPERTY(SettingsTheme* theme READ theme CONSTANT)
-    Q_PROPERTY(SettingsVisualizer* visualizer READ visualizer CONSTANT)
-    Q_PROPERTY(SettingsMcp* mcp READ mcp CONSTANT)
-    Q_PROPERTY(SettingsBrew* brew READ brew CONSTANT)
-    Q_PROPERTY(SettingsDye* dye READ dye CONSTANT)
-    Q_PROPERTY(SettingsNetwork* network READ network CONSTANT)
-    Q_PROPERTY(SettingsApp* app READ app CONSTANT)
-    Q_PROPERTY(SettingsCalibration* calibration READ calibration CONSTANT)
+    //
+    // FINAL is not decoration. Without it qmlcachegen refuses to compile any chained lookup
+    // through these accessors — `Settings.theme.x` degrades the base to `var` and bails with
+    // "Cannot use shadowable base type for further lookups", because a subclass could in
+    // principle shadow the member. `qqmljsshadowcheck.cpp:196-198` returns NotShadowable for a
+    // final property and that is the only escape. It cost 574 AOT skips across 89 files, 97 of
+    // them on `theme` alone; Theme.qml is read on every page construction, so this was the one
+    // warm bucket. Nothing subclasses Settings and no QML redeclares these names — FINAL states
+    // a fact that was already true. Do not drop it to make room for a subclass without
+    // re-reading that trade.
+    Q_PROPERTY(SettingsMqtt* mqtt READ mqtt CONSTANT FINAL)
+    Q_PROPERTY(SettingsAutoWake* autoWake READ autoWake CONSTANT FINAL)
+    Q_PROPERTY(SettingsHardware* hardware READ hardware CONSTANT FINAL)
+    Q_PROPERTY(SettingsAI* ai READ ai CONSTANT FINAL)
+    Q_PROPERTY(SettingsTheme* theme READ theme CONSTANT FINAL)
+    Q_PROPERTY(SettingsVisualizer* visualizer READ visualizer CONSTANT FINAL)
+    Q_PROPERTY(SettingsMcp* mcp READ mcp CONSTANT FINAL)
+    Q_PROPERTY(SettingsBrew* brew READ brew CONSTANT FINAL)
+    Q_PROPERTY(SettingsDye* dye READ dye CONSTANT FINAL)
+    Q_PROPERTY(SettingsNetwork* network READ network CONSTANT FINAL)
+    Q_PROPERTY(SettingsApp* app READ app CONSTANT FINAL)
+    Q_PROPERTY(SettingsCalibration* calibration READ calibration CONSTANT FINAL)
 
     // Machine settings
-    Q_PROPERTY(QString machineAddress READ machineAddress WRITE setMachineAddress NOTIFY machineAddressChanged)
-    Q_PROPERTY(QString scaleAddress READ scaleAddress WRITE setScaleAddress NOTIFY scaleAddressChanged)
-    Q_PROPERTY(QString scaleType READ scaleType WRITE setScaleType NOTIFY scaleTypeChanged)
-    Q_PROPERTY(bool keepScaleOn READ keepScaleOn WRITE setKeepScaleOn NOTIFY keepScaleOnChanged)
-    Q_PROPERTY(QString scaleName READ scaleName WRITE setScaleName NOTIFY scaleNameChanged)
+    Q_PROPERTY(QString machineAddress READ machineAddress WRITE setMachineAddress NOTIFY machineAddressChanged FINAL)
+    Q_PROPERTY(QString scaleAddress READ scaleAddress WRITE setScaleAddress NOTIFY scaleAddressChanged FINAL)
+    Q_PROPERTY(QString scaleType READ scaleType WRITE setScaleType NOTIFY scaleTypeChanged FINAL)
+    Q_PROPERTY(bool keepScaleOn READ keepScaleOn WRITE setKeepScaleOn NOTIFY keepScaleOnChanged FINAL)
+    Q_PROPERTY(QString scaleName READ scaleName WRITE setScaleName NOTIFY scaleNameChanged FINAL)
 
     // Multi-scale management
-    Q_PROPERTY(QVariantList knownScales READ knownScales NOTIFY knownScalesChanged)
-    Q_PROPERTY(QString primaryScaleAddress READ primaryScaleAddress NOTIFY knownScalesChanged)
+    Q_PROPERTY(QVariantList knownScales READ knownScales NOTIFY knownScalesChanged FINAL)
+    Q_PROPERTY(QString primaryScaleAddress READ primaryScaleAddress NOTIFY knownScalesChanged FINAL)
 
     // FlowScale (virtual scale from flow data)
-    Q_PROPERTY(bool useFlowScale READ useFlowScale WRITE setUseFlowScale NOTIFY useFlowScaleChanged)
+    Q_PROPERTY(bool useFlowScale READ useFlowScale WRITE setUseFlowScale NOTIFY useFlowScaleChanged FINAL)
 
     // Allow user to disable modal scale connection alert dialogs
-    Q_PROPERTY(bool showScaleDialogs READ showScaleDialogs WRITE setShowScaleDialogs NOTIFY showScaleDialogsChanged)
+    Q_PROPERTY(bool showScaleDialogs READ showScaleDialogs WRITE setShowScaleDialogs NOTIFY showScaleDialogsChanged FINAL)
 
     // Refractometer (DiFluid R2)
-    Q_PROPERTY(QString savedRefractometerAddress READ savedRefractometerAddress WRITE setSavedRefractometerAddress NOTIFY savedRefractometerChanged)
-    Q_PROPERTY(QString savedRefractometerName READ savedRefractometerName WRITE setSavedRefractometerName NOTIFY savedRefractometerChanged)
+    Q_PROPERTY(QString savedRefractometerAddress READ savedRefractometerAddress WRITE setSavedRefractometerAddress NOTIFY savedRefractometerChanged FINAL)
+    Q_PROPERTY(QString savedRefractometerName READ savedRefractometerName WRITE setSavedRefractometerName NOTIFY savedRefractometerChanged FINAL)
 
     // Enable USB serial polling for DE1 connection. Off by default to save battery
     // (polling every 2 s). Only needed when connecting the DE1 via USB-C cable.
-    Q_PROPERTY(bool usbSerialEnabled READ usbSerialEnabled WRITE setUsbSerialEnabled NOTIFY usbSerialEnabledChanged)
+    Q_PROPERTY(bool usbSerialEnabled READ usbSerialEnabled WRITE setUsbSerialEnabled NOTIFY usbSerialEnabledChanged FINAL)
 
 public:
     explicit Settings(QObject* parent = nullptr);

--- a/src/core/settings_ai.h
+++ b/src/core/settings_ai.h
@@ -8,20 +8,20 @@
 class SettingsAI : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(QString aiProvider READ aiProvider WRITE setAiProvider NOTIFY aiProviderChanged)
-    Q_PROPERTY(QString openaiApiKey READ openaiApiKey WRITE setOpenaiApiKey NOTIFY openaiApiKeyChanged)
-    Q_PROPERTY(QString anthropicApiKey READ anthropicApiKey WRITE setAnthropicApiKey NOTIFY anthropicApiKeyChanged)
-    Q_PROPERTY(QString geminiApiKey READ geminiApiKey WRITE setGeminiApiKey NOTIFY geminiApiKeyChanged)
-    Q_PROPERTY(QString ollamaEndpoint READ ollamaEndpoint WRITE setOllamaEndpoint NOTIFY ollamaEndpointChanged)
-    Q_PROPERTY(QString ollamaModel READ ollamaModel WRITE setOllamaModel NOTIFY ollamaModelChanged)
-    Q_PROPERTY(QString openaiEndpoint READ openaiEndpoint WRITE setOpenaiEndpoint NOTIFY openaiEndpointChanged)
-    Q_PROPERTY(QString anthropicEndpoint READ anthropicEndpoint WRITE setAnthropicEndpoint NOTIFY anthropicEndpointChanged)
-    Q_PROPERTY(QString openrouterApiKey READ openrouterApiKey WRITE setOpenrouterApiKey NOTIFY openrouterApiKeyChanged)
-    Q_PROPERTY(QString openrouterModel READ openrouterModel WRITE setOpenrouterModel NOTIFY openrouterModelChanged)
+    Q_PROPERTY(QString aiProvider READ aiProvider WRITE setAiProvider NOTIFY aiProviderChanged FINAL)
+    Q_PROPERTY(QString openaiApiKey READ openaiApiKey WRITE setOpenaiApiKey NOTIFY openaiApiKeyChanged FINAL)
+    Q_PROPERTY(QString anthropicApiKey READ anthropicApiKey WRITE setAnthropicApiKey NOTIFY anthropicApiKeyChanged FINAL)
+    Q_PROPERTY(QString geminiApiKey READ geminiApiKey WRITE setGeminiApiKey NOTIFY geminiApiKeyChanged FINAL)
+    Q_PROPERTY(QString ollamaEndpoint READ ollamaEndpoint WRITE setOllamaEndpoint NOTIFY ollamaEndpointChanged FINAL)
+    Q_PROPERTY(QString ollamaModel READ ollamaModel WRITE setOllamaModel NOTIFY ollamaModelChanged FINAL)
+    Q_PROPERTY(QString openaiEndpoint READ openaiEndpoint WRITE setOpenaiEndpoint NOTIFY openaiEndpointChanged FINAL)
+    Q_PROPERTY(QString anthropicEndpoint READ anthropicEndpoint WRITE setAnthropicEndpoint NOTIFY anthropicEndpointChanged FINAL)
+    Q_PROPERTY(QString openrouterApiKey READ openrouterApiKey WRITE setOpenrouterApiKey NOTIFY openrouterApiKeyChanged FINAL)
+    Q_PROPERTY(QString openrouterModel READ openrouterModel WRITE setOpenrouterModel NOTIFY openrouterModelChanged FINAL)
     // When true (default), tapping AI Advice opens the tap-only taste intake
     // picker before the conversation; when false, it opens the conversation
     // directly (pre-existing behavior). See add-ai-taste-intake.
-    Q_PROPERTY(bool tasteIntakeOnAsk READ tasteIntakeOnAsk WRITE setTasteIntakeOnAsk NOTIFY tasteIntakeOnAskChanged)
+    Q_PROPERTY(bool tasteIntakeOnAsk READ tasteIntakeOnAsk WRITE setTasteIntakeOnAsk NOTIFY tasteIntakeOnAskChanged FINAL)
 
 public:
     explicit SettingsAI(QObject* parent = nullptr);

--- a/src/core/settings_app.h
+++ b/src/core/settings_app.h
@@ -16,27 +16,27 @@ class SettingsApp : public QObject {
     Q_OBJECT
 
     // Platform capabilities (compile-time)
-    Q_PROPERTY(bool hasQuick3D READ hasQuick3D CONSTANT)
-    Q_PROPERTY(bool use12HourTime READ use12HourTime CONSTANT)
-    Q_PROPERTY(bool isDebugBuild READ isDebugBuild CONSTANT)
+    Q_PROPERTY(bool hasQuick3D READ hasQuick3D CONSTANT FINAL)
+    Q_PROPERTY(bool use12HourTime READ use12HourTime CONSTANT FINAL)
+    Q_PROPERTY(bool isDebugBuild READ isDebugBuild CONSTANT FINAL)
 
     // Launcher mode (Android only — registers app as the home screen launcher
     // via the LauncherAlias activity-alias)
-    Q_PROPERTY(bool launcherMode READ launcherMode WRITE setLauncherMode NOTIFY launcherModeChanged)
+    Q_PROPERTY(bool launcherMode READ launcherMode WRITE setLauncherMode NOTIFY launcherModeChanged FINAL)
 
     // Profile management
-    Q_PROPERTY(QVariantList favoriteProfiles READ favoriteProfiles NOTIFY favoriteProfilesChanged)
-    Q_PROPERTY(int selectedFavoriteProfile READ selectedFavoriteProfile WRITE setSelectedFavoriteProfile NOTIFY selectedFavoriteProfileChanged)
-    Q_PROPERTY(QStringList selectedBuiltInProfiles READ selectedBuiltInProfiles WRITE setSelectedBuiltInProfiles NOTIFY selectedBuiltInProfilesChanged)
-    Q_PROPERTY(QStringList hiddenProfiles READ hiddenProfiles WRITE setHiddenProfiles NOTIFY hiddenProfilesChanged)
-    Q_PROPERTY(QString currentProfile READ currentProfile WRITE setCurrentProfile NOTIFY currentProfileChanged)
-    Q_PROPERTY(QString autoLoadProfileFilename READ autoLoadProfileFilename WRITE setAutoLoadProfileFilename NOTIFY autoLoadProfileFilenameChanged)
-    Q_PROPERTY(int autoLoadRevertMinutes READ autoLoadRevertMinutes WRITE setAutoLoadRevertMinutes NOTIFY autoLoadRevertMinutesChanged)
+    Q_PROPERTY(QVariantList favoriteProfiles READ favoriteProfiles NOTIFY favoriteProfilesChanged FINAL)
+    Q_PROPERTY(int selectedFavoriteProfile READ selectedFavoriteProfile WRITE setSelectedFavoriteProfile NOTIFY selectedFavoriteProfileChanged FINAL)
+    Q_PROPERTY(QStringList selectedBuiltInProfiles READ selectedBuiltInProfiles WRITE setSelectedBuiltInProfiles NOTIFY selectedBuiltInProfilesChanged FINAL)
+    Q_PROPERTY(QStringList hiddenProfiles READ hiddenProfiles WRITE setHiddenProfiles NOTIFY hiddenProfilesChanged FINAL)
+    Q_PROPERTY(QString currentProfile READ currentProfile WRITE setCurrentProfile NOTIFY currentProfileChanged FINAL)
+    Q_PROPERTY(QString autoLoadProfileFilename READ autoLoadProfileFilename WRITE setAutoLoadProfileFilename NOTIFY autoLoadProfileFilenameChanged FINAL)
+    Q_PROPERTY(int autoLoadRevertMinutes READ autoLoadRevertMinutes WRITE setAutoLoadRevertMinutes NOTIFY autoLoadRevertMinutesChanged FINAL)
 
     // Auto-update
-    Q_PROPERTY(bool autoCheckUpdates READ autoCheckUpdates WRITE setAutoCheckUpdates NOTIFY autoCheckUpdatesChanged)
-    Q_PROPERTY(bool betaUpdatesEnabled READ betaUpdatesEnabled WRITE setBetaUpdatesEnabled NOTIFY betaUpdatesEnabledChanged)
-    Q_PROPERTY(qint64 lastKnownApkSizeBytes READ lastKnownApkSizeBytes WRITE setLastKnownApkSizeBytes NOTIFY lastKnownApkSizeBytesChanged)
+    Q_PROPERTY(bool autoCheckUpdates READ autoCheckUpdates WRITE setAutoCheckUpdates NOTIFY autoCheckUpdatesChanged FINAL)
+    Q_PROPERTY(bool betaUpdatesEnabled READ betaUpdatesEnabled WRITE setBetaUpdatesEnabled NOTIFY betaUpdatesEnabledChanged FINAL)
+    Q_PROPERTY(qint64 lastKnownApkSizeBytes READ lastKnownApkSizeBytes WRITE setLastKnownApkSizeBytes NOTIFY lastKnownApkSizeBytesChanged FINAL)
 
     // One-time "enable Appear on top to auto-reopen after updates" prompt
     // has been shown. Persists across app restarts; once true, the prompt
@@ -44,51 +44,51 @@ class SettingsApp : public QObject {
     // user is asked once at the teachable moment, no permanent in-app UI.
     // READ-only on the Q_PROPERTY so QML cannot accidentally re-arm the
     // prompt by writing false; UpdateChecker mutates via the C++ setter.
-    Q_PROPERTY(bool autoRelaunchPromptShown READ autoRelaunchPromptShown NOTIFY autoRelaunchPromptShownChanged)
+    Q_PROPERTY(bool autoRelaunchPromptShown READ autoRelaunchPromptShown NOTIFY autoRelaunchPromptShownChanged FINAL)
 
     // DE1 firmware update channel. When false (default), firmware comes
     // from fast.decentespresso.com/download/sync/de1plus; when true,
     // from .../de1nightly. Independent from betaUpdatesEnabled, which
     // controls the Decenza *app* update channel.
-    Q_PROPERTY(bool firmwareNightlyChannel READ firmwareNightlyChannel WRITE setFirmwareNightlyChannel NOTIFY firmwareNightlyChannelChanged)
+    Q_PROPERTY(bool firmwareNightlyChannel READ firmwareNightlyChannel WRITE setFirmwareNightlyChannel NOTIFY firmwareNightlyChannelChanged FINAL)
 
     // Daily backup
-    Q_PROPERTY(int dailyBackupHour READ dailyBackupHour WRITE setDailyBackupHour NOTIFY dailyBackupHourChanged)
+    Q_PROPERTY(int dailyBackupHour READ dailyBackupHour WRITE setDailyBackupHour NOTIFY dailyBackupHourChanged FINAL)
 
     // Water level / refill
-    Q_PROPERTY(QString waterLevelDisplayUnit READ waterLevelDisplayUnit WRITE setWaterLevelDisplayUnit NOTIFY waterLevelDisplayUnitChanged)
-    Q_PROPERTY(QString temperatureUnit READ temperatureUnit WRITE setTemperatureUnit NOTIFY temperatureUnitChanged)
+    Q_PROPERTY(QString waterLevelDisplayUnit READ waterLevelDisplayUnit WRITE setWaterLevelDisplayUnit NOTIFY waterLevelDisplayUnitChanged FINAL)
+    Q_PROPERTY(QString temperatureUnit READ temperatureUnit WRITE setTemperatureUnit NOTIFY temperatureUnitChanged FINAL)
 
     // Water refill level (mm threshold for refill warning, sent to machine)
-    Q_PROPERTY(int waterRefillPoint READ waterRefillPoint WRITE setWaterRefillPoint NOTIFY waterRefillPointChanged)
+    Q_PROPERTY(int waterRefillPoint READ waterRefillPoint WRITE setWaterRefillPoint NOTIFY waterRefillPointChanged FINAL)
 
     // Refill kit override (0=force off, 1=force on, 2=auto-detect)
-    Q_PROPERTY(int refillKitOverride READ refillKitOverride WRITE setRefillKitOverride NOTIFY refillKitOverrideChanged)
+    Q_PROPERTY(int refillKitOverride READ refillKitOverride WRITE setRefillKitOverride NOTIFY refillKitOverrideChanged FINAL)
 
     // Developer settings
-    Q_PROPERTY(bool developerTranslationUpload READ developerTranslationUpload WRITE setDeveloperTranslationUpload NOTIFY developerTranslationUploadChanged)
-    Q_PROPERTY(bool simulationMode READ simulationMode WRITE setSimulationMode NOTIFY simulationModeChanged)
+    Q_PROPERTY(bool developerTranslationUpload READ developerTranslationUpload WRITE setDeveloperTranslationUpload NOTIFY developerTranslationUploadChanged FINAL)
+    Q_PROPERTY(bool simulationMode READ simulationMode WRITE setSimulationMode NOTIFY simulationModeChanged FINAL)
     // Whether the paired refractometer should measure by itself when it detects a
     // sample. The device stores this too, but the R2 is only connected while the
     // post-shot review page is open — so the setting has to live here for the user
     // to be able to change it at any time. Applied to the device on every connect.
-    Q_PROPERTY(bool refractometerAutoTest READ refractometerAutoTest WRITE setRefractometerAutoTest NOTIFY refractometerAutoTestChanged)
+    Q_PROPERTY(bool refractometerAutoTest READ refractometerAutoTest WRITE setRefractometerAutoTest NOTIFY refractometerAutoTestChanged FINAL)
     // False on builds with no simulator compiled in (tablet release). QML gates
     // every Simulation Mode affordance on this, so the feature is absent from
     // the UI rather than present and dead. CONSTANT: it is a build property, so
     // it cannot change while the app is running.
-    Q_PROPERTY(bool simulatorAvailable READ simulatorAvailable CONSTANT)
-    Q_PROPERTY(bool hideGhcSimulator READ hideGhcSimulator WRITE setHideGhcSimulator NOTIFY hideGhcSimulatorChanged)
-    Q_PROPERTY(bool simulatedScaleEnabled READ simulatedScaleEnabled WRITE setSimulatedScaleEnabled NOTIFY simulatedScaleEnabledChanged)
-    Q_PROPERTY(bool screenCaptureEnabled READ screenCaptureEnabled WRITE setScreenCaptureEnabled NOTIFY screenCaptureEnabledChanged)
+    Q_PROPERTY(bool simulatorAvailable READ simulatorAvailable CONSTANT FINAL)
+    Q_PROPERTY(bool hideGhcSimulator READ hideGhcSimulator WRITE setHideGhcSimulator NOTIFY hideGhcSimulatorChanged FINAL)
+    Q_PROPERTY(bool simulatedScaleEnabled READ simulatedScaleEnabled WRITE setSimulatedScaleEnabled NOTIFY simulatedScaleEnabledChanged FINAL)
+    Q_PROPERTY(bool screenCaptureEnabled READ screenCaptureEnabled WRITE setScreenCaptureEnabled NOTIFY screenCaptureEnabledChanged FINAL)
 
     // During-steam live coaching cues (LiveSteamCoach). Two independent opt-ins,
     // both OFF by default: `steamCoachVisualEnabled` shows the on-screen banner on
     // the steam page, `steamCoachAudioEnabled` speaks the cues. Neither implies the
     // other, and the audio path is routed independently of the accessibility
     // master switch (AccessibilityManager::announceCoaching).
-    Q_PROPERTY(bool steamCoachVisualEnabled READ steamCoachVisualEnabled WRITE setSteamCoachVisualEnabled NOTIFY steamCoachVisualEnabledChanged)
-    Q_PROPERTY(bool steamCoachAudioEnabled READ steamCoachAudioEnabled WRITE setSteamCoachAudioEnabled NOTIFY steamCoachAudioEnabledChanged)
+    Q_PROPERTY(bool steamCoachVisualEnabled READ steamCoachVisualEnabled WRITE setSteamCoachVisualEnabled NOTIFY steamCoachVisualEnabledChanged FINAL)
+    Q_PROPERTY(bool steamCoachAudioEnabled READ steamCoachAudioEnabled WRITE setSteamCoachAudioEnabled NOTIFY steamCoachAudioEnabledChanged FINAL)
 
 public:
     explicit SettingsApp(QObject* parent = nullptr);

--- a/src/core/settings_autowake.h
+++ b/src/core/settings_autowake.h
@@ -7,10 +7,10 @@
 class SettingsAutoWake : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(bool autoWakeEnabled READ autoWakeEnabled WRITE setAutoWakeEnabled NOTIFY autoWakeEnabledChanged)
-    Q_PROPERTY(QVariantList autoWakeSchedule READ autoWakeSchedule WRITE setAutoWakeSchedule NOTIFY autoWakeScheduleChanged)
-    Q_PROPERTY(bool autoWakeStayAwakeEnabled READ autoWakeStayAwakeEnabled WRITE setAutoWakeStayAwakeEnabled NOTIFY autoWakeStayAwakeEnabledChanged)
-    Q_PROPERTY(int autoWakeStayAwakeMinutes READ autoWakeStayAwakeMinutes WRITE setAutoWakeStayAwakeMinutes NOTIFY autoWakeStayAwakeMinutesChanged)
+    Q_PROPERTY(bool autoWakeEnabled READ autoWakeEnabled WRITE setAutoWakeEnabled NOTIFY autoWakeEnabledChanged FINAL)
+    Q_PROPERTY(QVariantList autoWakeSchedule READ autoWakeSchedule WRITE setAutoWakeSchedule NOTIFY autoWakeScheduleChanged FINAL)
+    Q_PROPERTY(bool autoWakeStayAwakeEnabled READ autoWakeStayAwakeEnabled WRITE setAutoWakeStayAwakeEnabled NOTIFY autoWakeStayAwakeEnabledChanged FINAL)
+    Q_PROPERTY(int autoWakeStayAwakeMinutes READ autoWakeStayAwakeMinutes WRITE setAutoWakeStayAwakeMinutes NOTIFY autoWakeStayAwakeMinutesChanged FINAL)
 
 public:
     explicit SettingsAutoWake(QObject* parent = nullptr);

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -17,69 +17,69 @@ class SettingsBrew : public QObject {
     Q_OBJECT
 
     // Espresso
-    Q_PROPERTY(double espressoTemperature READ espressoTemperature WRITE setEspressoTemperature NOTIFY espressoTemperatureChanged)
-    Q_PROPERTY(double targetWeight READ targetWeight WRITE setTargetWeight NOTIFY targetWeightChanged)
-    Q_PROPERTY(double lastUsedRatio READ lastUsedRatio WRITE setLastUsedRatio NOTIFY lastUsedRatioChanged)
+    Q_PROPERTY(double espressoTemperature READ espressoTemperature WRITE setEspressoTemperature NOTIFY espressoTemperatureChanged FINAL)
+    Q_PROPERTY(double targetWeight READ targetWeight WRITE setTargetWeight NOTIFY targetWeightChanged FINAL)
+    Q_PROPERTY(double lastUsedRatio READ lastUsedRatio WRITE setLastUsedRatio NOTIFY lastUsedRatioChanged FINAL)
     // Home-screen quick-select brew-ratio presets (Ristretto / Normale / Lungo),
     // used by the ratioQuickSelect layout widget. Default 1 / 2 / 3.
-    Q_PROPERTY(double ratioPreset1 READ ratioPreset1 WRITE setRatioPreset1 NOTIFY ratioPreset1Changed)
-    Q_PROPERTY(double ratioPreset2 READ ratioPreset2 WRITE setRatioPreset2 NOTIFY ratioPreset2Changed)
-    Q_PROPERTY(double ratioPreset3 READ ratioPreset3 WRITE setRatioPreset3 NOTIFY ratioPreset3Changed)
+    Q_PROPERTY(double ratioPreset1 READ ratioPreset1 WRITE setRatioPreset1 NOTIFY ratioPreset1Changed FINAL)
+    Q_PROPERTY(double ratioPreset2 READ ratioPreset2 WRITE setRatioPreset2 NOTIFY ratioPreset2Changed FINAL)
+    Q_PROPERTY(double ratioPreset3 READ ratioPreset3 WRITE setRatioPreset3 NOTIFY ratioPreset3Changed FINAL)
     // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
-    Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
+    Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged FINAL)
     // Master toggle for weight-timed steaming (UI label "Weight-timed steaming").
     // When off, steam time is never scaled from milk weight. Default OFF; setting a
     // pitcher's reference milk (setSteamPitcherCalibration) turns it on automatically.
-    Q_PROPERTY(bool milkAutoCaptureEnabled READ milkAutoCaptureEnabled WRITE setMilkAutoCaptureEnabled NOTIFY milkAutoCaptureEnabledChanged)
+    Q_PROPERTY(bool milkAutoCaptureEnabled READ milkAutoCaptureEnabled WRITE setMilkAutoCaptureEnabled NOTIFY milkAutoCaptureEnabledChanged FINAL)
     // Whether the confirmation "ding" plays when a dose/milk auto-captures. Default
     // off — toggled by the bell on the Dose cup row.
-    Q_PROPERTY(bool doseCaptureSoundEnabled READ doseCaptureSoundEnabled WRITE setDoseCaptureSoundEnabled NOTIFY doseCaptureSoundEnabledChanged)
+    Q_PROPERTY(bool doseCaptureSoundEnabled READ doseCaptureSoundEnabled WRITE setDoseCaptureSoundEnabled NOTIFY doseCaptureSoundEnabledChanged FINAL)
     // Last actual steam session (milk weight + steam time), saved so the steam
     // setup can adopt them as a new reference baseline.
-    Q_PROPERTY(double lastSteamMilkG READ lastSteamMilkG WRITE setLastSteamMilkG NOTIFY lastSteamMilkGChanged)
-    Q_PROPERTY(double lastSteamTimeS READ lastSteamTimeS WRITE setLastSteamTimeS NOTIFY lastSteamTimeSChanged)
+    Q_PROPERTY(double lastSteamMilkG READ lastSteamMilkG WRITE setLastSteamMilkG NOTIFY lastSteamMilkGChanged FINAL)
+    Q_PROPERTY(double lastSteamTimeS READ lastSteamTimeS WRITE setLastSteamTimeS NOTIFY lastSteamTimeSChanged FINAL)
     // Global weight-timed steam rate (seconds of steam per gram of milk). One
     // calibration for every pitcher (assumes a consistent steam flow — a
     // simplification, not a physical guarantee), replacing per-pitcher
     // reference-milk scaling. 0 = uncalibrated. Clamped >= 0.
-    Q_PROPERTY(double steamSecondsPerGram READ steamSecondsPerGram WRITE setSteamSecondsPerGram NOTIFY steamSecondsPerGramChanged)
+    Q_PROPERTY(double steamSecondsPerGram READ steamSecondsPerGram WRITE setSteamSecondsPerGram NOTIFY steamSecondsPerGramChanged FINAL)
 
     // Steam
-    Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
-    Q_PROPERTY(int steamTimeout READ steamTimeout WRITE setSteamTimeout NOTIFY steamTimeoutChanged)
-    Q_PROPERTY(int steamFlow READ steamFlow WRITE setSteamFlow NOTIFY steamFlowChanged)
+    Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged FINAL)
+    Q_PROPERTY(int steamTimeout READ steamTimeout WRITE setSteamTimeout NOTIFY steamTimeoutChanged FINAL)
+    Q_PROPERTY(int steamFlow READ steamFlow WRITE setSteamFlow NOTIFY steamFlowChanged FINAL)
     // Session-only flag (no QSettings backing) — used during descaling to suppress
     // the steam heater. Setter is Q_INVOKABLE rather than a property WRITE so the
     // public API doesn't pretend this value persists across restarts.
-    Q_PROPERTY(bool steamDisabled READ steamDisabled NOTIFY steamDisabledChanged)
-    Q_PROPERTY(bool keepSteamHeaterOn READ keepSteamHeaterOn WRITE setKeepSteamHeaterOn NOTIFY keepSteamHeaterOnChanged)
-    Q_PROPERTY(int steamAutoFlushSeconds READ steamAutoFlushSeconds WRITE setSteamAutoFlushSeconds NOTIFY steamAutoFlushSecondsChanged)
+    Q_PROPERTY(bool steamDisabled READ steamDisabled NOTIFY steamDisabledChanged FINAL)
+    Q_PROPERTY(bool keepSteamHeaterOn READ keepSteamHeaterOn WRITE setKeepSteamHeaterOn NOTIFY keepSteamHeaterOnChanged FINAL)
+    Q_PROPERTY(int steamAutoFlushSeconds READ steamAutoFlushSeconds WRITE setSteamAutoFlushSeconds NOTIFY steamAutoFlushSecondsChanged FINAL)
 
     // Steam pitcher presets
-    Q_PROPERTY(QVariantList steamPitcherPresets READ steamPitcherPresets NOTIFY steamPitcherPresetsChanged)
-    Q_PROPERTY(int selectedSteamPitcher READ selectedSteamPitcher WRITE setSelectedSteamCup NOTIFY selectedSteamPitcherChanged)
+    Q_PROPERTY(QVariantList steamPitcherPresets READ steamPitcherPresets NOTIFY steamPitcherPresetsChanged FINAL)
+    Q_PROPERTY(int selectedSteamPitcher READ selectedSteamPitcher WRITE setSelectedSteamCup NOTIFY selectedSteamPitcherChanged FINAL)
 
     // Hot water
-    Q_PROPERTY(double waterTemperature READ waterTemperature WRITE setWaterTemperature NOTIFY waterTemperatureChanged)
-    Q_PROPERTY(int waterVolume READ waterVolume WRITE setWaterVolume NOTIFY waterVolumeChanged)
-    Q_PROPERTY(QString waterVolumeMode READ waterVolumeMode WRITE setWaterVolumeMode NOTIFY waterVolumeModeChanged)
-    Q_PROPERTY(double hotWaterSawOffset READ hotWaterSawOffset WRITE setHotWaterSawOffset NOTIFY hotWaterSawOffsetChanged)
-    Q_PROPERTY(int hotWaterSawSampleCount READ hotWaterSawSampleCount WRITE setHotWaterSawSampleCount NOTIFY hotWaterSawSampleCountChanged)
+    Q_PROPERTY(double waterTemperature READ waterTemperature WRITE setWaterTemperature NOTIFY waterTemperatureChanged FINAL)
+    Q_PROPERTY(int waterVolume READ waterVolume WRITE setWaterVolume NOTIFY waterVolumeChanged FINAL)
+    Q_PROPERTY(QString waterVolumeMode READ waterVolumeMode WRITE setWaterVolumeMode NOTIFY waterVolumeModeChanged FINAL)
+    Q_PROPERTY(double hotWaterSawOffset READ hotWaterSawOffset WRITE setHotWaterSawOffset NOTIFY hotWaterSawOffsetChanged FINAL)
+    Q_PROPERTY(int hotWaterSawSampleCount READ hotWaterSawSampleCount WRITE setHotWaterSawSampleCount NOTIFY hotWaterSawSampleCountChanged FINAL)
 
     // Hot water vessel presets
-    Q_PROPERTY(QVariantList waterVesselPresets READ waterVesselPresets NOTIFY waterVesselPresetsChanged)
-    Q_PROPERTY(int selectedWaterVessel READ selectedWaterVessel WRITE setSelectedWaterCup NOTIFY selectedWaterVesselChanged)
+    Q_PROPERTY(QVariantList waterVesselPresets READ waterVesselPresets NOTIFY waterVesselPresetsChanged FINAL)
+    Q_PROPERTY(int selectedWaterVessel READ selectedWaterVessel WRITE setSelectedWaterCup NOTIFY selectedWaterVesselChanged FINAL)
 
     // Flush presets
-    Q_PROPERTY(QVariantList flushPresets READ flushPresets NOTIFY flushPresetsChanged)
-    Q_PROPERTY(int selectedFlushPreset READ selectedFlushPreset WRITE setSelectedFlushPreset NOTIFY selectedFlushPresetChanged)
-    Q_PROPERTY(double flushFlow READ flushFlow WRITE setFlushFlow NOTIFY flushFlowChanged)
-    Q_PROPERTY(double flushSeconds READ flushSeconds WRITE setFlushSeconds NOTIFY flushSecondsChanged)
+    Q_PROPERTY(QVariantList flushPresets READ flushPresets NOTIFY flushPresetsChanged FINAL)
+    Q_PROPERTY(int selectedFlushPreset READ selectedFlushPreset WRITE setSelectedFlushPreset NOTIFY selectedFlushPresetChanged FINAL)
+    Q_PROPERTY(double flushFlow READ flushFlow WRITE setFlushFlow NOTIFY flushFlowChanged FINAL)
+    Q_PROPERTY(double flushSeconds READ flushSeconds WRITE setFlushSeconds NOTIFY flushSecondsChanged FINAL)
 
     // Temperature override (persistent)
-    Q_PROPERTY(double temperatureOverride READ temperatureOverride WRITE setTemperatureOverride NOTIFY temperatureOverrideChanged)
-    Q_PROPERTY(bool hasTemperatureOverride READ hasTemperatureOverride NOTIFY temperatureOverrideChanged)
+    Q_PROPERTY(double temperatureOverride READ temperatureOverride WRITE setTemperatureOverride NOTIFY temperatureOverrideChanged FINAL)
+    Q_PROPERTY(bool hasTemperatureOverride READ hasTemperatureOverride NOTIFY temperatureOverrideChanged FINAL)
 
     // Brew parameter overrides (persistent). The yield override is the SESSION
     // YIELD ANCHOR (add-yield-ratio-anchor): {value, mode} where mode is
@@ -89,12 +89,12 @@ class SettingsBrew : public QObject {
     // anchors an ABSOLUTE (grams); ratio writers use setBrewRatioAnchor().
     // hasBrewYieldOverride is defined as mode != none — never inferred by
     // comparing a resolved gram value against the profile target.
-    Q_PROPERTY(double brewYieldOverride READ brewYieldOverride WRITE setBrewYieldOverride NOTIFY brewOverridesChanged)
-    Q_PROPERTY(QString brewYieldMode READ brewYieldMode NOTIFY brewOverridesChanged)
-    Q_PROPERTY(bool hasBrewYieldOverride READ hasBrewYieldOverride NOTIFY brewOverridesChanged)
+    Q_PROPERTY(double brewYieldOverride READ brewYieldOverride WRITE setBrewYieldOverride NOTIFY brewOverridesChanged FINAL)
+    Q_PROPERTY(QString brewYieldMode READ brewYieldMode NOTIFY brewOverridesChanged FINAL)
+    Q_PROPERTY(bool hasBrewYieldOverride READ hasBrewYieldOverride NOTIFY brewOverridesChanged FINAL)
 
     // Stop-at-volume gating when a BLE scale provides weight data
-    Q_PROPERTY(bool ignoreVolumeWithScale READ ignoreVolumeWithScale WRITE setIgnoreVolumeWithScale NOTIFY ignoreVolumeWithScaleChanged)
+    Q_PROPERTY(bool ignoreVolumeWithScale READ ignoreVolumeWithScale WRITE setIgnoreVolumeWithScale NOTIFY ignoreVolumeWithScaleChanged FINAL)
 
 public:
     explicit SettingsBrew(QObject* parent = nullptr);

--- a/src/core/settings_calibration.h
+++ b/src/core/settings_calibration.h
@@ -55,12 +55,12 @@ class SettingsCalibration : public QObject {
     Q_OBJECT
 
     // Flow calibration
-    Q_PROPERTY(double flowCalibrationMultiplier READ flowCalibrationMultiplier WRITE setFlowCalibrationMultiplier NOTIFY flowCalibrationMultiplierChanged)
-    Q_PROPERTY(bool autoFlowCalibration READ autoFlowCalibration WRITE setAutoFlowCalibration NOTIFY autoFlowCalibrationChanged)
-    Q_PROPERTY(int perProfileFlowCalVersion READ perProfileFlowCalVersion NOTIFY perProfileFlowCalibrationChanged)
+    Q_PROPERTY(double flowCalibrationMultiplier READ flowCalibrationMultiplier WRITE setFlowCalibrationMultiplier NOTIFY flowCalibrationMultiplierChanged FINAL)
+    Q_PROPERTY(bool autoFlowCalibration READ autoFlowCalibration WRITE setAutoFlowCalibration NOTIFY autoFlowCalibrationChanged FINAL)
+    Q_PROPERTY(int perProfileFlowCalVersion READ perProfileFlowCalVersion NOTIFY perProfileFlowCalibrationChanged FINAL)
 
     // SAW (Stop-at-Weight) learning
-    Q_PROPERTY(double sawLearnedLag READ sawLearnedLag NOTIFY sawLearnedLagChanged)
+    Q_PROPERTY(double sawLearnedLag READ sawLearnedLag NOTIFY sawLearnedLagChanged FINAL)
 
 public:
     explicit SettingsCalibration(Settings* owner, QObject* parent = nullptr);

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -56,80 +56,80 @@ public:
 
 private:
     // DYE metadata - sticky fields
-    Q_PROPERTY(QString dyeBeanBrand READ dyeBeanBrand WRITE setDyeBeanBrand NOTIFY dyeBeanBrandChanged)
-    Q_PROPERTY(QString dyeBeanType READ dyeBeanType WRITE setDyeBeanType NOTIFY dyeBeanTypeChanged)
-    Q_PROPERTY(QString dyeRoastDate READ dyeRoastDate WRITE setDyeRoastDate NOTIFY dyeRoastDateChanged)
-    Q_PROPERTY(QString dyeRoastLevel READ dyeRoastLevel WRITE setDyeRoastLevel NOTIFY dyeRoastLevelChanged)
-    Q_PROPERTY(QString dyeGrinderBrand READ dyeGrinderBrand WRITE setDyeGrinderBrand NOTIFY dyeGrinderBrandChanged)
-    Q_PROPERTY(QString dyeGrinderModel READ dyeGrinderModel WRITE setDyeGrinderModel NOTIFY dyeGrinderModelChanged)
-    Q_PROPERTY(QString dyeGrinderBurrs READ dyeGrinderBurrs WRITE setDyeGrinderBurrs NOTIFY dyeGrinderBurrsChanged)
+    Q_PROPERTY(QString dyeBeanBrand READ dyeBeanBrand WRITE setDyeBeanBrand NOTIFY dyeBeanBrandChanged FINAL)
+    Q_PROPERTY(QString dyeBeanType READ dyeBeanType WRITE setDyeBeanType NOTIFY dyeBeanTypeChanged FINAL)
+    Q_PROPERTY(QString dyeRoastDate READ dyeRoastDate WRITE setDyeRoastDate NOTIFY dyeRoastDateChanged FINAL)
+    Q_PROPERTY(QString dyeRoastLevel READ dyeRoastLevel WRITE setDyeRoastLevel NOTIFY dyeRoastLevelChanged FINAL)
+    Q_PROPERTY(QString dyeGrinderBrand READ dyeGrinderBrand WRITE setDyeGrinderBrand NOTIFY dyeGrinderBrandChanged FINAL)
+    Q_PROPERTY(QString dyeGrinderModel READ dyeGrinderModel WRITE setDyeGrinderModel NOTIFY dyeGrinderModelChanged FINAL)
+    Q_PROPERTY(QString dyeGrinderBurrs READ dyeGrinderBurrs WRITE setDyeGrinderBurrs NOTIFY dyeGrinderBurrsChanged FINAL)
     // Active package's display name (read-only; defaults to "{brand} {model}").
     // UI shows this instead of the raw grinder identity (add-equipment-packages).
-    Q_PROPERTY(QString dyeEquipmentName READ dyeEquipmentName NOTIFY dyeEquipmentNameChanged)
+    Q_PROPERTY(QString dyeEquipmentName READ dyeEquipmentName NOTIFY dyeEquipmentNameChanged FINAL)
     // Active package's basket identity (read-only; empty when none). Basket is
     // part of the package identity, not a per-shot dial, so these are resolved
     // from the active package like dyeEquipmentName (add-basket-equipment).
-    Q_PROPERTY(QString dyeBasketBrand READ dyeBasketBrand NOTIFY dyeBasketChanged)
-    Q_PROPERTY(QString dyeBasketModel READ dyeBasketModel NOTIFY dyeBasketChanged)
+    Q_PROPERTY(QString dyeBasketBrand READ dyeBasketBrand NOTIFY dyeBasketChanged FINAL)
+    Q_PROPERTY(QString dyeBasketModel READ dyeBasketModel NOTIFY dyeBasketChanged FINAL)
     // Active package's puck-prep canonical flag string (e.g. "shaker,wdt"; empty =
     // none), resolved from the active package (add-puckprep-equipment). The Edit
     // Equipment form prefills its checkboxes from this when adding new gear.
-    Q_PROPERTY(QString dyePuckPrepCanonical READ dyePuckPrepCanonical NOTIFY dyePuckPrepChanged)
+    Q_PROPERTY(QString dyePuckPrepCanonical READ dyePuckPrepCanonical NOTIFY dyePuckPrepChanged FINAL)
     // One-line registry summary of the active basket (wall/flow/precision/dose),
     // empty for none or a custom off-registry basket.
-    Q_PROPERTY(QString dyeBasketSummary READ dyeBasketSummary NOTIFY dyeBasketChanged)
-    Q_PROPERTY(QString dyeGrinderSetting READ dyeGrinderSetting WRITE setDyeGrinderSetting NOTIFY dyeGrinderSettingChanged)
+    Q_PROPERTY(QString dyeBasketSummary READ dyeBasketSummary NOTIFY dyeBasketChanged FINAL)
+    Q_PROPERTY(QString dyeGrinderSetting READ dyeGrinderSetting WRITE setDyeGrinderSetting NOTIFY dyeGrinderSettingChanged FINAL)
     // Grinder rpm dial-in (add-equipment-packages); shown only when the active
     // package's grinder is rpmCapable. 0 = unset.
-    Q_PROPERTY(int dyeGrinderRpm READ dyeGrinderRpm WRITE setDyeGrinderRpm NOTIFY dyeGrinderRpmChanged)
+    Q_PROPERTY(int dyeGrinderRpm READ dyeGrinderRpm WRITE setDyeGrinderRpm NOTIFY dyeGrinderRpmChanged FINAL)
     // The active equipment package id (the grinder the next shot is ground on).
     // Switching it applies the package's grinder identity + last dial.
-    Q_PROPERTY(qint64 activeEquipmentId READ activeEquipmentId WRITE setActiveEquipmentId NOTIFY activeEquipmentIdChanged)
-    Q_PROPERTY(double dyeBeanWeight READ dyeBeanWeight WRITE setDyeBeanWeight NOTIFY dyeBeanWeightChanged)
-    Q_PROPERTY(double dyeDrinkWeight READ dyeDrinkWeight WRITE setDyeDrinkWeight NOTIFY dyeDrinkWeightChanged)
-    Q_PROPERTY(double dyeDrinkTds READ dyeDrinkTds WRITE setDyeDrinkTds NOTIFY dyeDrinkTdsChanged)
-    Q_PROPERTY(double dyeDrinkEy READ dyeDrinkEy WRITE setDyeDrinkEy NOTIFY dyeDrinkEyChanged)
-    Q_PROPERTY(QString dyeShotNotes READ dyeShotNotes WRITE setDyeShotNotes NOTIFY dyeShotNotesChanged)
-    Q_PROPERTY(QString dyeBarista READ dyeBarista WRITE setDyeBarista NOTIFY dyeBaristaChanged)
-    Q_PROPERTY(QString dyeShotDateTime READ dyeShotDateTime WRITE setDyeShotDateTime NOTIFY dyeShotDateTimeChanged)
+    Q_PROPERTY(qint64 activeEquipmentId READ activeEquipmentId WRITE setActiveEquipmentId NOTIFY activeEquipmentIdChanged FINAL)
+    Q_PROPERTY(double dyeBeanWeight READ dyeBeanWeight WRITE setDyeBeanWeight NOTIFY dyeBeanWeightChanged FINAL)
+    Q_PROPERTY(double dyeDrinkWeight READ dyeDrinkWeight WRITE setDyeDrinkWeight NOTIFY dyeDrinkWeightChanged FINAL)
+    Q_PROPERTY(double dyeDrinkTds READ dyeDrinkTds WRITE setDyeDrinkTds NOTIFY dyeDrinkTdsChanged FINAL)
+    Q_PROPERTY(double dyeDrinkEy READ dyeDrinkEy WRITE setDyeDrinkEy NOTIFY dyeDrinkEyChanged FINAL)
+    Q_PROPERTY(QString dyeShotNotes READ dyeShotNotes WRITE setDyeShotNotes NOTIFY dyeShotNotesChanged FINAL)
+    Q_PROPERTY(QString dyeBarista READ dyeBarista WRITE setDyeBarista NOTIFY dyeBaristaChanged FINAL)
+    Q_PROPERTY(QString dyeShotDateTime READ dyeShotDateTime WRITE setDyeShotDateTime NOTIFY dyeShotDateTimeChanged FINAL)
 
     // Bean Base (Loffee Labs) link state — sticky like the bean fields.
     // dyeBeanBaseId empty = unlinked (the free-text-only path most beans use).
     // dyeBeanBaseData holds the full cached entry as one compact-JSON blob;
     // consumers (shot snapshot, Visualizer upload, AI advisor) read it as a
     // unit, so it is deliberately NOT split into per-attribute properties.
-    Q_PROPERTY(QString dyeBeanBaseId READ dyeBeanBaseId WRITE setDyeBeanBaseId NOTIFY dyeBeanBaseIdChanged)
-    Q_PROPERTY(QString dyeBeanBaseData READ dyeBeanBaseData WRITE setDyeBeanBaseData NOTIFY dyeBeanBaseDataChanged)
+    Q_PROPERTY(QString dyeBeanBaseId READ dyeBeanBaseId WRITE setDyeBeanBaseId NOTIFY dyeBeanBaseIdChanged FINAL)
+    Q_PROPERTY(QString dyeBeanBaseData READ dyeBeanBaseData WRITE setDyeBeanBaseData NOTIFY dyeBeanBaseDataChanged FINAL)
 
     // The active coffee bag (DB row id in coffee_bags), -1 = no bag selected.
     // Setting it loads the bag and applies its fields to the dye cache.
-    Q_PROPERTY(int activeBagId READ activeBagId WRITE setActiveBagId NOTIFY activeBagIdChanged)
+    Q_PROPERTY(int activeBagId READ activeBagId WRITE setActiveBagId NOTIFY activeBagIdChanged FINAL)
     // The active recipe (DB row id in recipes), -1 = none (add-recipes). Only
     // the persisted id lives here — activation, write-through stamping, and
     // deactivate-on-ingredient-swap are MainController's job (the recipe layer
     // sits above the settings façade, unlike bags whose fields ARE dye state).
-    Q_PROPERTY(int activeRecipeId READ activeRecipeId WRITE setActiveRecipeId NOTIFY activeRecipeIdChanged)
+    Q_PROPERTY(int activeRecipeId READ activeRecipeId WRITE setActiveRecipeId NOTIFY activeRecipeIdChanged FINAL)
     // The recipe pinned to auto-load (recipe-auto-load), -1 = none. Mutually
     // exclusive with SettingsApp::autoLoadProfileFilename — setting either one
     // clears the other; the cross-clear is wired in Settings (the façade that
     // owns both sub-objects), not here, so this class stays ignorant of
     // SettingsApp. Shares SettingsApp::autoLoadRevertMinutes with the profile
     // side rather than having its own timeout.
-    Q_PROPERTY(int autoLoadRecipeId READ autoLoadRecipeId WRITE setAutoLoadRecipeId NOTIFY autoLoadRecipeIdChanged)
+    Q_PROPERTY(int autoLoadRecipeId READ autoLoadRecipeId WRITE setAutoLoadRecipeId NOTIFY autoLoadRecipeIdChanged FINAL)
     // Lifecycle fields of the active bag, mirrored for QML display and the
     // shot snapshot (read-only here; edited via CoffeeBagStorage).
-    Q_PROPERTY(QString activeBagFrozenDate READ activeBagFrozenDate NOTIFY activeBagChanged)
-    Q_PROPERTY(QString activeBagDefrostDate READ activeBagDefrostDate NOTIFY activeBagChanged)
+    Q_PROPERTY(QString activeBagFrozenDate READ activeBagFrozenDate NOTIFY activeBagChanged FINAL)
+    Q_PROPERTY(QString activeBagDefrostDate READ activeBagDefrostDate NOTIFY activeBagChanged FINAL)
     // Non-frozen storage lifecycle (bean-freshness-followup): storage category
     // and opened date of the active bag.
-    Q_PROPERTY(QString activeBagStorageHint READ activeBagStorageHint NOTIFY activeBagChanged)
-    Q_PROPERTY(QString activeBagOpenedDate READ activeBagOpenedDate NOTIFY activeBagChanged)
+    Q_PROPERTY(QString activeBagStorageHint READ activeBagStorageHint NOTIFY activeBagChanged FINAL)
+    Q_PROPERTY(QString activeBagOpenedDate READ activeBagOpenedDate NOTIFY activeBagChanged FINAL)
     // The active bag's own yield spec (add-yield-ratio-anchor). QML-visible:
     // Brew Settings reads them for the Update Bag button's enable-gate and
     // for Clear's baseline, so they MUST be properties — a plain getter reads
     // as `undefined` in QML and silently defeats both.
-    Q_PROPERTY(double activeBagYieldValue READ activeBagYieldValue NOTIFY activeBagYieldSpecChanged)
-    Q_PROPERTY(QString activeBagYieldMode READ activeBagYieldMode NOTIFY activeBagYieldSpecChanged)
+    Q_PROPERTY(double activeBagYieldValue READ activeBagYieldValue NOTIFY activeBagYieldSpecChanged FINAL)
+    Q_PROPERTY(QString activeBagYieldMode READ activeBagYieldMode NOTIFY activeBagYieldSpecChanged FINAL)
 
 public:
     explicit SettingsDye(QObject* parent = nullptr);

--- a/src/core/settings_hardware.h
+++ b/src/core/settings_hardware.h
@@ -8,13 +8,13 @@
 class SettingsHardware : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(int heaterIdleTemp READ heaterIdleTemp WRITE setHeaterIdleTemp NOTIFY heaterIdleTempChanged)
-    Q_PROPERTY(int heaterWarmupFlow READ heaterWarmupFlow WRITE setHeaterWarmupFlow NOTIFY heaterWarmupFlowChanged)
-    Q_PROPERTY(int heaterTestFlow READ heaterTestFlow WRITE setHeaterTestFlow NOTIFY heaterTestFlowChanged)
-    Q_PROPERTY(int heaterWarmupTimeout READ heaterWarmupTimeout WRITE setHeaterWarmupTimeout NOTIFY heaterWarmupTimeoutChanged)
-    Q_PROPERTY(int hotWaterFlowRate READ hotWaterFlowRate WRITE setHotWaterFlowRate NOTIFY hotWaterFlowRateChanged)
-    Q_PROPERTY(bool steamTwoTapStop READ steamTwoTapStop WRITE setSteamTwoTapStop NOTIFY steamTwoTapStopChanged)
-    Q_PROPERTY(int fanThreshold READ fanThreshold WRITE setFanThreshold NOTIFY fanThresholdChanged)
+    Q_PROPERTY(int heaterIdleTemp READ heaterIdleTemp WRITE setHeaterIdleTemp NOTIFY heaterIdleTempChanged FINAL)
+    Q_PROPERTY(int heaterWarmupFlow READ heaterWarmupFlow WRITE setHeaterWarmupFlow NOTIFY heaterWarmupFlowChanged FINAL)
+    Q_PROPERTY(int heaterTestFlow READ heaterTestFlow WRITE setHeaterTestFlow NOTIFY heaterTestFlowChanged FINAL)
+    Q_PROPERTY(int heaterWarmupTimeout READ heaterWarmupTimeout WRITE setHeaterWarmupTimeout NOTIFY heaterWarmupTimeoutChanged FINAL)
+    Q_PROPERTY(int hotWaterFlowRate READ hotWaterFlowRate WRITE setHotWaterFlowRate NOTIFY hotWaterFlowRateChanged FINAL)
+    Q_PROPERTY(bool steamTwoTapStop READ steamTwoTapStop WRITE setSteamTwoTapStop NOTIFY steamTwoTapStopChanged FINAL)
+    Q_PROPERTY(int fanThreshold READ fanThreshold WRITE setFanThreshold NOTIFY fanThresholdChanged FINAL)
 
 public:
     explicit SettingsHardware(QObject* parent = nullptr);

--- a/src/core/settings_mcp.h
+++ b/src/core/settings_mcp.h
@@ -12,25 +12,25 @@
 class SettingsMcp : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(bool mcpEnabled READ mcpEnabled WRITE setMcpEnabled NOTIFY mcpEnabledChanged)
-    Q_PROPERTY(int mcpAccessLevel READ mcpAccessLevel WRITE setMcpAccessLevel NOTIFY mcpAccessLevelChanged)
-    Q_PROPERTY(int mcpConfirmationLevel READ mcpConfirmationLevel WRITE setMcpConfirmationLevel NOTIFY mcpConfirmationLevelChanged)
-    Q_PROPERTY(QString mcpApiKey READ mcpApiKey NOTIFY mcpApiKeyChanged)
+    Q_PROPERTY(bool mcpEnabled READ mcpEnabled WRITE setMcpEnabled NOTIFY mcpEnabledChanged FINAL)
+    Q_PROPERTY(int mcpAccessLevel READ mcpAccessLevel WRITE setMcpAccessLevel NOTIFY mcpAccessLevelChanged FINAL)
+    Q_PROPERTY(int mcpConfirmationLevel READ mcpConfirmationLevel WRITE setMcpConfirmationLevel NOTIFY mcpConfirmationLevelChanged FINAL)
+    Q_PROPERTY(QString mcpApiKey READ mcpApiKey NOTIFY mcpApiKeyChanged FINAL)
 
     // Remote MCP connector (public-internet reachability for Claude/ChatGPT
     // mobile connectors). See docs/CLAUDE_MD/MCP_SERVER.md and the
     // add-remote-mcp-connector change. Defaults off; opt-in.
-    Q_PROPERTY(bool remoteMcpEnabled READ remoteMcpEnabled WRITE setRemoteMcpEnabled NOTIFY remoteMcpEnabledChanged)
-    Q_PROPERTY(QString remoteMcpMode READ remoteMcpMode WRITE setRemoteMcpMode NOTIFY remoteMcpModeChanged)
-    Q_PROPERTY(int remoteMcpPort READ remoteMcpPort WRITE setRemoteMcpPort NOTIFY remoteMcpPortChanged)
-    Q_PROPERTY(QString remoteMcpCustomBaseUrl READ remoteMcpCustomBaseUrl WRITE setRemoteMcpCustomBaseUrl NOTIFY remoteMcpCustomBaseUrlChanged)
+    Q_PROPERTY(bool remoteMcpEnabled READ remoteMcpEnabled WRITE setRemoteMcpEnabled NOTIFY remoteMcpEnabledChanged FINAL)
+    Q_PROPERTY(QString remoteMcpMode READ remoteMcpMode WRITE setRemoteMcpMode NOTIFY remoteMcpModeChanged FINAL)
+    Q_PROPERTY(int remoteMcpPort READ remoteMcpPort WRITE setRemoteMcpPort NOTIFY remoteMcpPortChanged FINAL)
+    Q_PROPERTY(QString remoteMcpCustomBaseUrl READ remoteMcpCustomBaseUrl WRITE setRemoteMcpCustomBaseUrl NOTIFY remoteMcpCustomBaseUrlChanged FINAL)
     // The capability token. QML normally consumes it only via the composed
     // connector URL (RemoteMcpAccess.connectorUrl), but it is a readable property
     // so the NOTIFY can drive that URL binding and local UI. Rotation is the
     // revocation story; the token is no more sensitive than the existing plaintext
     // mcpApiKey and never leaves the owner's device except inside the URL they
     // paste into their AI app.
-    Q_PROPERTY(QString remoteMcpToken READ remoteMcpToken NOTIFY remoteMcpTokenChanged)
+    Q_PROPERTY(QString remoteMcpToken READ remoteMcpToken NOTIFY remoteMcpTokenChanged FINAL)
 
 public:
     explicit SettingsMcp(QObject* parent = nullptr);

--- a/src/core/settings_mqtt.h
+++ b/src/core/settings_mqtt.h
@@ -7,16 +7,16 @@
 class SettingsMqtt : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(bool mqttEnabled READ mqttEnabled WRITE setMqttEnabled NOTIFY mqttEnabledChanged)
-    Q_PROPERTY(QString mqttBrokerHost READ mqttBrokerHost WRITE setMqttBrokerHost NOTIFY mqttBrokerHostChanged)
-    Q_PROPERTY(int mqttBrokerPort READ mqttBrokerPort WRITE setMqttBrokerPort NOTIFY mqttBrokerPortChanged)
-    Q_PROPERTY(QString mqttUsername READ mqttUsername WRITE setMqttUsername NOTIFY mqttUsernameChanged)
-    Q_PROPERTY(QString mqttPassword READ mqttPassword WRITE setMqttPassword NOTIFY mqttPasswordChanged)
-    Q_PROPERTY(QString mqttBaseTopic READ mqttBaseTopic WRITE setMqttBaseTopic NOTIFY mqttBaseTopicChanged)
-    Q_PROPERTY(int mqttPublishInterval READ mqttPublishInterval WRITE setMqttPublishInterval NOTIFY mqttPublishIntervalChanged)
-    Q_PROPERTY(bool mqttRetainMessages READ mqttRetainMessages WRITE setMqttRetainMessages NOTIFY mqttRetainMessagesChanged)
-    Q_PROPERTY(bool mqttHomeAssistantDiscovery READ mqttHomeAssistantDiscovery WRITE setMqttHomeAssistantDiscovery NOTIFY mqttHomeAssistantDiscoveryChanged)
-    Q_PROPERTY(QString mqttClientId READ mqttClientId WRITE setMqttClientId NOTIFY mqttClientIdChanged)
+    Q_PROPERTY(bool mqttEnabled READ mqttEnabled WRITE setMqttEnabled NOTIFY mqttEnabledChanged FINAL)
+    Q_PROPERTY(QString mqttBrokerHost READ mqttBrokerHost WRITE setMqttBrokerHost NOTIFY mqttBrokerHostChanged FINAL)
+    Q_PROPERTY(int mqttBrokerPort READ mqttBrokerPort WRITE setMqttBrokerPort NOTIFY mqttBrokerPortChanged FINAL)
+    Q_PROPERTY(QString mqttUsername READ mqttUsername WRITE setMqttUsername NOTIFY mqttUsernameChanged FINAL)
+    Q_PROPERTY(QString mqttPassword READ mqttPassword WRITE setMqttPassword NOTIFY mqttPasswordChanged FINAL)
+    Q_PROPERTY(QString mqttBaseTopic READ mqttBaseTopic WRITE setMqttBaseTopic NOTIFY mqttBaseTopicChanged FINAL)
+    Q_PROPERTY(int mqttPublishInterval READ mqttPublishInterval WRITE setMqttPublishInterval NOTIFY mqttPublishIntervalChanged FINAL)
+    Q_PROPERTY(bool mqttRetainMessages READ mqttRetainMessages WRITE setMqttRetainMessages NOTIFY mqttRetainMessagesChanged FINAL)
+    Q_PROPERTY(bool mqttHomeAssistantDiscovery READ mqttHomeAssistantDiscovery WRITE setMqttHomeAssistantDiscovery NOTIFY mqttHomeAssistantDiscoveryChanged FINAL)
+    Q_PROPERTY(QString mqttClientId READ mqttClientId WRITE setMqttClientId NOTIFY mqttClientIdChanged FINAL)
 
 public:
     explicit SettingsMqtt(QObject* parent = nullptr);

--- a/src/core/settings_network.h
+++ b/src/core/settings_network.h
@@ -16,40 +16,40 @@ class SettingsNetwork : public QObject {
     Q_OBJECT
 
     // Saved searches & shot history sort
-    Q_PROPERTY(QStringList savedSearches READ savedSearches WRITE setSavedSearches NOTIFY savedSearchesChanged)
-    Q_PROPERTY(QString shotHistorySortField READ shotHistorySortField WRITE setShotHistorySortField NOTIFY shotHistorySortFieldChanged)
-    Q_PROPERTY(QString shotHistorySortDirection READ shotHistorySortDirection WRITE setShotHistorySortDirection NOTIFY shotHistorySortDirectionChanged)
+    Q_PROPERTY(QStringList savedSearches READ savedSearches WRITE setSavedSearches NOTIFY savedSearchesChanged FINAL)
+    Q_PROPERTY(QString shotHistorySortField READ shotHistorySortField WRITE setShotHistorySortField NOTIFY shotHistorySortFieldChanged FINAL)
+    Q_PROPERTY(QString shotHistorySortDirection READ shotHistorySortDirection WRITE setShotHistorySortDirection NOTIFY shotHistorySortDirectionChanged FINAL)
 
     // Recipes page sort (recipe-list-organization)
-    Q_PROPERTY(QString recipeSortField READ recipeSortField WRITE setRecipeSortField NOTIFY recipeSortFieldChanged)
-    Q_PROPERTY(QString recipeSortDirection READ recipeSortDirection WRITE setRecipeSortDirection NOTIFY recipeSortDirectionChanged)
+    Q_PROPERTY(QString recipeSortField READ recipeSortField WRITE setRecipeSortField NOTIFY recipeSortFieldChanged FINAL)
+    Q_PROPERTY(QString recipeSortDirection READ recipeSortDirection WRITE setRecipeSortDirection NOTIFY recipeSortDirectionChanged FINAL)
 
     // Shot server (HTTP API)
-    Q_PROPERTY(bool shotServerEnabled READ shotServerEnabled WRITE setShotServerEnabled NOTIFY shotServerEnabledChanged)
-    Q_PROPERTY(QString shotServerHostname READ shotServerHostname WRITE setShotServerHostname NOTIFY shotServerHostnameChanged)
-    Q_PROPERTY(int shotServerPort READ shotServerPort WRITE setShotServerPort NOTIFY shotServerPortChanged)
-    Q_PROPERTY(bool webSecurityEnabled READ webSecurityEnabled WRITE setWebSecurityEnabled NOTIFY webSecurityEnabledChanged)
+    Q_PROPERTY(bool shotServerEnabled READ shotServerEnabled WRITE setShotServerEnabled NOTIFY shotServerEnabledChanged FINAL)
+    Q_PROPERTY(QString shotServerHostname READ shotServerHostname WRITE setShotServerHostname NOTIFY shotServerHostnameChanged FINAL)
+    Q_PROPERTY(int shotServerPort READ shotServerPort WRITE setShotServerPort NOTIFY shotServerPortChanged FINAL)
+    Q_PROPERTY(bool webSecurityEnabled READ webSecurityEnabled WRITE setWebSecurityEnabled NOTIFY webSecurityEnabledChanged FINAL)
 
     // Auto-favorites
-    Q_PROPERTY(QString autoFavoritesGroupBy READ autoFavoritesGroupBy WRITE setAutoFavoritesGroupBy NOTIFY autoFavoritesGroupByChanged)
-    Q_PROPERTY(int autoFavoritesMaxItems READ autoFavoritesMaxItems WRITE setAutoFavoritesMaxItems NOTIFY autoFavoritesMaxItemsChanged)
-    Q_PROPERTY(bool autoFavoritesOpenBrewSettings READ autoFavoritesOpenBrewSettings WRITE setAutoFavoritesOpenBrewSettings NOTIFY autoFavoritesOpenBrewSettingsChanged)
-    Q_PROPERTY(bool autoFavoritesHideUnrated READ autoFavoritesHideUnrated WRITE setAutoFavoritesHideUnrated NOTIFY autoFavoritesHideUnratedChanged)
+    Q_PROPERTY(QString autoFavoritesGroupBy READ autoFavoritesGroupBy WRITE setAutoFavoritesGroupBy NOTIFY autoFavoritesGroupByChanged FINAL)
+    Q_PROPERTY(int autoFavoritesMaxItems READ autoFavoritesMaxItems WRITE setAutoFavoritesMaxItems NOTIFY autoFavoritesMaxItemsChanged FINAL)
+    Q_PROPERTY(bool autoFavoritesOpenBrewSettings READ autoFavoritesOpenBrewSettings WRITE setAutoFavoritesOpenBrewSettings NOTIFY autoFavoritesOpenBrewSettingsChanged FINAL)
+    Q_PROPERTY(bool autoFavoritesHideUnrated READ autoFavoritesHideUnrated WRITE setAutoFavoritesHideUnrated NOTIFY autoFavoritesHideUnratedChanged FINAL)
 
     // Shot export
-    Q_PROPERTY(bool exportShotsToFile READ exportShotsToFile WRITE setExportShotsToFile NOTIFY exportShotsToFileChanged)
+    Q_PROPERTY(bool exportShotsToFile READ exportShotsToFile WRITE setExportShotsToFile NOTIFY exportShotsToFileChanged FINAL)
 
     // Layout configuration
-    Q_PROPERTY(QString layoutConfiguration READ layoutConfiguration WRITE setLayoutConfiguration NOTIFY layoutConfigurationChanged)
+    Q_PROPERTY(QString layoutConfiguration READ layoutConfiguration WRITE setLayoutConfiguration NOTIFY layoutConfigurationChanged FINAL)
     // One-time recipes-first layout upgrade offer (recipes-idle-layout-upgrade)
-    Q_PROPERTY(bool recipesUpgradeOffered READ recipesUpgradeOffered WRITE setRecipesUpgradeOffered NOTIFY recipesUpgradeOfferedChanged)
+    Q_PROPERTY(bool recipesUpgradeOffered READ recipesUpgradeOffered WRITE setRecipesUpgradeOffered NOTIFY recipesUpgradeOfferedChanged FINAL)
 
     // Discuss Shot URLs
-    Q_PROPERTY(int discussShotApp READ discussShotApp WRITE setDiscussShotApp NOTIFY discussShotAppChanged)
-    Q_PROPERTY(QString discussShotCustomUrl READ discussShotCustomUrl WRITE setDiscussShotCustomUrl NOTIFY discussShotCustomUrlChanged)
-    Q_PROPERTY(QString claudeRcSessionUrl READ claudeRcSessionUrl WRITE setClaudeRcSessionUrl NOTIFY claudeRcSessionUrlChanged)
-    Q_PROPERTY(int discussAppNone READ discussAppNone CONSTANT)
-    Q_PROPERTY(int discussAppClaudeDesktop READ discussAppClaudeDesktop CONSTANT)
+    Q_PROPERTY(int discussShotApp READ discussShotApp WRITE setDiscussShotApp NOTIFY discussShotAppChanged FINAL)
+    Q_PROPERTY(QString discussShotCustomUrl READ discussShotCustomUrl WRITE setDiscussShotCustomUrl NOTIFY discussShotCustomUrlChanged FINAL)
+    Q_PROPERTY(QString claudeRcSessionUrl READ claudeRcSessionUrl WRITE setClaudeRcSessionUrl NOTIFY claudeRcSessionUrlChanged FINAL)
+    Q_PROPERTY(int discussAppNone READ discussAppNone CONSTANT FINAL)
+    Q_PROPERTY(int discussAppClaudeDesktop READ discussAppClaudeDesktop CONSTANT FINAL)
 
 public:
     explicit SettingsNetwork(QObject* parent = nullptr);

--- a/src/core/settings_theme.h
+++ b/src/core/settings_theme.h
@@ -17,24 +17,24 @@ class SettingsTheme : public QObject {
     Q_OBJECT
 
     // Skin (asset folder selection)
-    Q_PROPERTY(QString skin READ skin WRITE setSkin NOTIFY skinChanged)
-    Q_PROPERTY(QString skinPath READ skinPath NOTIFY skinChanged)
+    Q_PROPERTY(QString skin READ skin WRITE setSkin NOTIFY skinChanged FINAL)
+    Q_PROPERTY(QString skinPath READ skinPath NOTIFY skinChanged FINAL)
 
     // Theme palette
-    Q_PROPERTY(QVariantMap customThemeColors READ customThemeColors WRITE setCustomThemeColors NOTIFY customThemeColorsChanged)
-    Q_PROPERTY(QVariantList colorGroups READ colorGroups WRITE setColorGroups NOTIFY colorGroupsChanged)
-    Q_PROPERTY(QString activeThemeName READ activeThemeName WRITE setActiveThemeName NOTIFY activeThemeNameChanged)
-    Q_PROPERTY(QString darkThemeName READ darkThemeName WRITE setDarkThemeName NOTIFY darkThemeNameChanged)
-    Q_PROPERTY(QString lightThemeName READ lightThemeName WRITE setLightThemeName NOTIFY lightThemeNameChanged)
-    Q_PROPERTY(QStringList themeNames READ themeNames NOTIFY themeNamesChanged)
+    Q_PROPERTY(QVariantMap customThemeColors READ customThemeColors WRITE setCustomThemeColors NOTIFY customThemeColorsChanged FINAL)
+    Q_PROPERTY(QVariantList colorGroups READ colorGroups WRITE setColorGroups NOTIFY colorGroupsChanged FINAL)
+    Q_PROPERTY(QString activeThemeName READ activeThemeName WRITE setActiveThemeName NOTIFY activeThemeNameChanged FINAL)
+    Q_PROPERTY(QString darkThemeName READ darkThemeName WRITE setDarkThemeName NOTIFY darkThemeNameChanged FINAL)
+    Q_PROPERTY(QString lightThemeName READ lightThemeName WRITE setLightThemeName NOTIFY lightThemeNameChanged FINAL)
+    Q_PROPERTY(QStringList themeNames READ themeNames NOTIFY themeNamesChanged FINAL)
     // Translucent "glass" chrome — scrimmed cards, bars and dialogs. An OPTION rather
     // than a theme: glassiness is orthogonal to light/dark, so any theme can be glass.
     // It started life as a built-in "Glass" theme and that was the wrong shape — a theme
     // occupies one polarity slot, so it could only ever be half-applied, and it could not
     // be combined with the user's own colours.
-    Q_PROPERTY(bool glassChrome READ glassChrome WRITE setGlassChrome NOTIFY glassChromeChanged)
-    Q_PROPERTY(double screenBrightness READ screenBrightness WRITE setScreenBrightness NOTIFY screenBrightnessChanged)
-    Q_PROPERTY(QVariantMap customFontSizes READ customFontSizes WRITE setCustomFontSizes NOTIFY customFontSizesChanged)
+    Q_PROPERTY(bool glassChrome READ glassChrome WRITE setGlassChrome NOTIFY glassChromeChanged FINAL)
+    Q_PROPERTY(double screenBrightness READ screenBrightness WRITE setScreenBrightness NOTIFY screenBrightnessChanged FINAL)
+    Q_PROPERTY(QVariantMap customFontSizes READ customFontSizes WRITE setCustomFontSizes NOTIFY customFontSizesChanged FINAL)
     // Defaults merged with the user's overrides — the single value QML should render at.
     // A PROPERTY, not an invokable: a binding re-evaluates when a NOTIFY fires for a
     // property it READ during its last evaluation. A Q_INVOKABLE call registers no such
@@ -42,31 +42,31 @@ class SettingsTheme : public QObject {
     // when a slider moves. (An invokable CAN work if the same expression also reads a
     // notifying property — see Tr.qml, which reads translationVersion for exactly that
     // reason — but relying on that is a trap, so the value is exposed as a property.)
-    Q_PROPERTY(QVariantMap effectiveFontSizes READ effectiveFontSizes NOTIFY customFontSizesChanged)
+    Q_PROPERTY(QVariantMap effectiveFontSizes READ effectiveFontSizes NOTIFY customFontSizesChanged FINAL)
 
     // The bundled UI font family main.cpp actually registered, or empty if registration
     // failed. CONSTANT: main.cpp sets it before the QML engine is created and it never
     // changes, so no notify is needed. Exists so Theme.qml can state the family on every
     // font role explicitly instead of relying on application-font inheritance (#1537).
-    Q_PROPERTY(QString bundledFontFamily READ bundledFontFamily CONSTANT)
+    Q_PROPERTY(QString bundledFontFamily READ bundledFontFamily CONSTANT FINAL)
 
     // Symbol fallback family, chained after bundledFontFamily in Theme's font roles so
     // arrows and geometric shapes come from the bundle rather than a per-machine host
     // font. Empty when registration failed, which Theme must treat as "omit it" — a
     // stray empty string in a families list resolves to the application default and
     // would silently reinstate the platform fallback this exists to remove.
-    Q_PROPERTY(QString symbolFontFamily READ symbolFontFamily CONSTANT)
+    Q_PROPERTY(QString symbolFontFamily READ symbolFontFamily CONSTANT FINAL)
 
     // Theme mode (light/dark/system)
-    Q_PROPERTY(QString themeMode READ themeMode WRITE setThemeMode NOTIFY themeModeChanged)
-    Q_PROPERTY(bool isDarkMode READ isDarkMode NOTIFY isDarkModeChanged)
-    Q_PROPERTY(QString editingPalette READ editingPalette WRITE setEditingPalette NOTIFY editingPaletteChanged)
+    Q_PROPERTY(QString themeMode READ themeMode WRITE setThemeMode NOTIFY themeModeChanged FINAL)
+    Q_PROPERTY(bool isDarkMode READ isDarkMode NOTIFY isDarkModeChanged FINAL)
+    Q_PROPERTY(QString editingPalette READ editingPalette WRITE setEditingPalette NOTIFY editingPaletteChanged FINAL)
 
     // Custom background image, applied app-wide (see add-custom-background).
     // Absolute filesystem path; empty = today's flat Theme.backgroundColor. Same image in
     // both light and dark mode. Sourced from the screensaver media library (personal
     // uploads + locally-cached catalog images) — see ScreensaverVideoManager.
-    Q_PROPERTY(QString backgroundImagePath READ backgroundImagePath WRITE setBackgroundImagePath NOTIFY backgroundImagePathChanged)
+    Q_PROPERTY(QString backgroundImagePath READ backgroundImagePath WRITE setBackgroundImagePath NOTIFY backgroundImagePathChanged FINAL)
 
     // Built-in background colour — a curated flat colour for users who want a calmer
     // backdrop than a screensaver photo. The pattern is a separate axis; see below. Holds a catalogue id
@@ -78,7 +78,7 @@ class SettingsTheme : public QObject {
     // while one is active. It is not carried as a qrc: path in backgroundImagePath
     // because ScreensaverVideoManager compares that setting against real file paths and
     // clears it when the backing file is deleted; a preset has no backing file.
-    Q_PROPERTY(QString backgroundPreset READ backgroundPreset WRITE setBackgroundPreset NOTIFY backgroundPresetChanged)
+    Q_PROPERTY(QString backgroundPreset READ backgroundPreset WRITE setBackgroundPreset NOTIFY backgroundPresetChanged FINAL)
 
     // Which KIND of background is active: "none", "colour", "image" or "shot".
     //
@@ -93,12 +93,12 @@ class SettingsTheme : public QObject {
     // the clearing becomes quadratic and the failure is two sources live at once, where
     // whichever renderer tests first wins. Existing installs are migrated by derivation on
     // read (see backgroundSource()), not by rewriting stored values.
-    Q_PROPERTY(QString backgroundSource READ backgroundSource NOTIFY backgroundSourceChanged)
+    Q_PROPERTY(QString backgroundSource READ backgroundSource NOTIFY backgroundSourceChanged FINAL)
 
     // For the "shot" source: whether the advanced curve set is drawn. A property of the
     // chosen ENTRY, deliberately not a mirror of shotReview/advancedMode — that toggle is
     // used to inspect one shot and must not repaint the whole app.
-    Q_PROPERTY(bool backgroundShotAdvanced READ backgroundShotAdvanced NOTIFY backgroundSourceChanged)
+    Q_PROPERTY(bool backgroundShotAdvanced READ backgroundShotAdvanced NOTIFY backgroundSourceChanged FINAL)
 
     // Optional pattern drawn over the background colour. A SECOND axis rather than a
     // property of each colour: baking the two together produced a catalogue where half the
@@ -107,34 +107,34 @@ class SettingsTheme : public QObject {
     // Not drawn over an image or a shot chart; the chooser disables the row there rather
     // than accepting a selection that does nothing, and the stored value is retained so
     // returning to a colour restores it.
-    Q_PROPERTY(QString backgroundPattern READ backgroundPattern WRITE setBackgroundPattern NOTIFY backgroundPatternChanged)
+    Q_PROPERTY(QString backgroundPattern READ backgroundPattern WRITE setBackgroundPattern NOTIFY backgroundPatternChanged FINAL)
 
     // The two catalogues, for the chooser.
-    Q_PROPERTY(QVariantList backgroundPresets READ backgroundPresets CONSTANT)
-    Q_PROPERTY(QVariantList backgroundPatterns READ backgroundPatterns CONSTANT)
+    Q_PROPERTY(QVariantList backgroundPresets READ backgroundPresets CONSTANT FINAL)
+    Q_PROPERTY(QVariantList backgroundPatterns READ backgroundPatterns CONSTANT FINAL)
 
     // The active colour and pattern as maps (empty when none). Properties rather than
     // invokables so a QML binding re-runs when the selection changes — an invokable would
     // register no dependency.
-    Q_PROPERTY(QVariantMap activeBackgroundPreset READ activeBackgroundPreset NOTIFY backgroundPresetChanged)
-    Q_PROPERTY(QVariantMap activeBackgroundPattern READ activeBackgroundPattern NOTIFY backgroundPatternChanged)
+    Q_PROPERTY(QVariantMap activeBackgroundPreset READ activeBackgroundPreset NOTIFY backgroundPresetChanged FINAL)
+    Q_PROPERTY(QVariantMap activeBackgroundPattern READ activeBackgroundPattern NOTIFY backgroundPatternChanged FINAL)
 
     // Everything the app paints on the active background colour — text, secondary text,
     // card/bar surface, action tile, border — computed in C++ by BackgroundPresets::derive
     // so the contrast tests measure the shipped arithmetic rather than a copy of it.
     // Empty when no colour is selected.
-    Q_PROPERTY(QVariantMap derivedBackgroundColors READ derivedBackgroundColors NOTIFY backgroundPresetChanged)
+    Q_PROPERTY(QVariantMap derivedBackgroundColors READ derivedBackgroundColors NOTIFY backgroundPresetChanged FINAL)
 
     // Screen shaders
-    Q_PROPERTY(QString activeShader READ activeShader WRITE setActiveShader NOTIFY activeShaderChanged)
-    Q_PROPERTY(QVariantMap shaderParams READ shaderParams NOTIFY shaderParamsChanged)
+    Q_PROPERTY(QString activeShader READ activeShader WRITE setActiveShader NOTIFY activeShaderChanged FINAL)
+    Q_PROPERTY(QVariantMap shaderParams READ shaderParams NOTIFY shaderParamsChanged FINAL)
 
     // Theme flash (in-memory only, for identifying colors on device)
-    Q_PROPERTY(QString flashColorName READ flashColorName NOTIFY flashColorNameChanged)
-    Q_PROPERTY(int flashPhase READ flashPhase NOTIFY flashPhaseChanged)
+    Q_PROPERTY(QString flashColorName READ flashColorName NOTIFY flashColorNameChanged FINAL)
+    Q_PROPERTY(int flashPhase READ flashPhase NOTIFY flashPhaseChanged FINAL)
 
     // Colors detected on the current page (set from QML tree walker)
-    Q_PROPERTY(QStringList currentPageColors READ currentPageColors WRITE setCurrentPageColors NOTIFY currentPageColorsChanged)
+    Q_PROPERTY(QStringList currentPageColors READ currentPageColors WRITE setCurrentPageColors NOTIFY currentPageColorsChanged FINAL)
 
 public:
     explicit SettingsTheme(QObject* parent = nullptr);

--- a/src/core/settings_visualizer.h
+++ b/src/core/settings_visualizer.h
@@ -8,14 +8,14 @@
 class SettingsVisualizer : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(QString visualizerUsername READ visualizerUsername WRITE setVisualizerUsername NOTIFY visualizerUsernameChanged)
-    Q_PROPERTY(QString visualizerPassword READ visualizerPassword WRITE setVisualizerPassword NOTIFY visualizerPasswordChanged)
-    Q_PROPERTY(bool visualizerAutoUpload READ visualizerAutoUpload WRITE setVisualizerAutoUpload NOTIFY visualizerAutoUploadChanged)
-    Q_PROPERTY(bool visualizerAutoUpdate READ visualizerAutoUpdate WRITE setVisualizerAutoUpdate NOTIFY visualizerAutoUpdateChanged)
-    Q_PROPERTY(double visualizerMinDuration READ visualizerMinDuration WRITE setVisualizerMinDuration NOTIFY visualizerMinDurationChanged)
-    Q_PROPERTY(bool visualizerExtendedMetadata READ visualizerExtendedMetadata WRITE setVisualizerExtendedMetadata NOTIFY visualizerExtendedMetadataChanged)
-    Q_PROPERTY(bool visualizerShowAfterShot READ visualizerShowAfterShot WRITE setVisualizerShowAfterShot NOTIFY visualizerShowAfterShotChanged)
-    Q_PROPERTY(bool visualizerClearNotesOnStart READ visualizerClearNotesOnStart WRITE setVisualizerClearNotesOnStart NOTIFY visualizerClearNotesOnStartChanged)
+    Q_PROPERTY(QString visualizerUsername READ visualizerUsername WRITE setVisualizerUsername NOTIFY visualizerUsernameChanged FINAL)
+    Q_PROPERTY(QString visualizerPassword READ visualizerPassword WRITE setVisualizerPassword NOTIFY visualizerPasswordChanged FINAL)
+    Q_PROPERTY(bool visualizerAutoUpload READ visualizerAutoUpload WRITE setVisualizerAutoUpload NOTIFY visualizerAutoUploadChanged FINAL)
+    Q_PROPERTY(bool visualizerAutoUpdate READ visualizerAutoUpdate WRITE setVisualizerAutoUpdate NOTIFY visualizerAutoUpdateChanged FINAL)
+    Q_PROPERTY(double visualizerMinDuration READ visualizerMinDuration WRITE setVisualizerMinDuration NOTIFY visualizerMinDurationChanged FINAL)
+    Q_PROPERTY(bool visualizerExtendedMetadata READ visualizerExtendedMetadata WRITE setVisualizerExtendedMetadata NOTIFY visualizerExtendedMetadataChanged FINAL)
+    Q_PROPERTY(bool visualizerShowAfterShot READ visualizerShowAfterShot WRITE setVisualizerShowAfterShot NOTIFY visualizerShowAfterShotChanged FINAL)
+    Q_PROPERTY(bool visualizerClearNotesOnStart READ visualizerClearNotesOnStart WRITE setVisualizerClearNotesOnStart NOTIFY visualizerClearNotesOnStartChanged FINAL)
 
 public:
     explicit SettingsVisualizer(QObject* parent = nullptr);

--- a/tests/tst_textescaping.cpp
+++ b/tests/tst_textescaping.cpp
@@ -105,9 +105,12 @@ void TestTextEscaping::initTestCase()
                         // parameter text would silently turn `sep = "a: b"` into `sep = "a"`,
                         // or `re = /a:b/` into `/a/` — both still parse, so the test would go
                         // green while exercising a function Theme.qml does not have. None of
-                        // the extracted functions has a default value today; if one gains one,
-                        // fail loudly here instead. The unstripped text is returned so the
-                        // engine reports a SyntaxError, which QVERIFY2 below surfaces.
+                        // the extracted functions has a default value today. Note the guard is
+                        // narrower than "no defaults": a plain `pixelSize: var = 16` contains
+                        // none of these characters, so it strips cleanly and is fine. What the
+                        // guard catches is a default whose VALUE could contain a colon the
+                        // regex would eat. When it trips, the unstripped text is returned so
+                        // the engine reports a SyntaxError, which QVERIFY2 below surfaces.
                         if (!params.contains('"') && !params.contains('\'')
                             && !params.contains('/') && !params.contains('(')
                             && !params.contains('{')) {

--- a/tests/tst_textescaping.cpp
+++ b/tests/tst_textescaping.cpp
@@ -77,22 +77,46 @@ void TestTextEscaping::initTestCase()
                     // Strip QML type annotations from the SIGNATURE only, because what comes
                     // back is evaluated by a plain QJSEngine below and `function f(s: string)`
                     // is a JavaScript SyntaxError ("Type annotations are not permitted in
-                    // function parameters in JavaScript functions"). The annotations exist so
-                    // qmlcachegen will compile these ahead of time — Theme.qml is read on every
-                    // page construction and was the worst-compiled file in the app at 11.5%.
-                    // Without this the test dictates that the hottest QML in the project stay
-                    // un-annotated, which is the tail wagging the dog.
+                    // function parameters in JavaScript functions", qqmljs.g:578). The
+                    // annotations exist so qmlcachegen will compile these ahead of time;
+                    // without this the test would dictate that Theme.qml — read on every page
+                    // construction — stay un-annotated, which is the tail wagging the dog.
                     //
-                    // Signature only: the body legitimately contains ':' in ternaries and object
-                    // literals. The cut is bounded to the first ')' followed by an optional
-                    // return annotation and the opening brace.
+                    // Signature only: the body legitimately contains ':' in ternaries
+                    // (`cp > 0xFFFF ? 2 : 1`), in string literals ("qrc:/emoji/",
+                    // style="vertical-align: middle") and in comments. The cut is bounded to
+                    // the first ')' followed by an optional return annotation and the brace.
+                    //
+                    // WHAT THIS TEST NO LONGER COVERS: stripping the annotations means the
+                    // QJSEngine below runs the UNTYPED function, while the app runs the typed
+                    // one through coerceAndCall (qv4function.cpp:68-73). Argument coercion is
+                    // therefore untested here — a green run says nothing about it. That gap is
+                    // real: a `string` annotation turns undefined into the literal "undefined"
+                    // (qv4jscall_p.h:337 -> qv4runtime.cpp:618), which is why the guarded
+                    // parameters in Theme.qml are `var`. Covering it needs a QML-engine test
+                    // that links the Decenza module, which no test binary does today.
                     const qsizetype open = fn.indexOf('(');
-                    const qsizetype close = fn.indexOf(')', open);
-                    const qsizetype brace = fn.indexOf('{', close);
+                    const qsizetype close = open < 0 ? -1 : fn.indexOf(')', open);
+                    const qsizetype brace = close < 0 ? -1 : fn.indexOf('{', close);
                     if (open > 0 && close > open && brace > close) {
                         QString params = fn.mid(open + 1, close - open - 1);
-                        params.remove(QRegularExpression(QStringLiteral("\\s*:\\s*[A-Za-z_][\\w.<>]*")));
-                        fn = fn.left(open + 1) + params + QStringLiteral(") ") + fn.mid(brace);
+                        // Refuse to strip anything that could make the regex cut inside a
+                        // literal rather than an annotation. `\s*:\s*ident` applied to raw
+                        // parameter text would silently turn `sep = "a: b"` into `sep = "a"`,
+                        // or `re = /a:b/` into `/a/` — both still parse, so the test would go
+                        // green while exercising a function Theme.qml does not have. None of
+                        // the extracted functions has a default value today; if one gains one,
+                        // fail loudly here instead. The unstripped text is returned so the
+                        // engine reports a SyntaxError, which QVERIFY2 below surfaces.
+                        if (!params.contains('"') && !params.contains('\'')
+                            && !params.contains('/') && !params.contains('(')
+                            && !params.contains('{')) {
+                            const qsizetype before = params.count(',');
+                            params.remove(QRegularExpression(
+                                QStringLiteral("\\s*:\\s*[A-Za-z_][\\w.<>]*")));
+                            if (params.count(',') == before)
+                                fn = fn.left(open + 1) + params + QStringLiteral(") ") + fn.mid(brace);
+                        }
                     }
                     return fn;
                 }

--- a/tests/tst_textescaping.cpp
+++ b/tests/tst_textescaping.cpp
@@ -72,7 +72,30 @@ void TestTextEscaping::initTestCase()
         for (; i < src.size(); ++i) {
             if (src[i] == '{') ++depth;
             else if (src[i] == '}') {
-                if (--depth == 0) return src.mid(start, i - start + 1);
+                if (--depth == 0) {
+                    QString fn = src.mid(start, i - start + 1);
+                    // Strip QML type annotations from the SIGNATURE only, because what comes
+                    // back is evaluated by a plain QJSEngine below and `function f(s: string)`
+                    // is a JavaScript SyntaxError ("Type annotations are not permitted in
+                    // function parameters in JavaScript functions"). The annotations exist so
+                    // qmlcachegen will compile these ahead of time — Theme.qml is read on every
+                    // page construction and was the worst-compiled file in the app at 11.5%.
+                    // Without this the test dictates that the hottest QML in the project stay
+                    // un-annotated, which is the tail wagging the dog.
+                    //
+                    // Signature only: the body legitimately contains ':' in ternaries and object
+                    // literals. The cut is bounded to the first ')' followed by an optional
+                    // return annotation and the opening brace.
+                    const qsizetype open = fn.indexOf('(');
+                    const qsizetype close = fn.indexOf(')', open);
+                    const qsizetype brace = fn.indexOf('{', close);
+                    if (open > 0 && close > open && brace > close) {
+                        QString params = fn.mid(open + 1, close - open - 1);
+                        params.remove(QRegularExpression(QStringLiteral("\\s*:\\s*[A-Za-z_][\\w.<>]*")));
+                        fn = fn.left(open + 1) + params + QStringLiteral(") ") + fn.mid(brace);
+                    }
+                    return fn;
+                }
             }
         }
         return QString();


### PR DESCRIPTION
## What

qmlcachegen was refusing to compile chained lookups through `Settings` and `MainController`. A non-final property can be shadowed by a subclass, so `Settings.theme.x` degraded the base to `var` and bailed with *"Cannot use shadowable base type for further lookups"*. Per [`qqmljsshadowcheck.cpp:196-198`](https://code.qt.io/cgit/qt/qtdeclarative.git/tree/src/qmlcompiler/qqmljsshadowcheck.cpp), a final property is the **only** escape. Nothing subclasses either class and no QML redeclares these names, so `FINAL` states a fact that was already true.

Then annotated the untyped functions in the two hottest QML files — an unannotated function is not compiled, and neither is any *call* to it, so a handful of definitions poison many call sites.

| | Before | After |
|---|---|---|
| Global AOT | 44.7 % | **60.6 %** |
| `Theme.qml` | 11.5 % | **34.5 %** |
| `IdlePage.qml` | 43.4 % | **51.9 %** |
| shadowable-base skips | 574 | **72** |

> **Correction.** This table first read `46.4 %`. That was measured against a build which had recompiled only the two edited QML files, leaving 213 units' `.aotstats` describing the previous state. The real figure is **60.6 %** — annotating `Theme.qml` unblocked ~4,200 call sites tree-wide (`call to untyped JavaScript function` went **4,681 -> 499**), and that only became visible once a `Q_OBJECT` header edit forced all 215 units to regenerate. `BUILD_PERFORMANCE.md` now carries the check that catches this.

`Theme.qml` is the one that matters — it is read on every page construction and was the worst-compiled file in the app.

## Three findings worth more than the percentages

**1. Removing a skip reason does not mean the binding compiles.**

| | skips removed | AOT gained |
|---|---|---|
| Pass 1 (sub-object accessors) | 429 | **394** (92 %) |
| Pass 2 (remaining 218 settings props) | 73 | **15** (21 %) |

58 of pass 2 bindings simply failed for a *different* reason instead. Pass 2 is kept anyway — `FINAL` is correct on all of them and stops the class returning — but anyone extending this work will over-predict without knowing that.

**2. Type annotations coerce, and that is a live hazard.** `maxLen: int` would have turned `maxLen ?? 2000` into `0 ?? 2000` = `0`, truncating **every accessible string to an ellipsis**. The four optional parameters take `var`. Being conservative with `var` elsewhere costs 67 remaining "ambiguous conversion" skips in `Theme.qml`; tightening them is the same silent-coercion risk and **nothing tests QML**.

**3. One annotation caused a real runtime bug, and I do not understand why.** Annotating the seven `TemperatureDisplay` wrappers made qmlcachegen compile `tempUnitSuffix()` into something returning `undefined`, which surfaced as `Unable to assign [undefined] to QString` at `RecipeEditorPage.qml:435` and `:495` in the running app. The C++ signatures are fine (`unitSuffix(bool) -> QString`). I reverted the smallest set that certainly contains it rather than guess at a mechanism. **If someone re-annotates those seven later, it will come back.**

## Test change

`tst_textescaping` extracts these function bodies out of `Theme.qml` and evaluates them in a plain `QJSEngine`, where `function f(s: string)` is a JavaScript `SyntaxError`. Fixed in the test — strip annotations from the signature only, since bodies legitimately contain `:` in ternaries. Otherwise a test dictates that the hottest QML in the app stay un-annotated.

## Verification

- **108 tests pass**, 0 failed, 0 with warnings
- qmllint gate **222/222**
- App launched, idle page reached clean, `RecipeEditorPage` errors confirmed gone with the same code path exercised

## What a reviewer should push back on

- **Blast radius.** 254 property declarations across 14 headers for a 1.7-point global AOT gain. Pass 2 alone was 218 declarations for 15 bindings.
- **Desktop only.** Nothing here is verified on Android or iOS. Android has the V4 JIT (`configure.cmake:96-100`); **iOS does not** — Apple forbids it — so AOT is the only compiled path there and this is worth strictly more on iOS than the macOS numbers suggest.
- **The startup harness cannot measure this.** Three launches of identical code gave **3.4 s, 6.4 s and 13.4 s** for the AOT-sensitive window. The variance tracks window-focus churn and swamps any AOT effect by an order of magnitude. `BUILD_PERFORMANCE.md` does not warn about this; relevant to anyone about to run that A/B on a tablet and trust one number.

## Not done, deliberately

`IdlePage.qml` still has 125 `Cannot retrieve a non-object type by ID: idlePage` skips. It is systemic — 81 files, weak correlation with `pragma ComponentBehavior: Bound` (51 % vs 24 %) — and I could not explain it, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
