### PR TITLE
docs(openspec): verify the Qt 6.12 charts polish items against the 6.12 branch

### DIFF
--- a/openspec/changes/charts-qt-6-12-polish/proposal.md
+++ b/openspec/changes/charts-qt-6-12-polish/proposal.md
@@ -10,9 +10,40 @@ This change collects every visual / API / performance item that was deferred dur
 
 Decenza will upgrade to Qt 6.12 in a separate `upgrade-qt-6-12` change after 6.12 GA (2026-09-22). This change runs after that upgrade lands.
 
+## Verification against Qt 6.12 (done 2026-07-29, Beta 2 tree)
+
+Every item below was checked against the actual `qt/qtgraphs` **`6.12` branch** (feature freeze
+was 2026-06-02, so this is what GA ships barring bug fixes) and the 6.12 doc snapshots. Three of
+the six assumptions in the original proposal were wrong; the sections carry the corrected API
+names and file:line citations. Fetch commands used (GitHub mirror of `code.qt.io`):
+
+```
+gh api "repos/qt/qtgraphs/contents/<path>?ref=6.12" -H "Accept: application/vnd.github.raw"
+gh api "search/code?q=<symbol>+repo:qt/qtgraphs"
+```
+
+Summary of the correction:
+
+| # | Original assumption | Verified reality on the 6.12 branch |
+|---|---|---|
+| 1 | Maybe a new `tickLength` / `labelsMargin` | **No.** Main-tick length is not parameterized at all — see §1 |
+| 2 | Maybe a new `labelsAnchor` | **No.** Accept gap — see §2 |
+| 3 | `useCanvasPainter: true`, one-line flip | Property exists but is **compile-gated behind an off-by-default Qt feature** — see §3 |
+| 4 | New `XYSeries.data` | Property is named **`values`**, plus three siblings the proposal missed — see §4 |
+| 5 | `ValueAxis.labelPostFormat` | **Confirmed**, `REVISION(6, 12)` — see §5 |
+| 6 | Multi-axis margin fix | Unchanged; 6.12 also adds `GraphsView.dynamicLabelMargins` — see §6 |
+
+**Corrected 6.12 schedule** (wiki.qt.io/Qt_6.12_Release): feature freeze 2026-06-02, Beta 1
+2026-06-11, Beta 2 2026-07-14 (shipped), Beta 3 2026-08-18, RC 2026-09-08, GA 2026-09-22.
+
+**Not relevant to Decenza in 6.12's Graphs work**: `QLogValueAxis` / logarithmic axis (with
+`AxisTicker.isLogarithmic` + `base`, `REVISION(6, 12)`) and the 3D panning improvements. No
+Decenza graph uses a log axis. Still **no built-in legend, no dashed stroke style, no pixel↔data
+mapping API** — all four Stage 0 bridges stay ours.
+
 ## Deferred items
 
-### 1. X / Y axis tick-mark length
+### 1. X / Y axis tick-mark length — CLOSED as "not addressable in 6.12"
 
 **Symptom**: Qt Graphs draws ~6–10 px vertical strokes between the X axis spine and the tick labels (and equivalent horizontal strokes off the Y axis). Qt Charts drew them at ~2–3 px or omitted them entirely. The Decenza eye-test calls them "still too long" after every Qt 6.11 lever was tried.
 
@@ -23,48 +54,156 @@ Decenza will upgrade to Qt 6.12 in a separate `upgrade-qt-6-12` change after 6.1
 
 **Qt 6.11 limitation**: `GraphsTheme.axisX` (type `GraphsLine`) exposes only `mainColor`, `subColor`, `mainWidth`, `subWidth`, `labelTextColor`. No `tickLength`, `tickVisible`, or `labelsMargin` property exists. The remaining strokes may also be vertical gridlines spilling past the plot-area clip, which Qt 6.11 also gives no way to suppress.
 
-**6.12 check**: re-read the `GraphsTheme` and `GraphsLine` doc pages. Search the `qt/qtgraphs.git` `dev`-branch log for `tickLength`, `labelsMargin`, `tickVisible`, and `clipToPlotArea`. If a new property exists, set it in `DecenzaGraphsTheme.qml`; if not, file an upstream Qt suggestion citing this list of attempts and note the workaround (custom overlay) here.
+**6.12 verdict: no API, and now we know why.** `GraphsTheme` / `GraphsLine` on the 6.12 branch carry
+the same five members — nothing added. The tick geometry is in a shader with no length uniform for
+main ticks:
 
-### 2. Leftmost X tick label alignment
+- `src/graphs2d/data/tickershader.frag` (6.12) declares uniforms `subTickLength`, `tickLineWidth`,
+  `subTickLineWidth`, `spacing`, `smoothing`, `subTickScale` — **there is no `tickLength`**.
+- In `main()`, sub-ticks are length-gated (`if (flipped && fragCoord.y < iResolution.y *
+  subTickLength) …`) but the major lines are drawn unconditionally: `lines += createBars(fragCoord.x,
+  spacing, tickLineWidth);`. **Main ticks therefore span the full extent of the ticker item.**
+- That extent is the axis area itself: `axisrenderer.cpp` does `ax.ticker->setWidth(rect.width());
+  ax.ticker->setHeight(rect.height());` (≈:1160/:1225) from the X/Y axis rect. So main-tick length
+  is a function of the axis label band, not of anything settable.
+- `subTickLength` *is* a property — but of the private `AxisTicker` QQuickItem
+  (`src/graphs2d/axis/axisticker_p.h:36`), not reachable from QML, and `axisrenderer.cpp` overwrites
+  it internally (`setSubTickLength(0.5)` ≈:582, `(0.2)` ≈:615).
+- Also note ticker and axis spine share one colour (`theme()->axisY().mainColor()` feeds
+  `ax.ticker->setTickColor()` and the axis line), so there is no "hide the ticks, keep the spine"
+  trick either.
+
+**Action**: close the item as not addressable, and file the upstream suggestion — the concrete ask
+is a `tickLength` uniform + `GraphsLine` property mirroring the existing `subTickLength`, citing
+`tickershader.frag` `main()` where the major-line branch has no gate. Keep the four levers already
+in `DecenzaGraphsTheme.qml`; they are the best available.
+
+### 2. Leftmost X tick label alignment — CLOSED as "accept gap"
 
 **Symptom**: The "0" label on the X axis sits noticeably right of where the Y axis spine is. Qt Charts kept the leftmost label flush with the axis edge; Qt Graphs centres each label on its tick and shifts the leftmost label inward to keep it inside plot bounds.
 
-**6.12 check**: look for any new `labelsAnchor`, `labelsAlignment`, or `firstLabelAnchor` property on `ValueAxis` or `GraphsTheme`. If absent, leave the alignment as-is — it's cosmetic and a custom overlay is more code than the polish is worth.
+**6.12 verdict: no such property.** `ValueAxis` on 6.12 is `labelDecimals`, `labelFormat`,
+`labelPostFormat` (new), `min`, `max`, `pan`, `subTickCount`, `tickAnchor`, `tickInterval`,
+`visualMin`, `visualMax`, `zoom`. No `labelsAnchor` / `labelsAlignment` / `firstLabelAnchor` on the
+axis or on `GraphsTheme`. Close as accept-gap — but re-look once after §6 flips
+`dynamicLabelMargins`, since that reflows the axis label band and may move the leftmost label on its
+own.
 
-### 3. Switch each migrated `GraphsView` to the `QCanvasPainter` backend
+### 3. Switch each migrated `GraphsView` to the `QCanvasPainter` backend — BLOCKED ON A BUILD FEATURE
 
 Per Pre-Stage 0 task §11 in `../archive/2026-05-15-migrate-charting-to-qt-graphs/tasks.md`. Qt 6.12 lands a second rendering backend ([QTBUG-140734](https://qt-project.atlassian.net/browse/QTBUG-140734)) selected via `useCanvasPainter: true`. Off by default in 6.12.
 
-**Files to flip**:
+**The property is real but the one-line flip is not sufficient.** Verified on the 6.12 branch:
+
+- `GraphsView` declares `Q_PROPERTY(bool useCanvasPainter … REVISION(6, 12))`
+  (`src/graphs2d/qgraphsview_p.h:86`). It is absent from the 6.12 QML doc page, so docs alone say
+  "doesn't exist" — the source is the authority here.
+- **Both the getter and the setter are compiled out unless `USE_PAINTER_BACKEND` is defined.**
+  `qgraphsview.cpp:1900-1925`: the setter body is `#ifdef USE_PAINTER_BACKEND … #else
+  Q_UNUSED(newUseCanvasPainter);`. So on a Qt without the backend, `useCanvasPainter: true` is a
+  **silent no-op** — no warning, no visual change, and no FPS change. A "we flipped it and measured
+  nothing" result is indistinguishable from "the flag did nothing".
+- `USE_PAINTER_BACKEND` comes from the CMake feature `graphs-2d-high-performance-backend`
+  (`src/graphs2d/CMakeLists.txt:119-124`), and that feature is **`AUTODETECT OFF`** with
+  `CONDITION TARGET Qt6::CanvasPainter` (`src/configure.cmake:49-54`). Off unless explicitly
+  configured on. `graphs-2d-high-quality-backend` (Quick Shapes, `USE_SHAPE_BACKEND`) has no
+  AUTODETECT clause and is the on-by-default path.
+- Per-view default depends on which backends got compiled (`qgraphsview_p.h:360-366`):
+  `USE_SHAPE_BACKEND` defined → default `false`; only `USE_PAINTER_BACKEND` → default `true`;
+  neither → `false`.
+
+**So the first task here is a build question, not a QML question**: does the Qt 6.12 binary from the
+online installer ship `graphs-2d-high-performance-backend` ON? If yes, item 3 is the one-line flip as
+written. If no, the options are (a) drop item 3 and stay on Quick Shapes, or (b) build `qtgraphs`
+from source with `-DFEATURE_graphs_2d_high_performance_backend=ON`, which means shipping a
+non-stock Qt module on Android/iOS/desktop — a much larger decision than a polish PR, and the
+`upgrade-qt-6-12` change is where it belongs.
+
+**Files to flip (if the feature turns out to be available)**:
+All six migrated graphs are done (no `QtCharts` import remains anywhere in `qml/`), so the flip list
+is final:
+
 - `qml/pages/FlowCalibrationPage.qml`
-- `qml/components/SteamGraph.qml` (after Stage 2 migration)
-- `qml/components/ShotGraph.qml` (after Stage 3a)
-- `qml/components/HistoryShotGraph.qml` (after Stage 3b)
-- `qml/components/ComparisonGraph.qml` (after Stage 3c)
-- `qml/components/ProfileGraph.qml` (after Stage 3d)
+- `qml/components/SteamGraph.qml`
+- `qml/components/ShotGraph.qml`
+- `qml/components/HistoryShotGraph.qml`
+- `qml/components/ComparisonGraph.qml`
+- `qml/components/ProfileGraph.qml`
 
 One line per file. Re-measure FPS on the Decent tablet against the Stage 0 baseline (`docs/CLAUDE_MD/PERFORMANCE_BASELINE.md`).
 
-### 4. Adopt the declarative `XYSeries.data` property where the C++ round-trip is unnecessary
+### 4. Adopt the declarative `XYSeries.values` property where the per-point append loop is wasteful
 
-Qt 6.12 adds a declarative `data` property on `XYSeries` and subclasses ([QTBUG-134005](https://qt-project.atlassian.net/browse/QTBUG-134005), [QTBUG-141139](https://qt-project.atlassian.net/browse/QTBUG-141139)). Live ~5 Hz extraction series keep using the C++ `QXYSeries::replace()` pattern (still faster). But static / computed series — goal curves, profile-editor previews — can be populated declaratively:
+Qt 6.12 adds the declarative point API on `XYSeries` ([QTBUG-134005](https://qt-project.atlassian.net/browse/QTBUG-134005), [QTBUG-141139](https://qt-project.atlassian.net/browse/QTBUG-141139)). **The property is `values`, not `data`** — verified `Q_PROPERTY(QVariantList values … REVISION(6, 12))` at `src/graphs2d/xychart/qxyseries.h:27`. Three siblings landed with it, all `REVISION(6, 12)`, and the original proposal missed all three:
 
-- `qml/components/ProfileGraph.qml` — pure preview, no live data
-- `qml/components/SteamGraph.qml` — goal-temperature curve only
-- Any `DashedLineSeries` bridge instance whose `points` is data-bound
+- `valueMapping` (enum) — whether bare numbers in the list are X or Y components
+- `valueMin` (qreal) and `stepSize` (qreal) — the implied other axis for a numbers-only list
 
-This is a code-clarity win, not a perf change. Optional.
+`setValues()` converts once and calls `replace()` internally (`qxyseries.cpp:729-743`), so it is
+**the same single-`replace()` cost as the C++ path**, not a per-point round-trip. An empty list
+clears the series.
 
-### 5. `ValueAxis.labelPostFormat`
+Live ~5 Hz extraction series keep the C++ `QXYSeries::replace()` pattern. The real win is the
+**static/one-shot series that currently append point by point** — each `append()` is a separate
+signal + geometry dirty:
 
-Qt 6.12 adds a `labelPostFormat` property (e.g. `"%.1f bar"`) on `ValueAxis` / `LogValueAxis`. Replaces the bespoke `labelFormat` + unit-suffix plumbing scattered across the migrated graphs. Verify the property exists on 6.12 GA, then adopt in:
+- `qml/components/HistoryShotGraph.qml:143-158` — six series (`pressureSeries`, `flowSeries`,
+  `weightFlowRateSeries`, `resistanceSeries`, `conductanceSeries`, `darcyResistanceSeries`) filled
+  in one `for` loop of `append(x, y)` per point on shot load. Best candidate: one `values`
+  assignment per series.
+- `qml/pages/FlowCalibrationPage.qml:264-272` — `flowSeries.append()` / `weightFlowSeries.append()`
+  in a loop.
+- `qml/components/ProfileGraph.qml:342-490` — `updateCurves()` appends to `pressureSeries0` /
+  `flowSeries0` across every frame-shape branch; a pure preview, no live data. Largest rewrite of
+  the three (build the arrays, assign once); do it last.
+- **`valueMin` + `stepSize` candidate**: any of the above whose X samples are evenly spaced can pass
+  Y numbers only and let the axis imply X. Check the actual sample spacing before assuming it.
 
-- `qml/pages/FlowCalibrationPage.qml` (currently `titleText: "mL/s · g/s"` on the Y axis — could move the unit into the labels)
-- `qml/components/SteamGraph.qml`, `ShotGraph.qml`, etc.
+**Out of scope**: `qml/components/graphs/DashedLineSeries.qml` is a `Shape`/`ShapePath` overlay, not
+an `XYSeries` — its `points` property is ours and `values` does not apply. The original proposal
+listed it in error.
 
-### 6. Multi-axis margin fix
+Clarity plus fewer signal emissions on load. Optional but cheap.
+
+### 5. `ValueAxis.labelPostFormat` — CONFIRMED, ready to adopt
+
+Verified on 6.12: `labelPostFormat` (string, since 6.12) exists on `ValueAxis`. Replaces the
+`labelFormat` + separate unit-in-the-title plumbing. Current sites, all `labelFormat` + `titleText`
+pairs where the unit could move into the labels:
+
+| File | Lines |
+|---|---|
+| `qml/pages/FlowCalibrationPage.qml` | 50-51 (`"%.0f"` + `titleText: "s"`), 62-63 (`"%.1f"` + `"mL/s · g/s"`) |
+| `qml/components/ShotGraph.qml` | 129/136, 147-148 (`"bar / mL·g/s"`) |
+| `qml/components/HistoryShotGraph.qml` | 429/437, 446-448 (`titleText` is conditional on `showLabels`) |
+| `qml/components/SteamGraph.qml` | 117/124, 135-136 |
+| `qml/components/ComparisonGraph.qml` | 359-360, 373-374 |
+| `qml/components/ProfileGraph.qml` | 144, 154 (no `titleText`) |
+
+**Watch the i18n rule**: three of these titles go through `TranslationManager.translate(…)`
+(`ShotGraph.qml:136`, `HistoryShotGraph.qml:437`, `SteamGraph.qml:124`). A unit suffix moved into
+`labelPostFormat` must stay a translated binding, not a hardcoded string. The multi-unit shared axes
+(`"bar / mL/s"`, `"bar / mL·g/s"`) are **not** candidates — one axis, several units, so the suffix
+belongs in the title. Realistically only `FlowCalibrationPage`'s X axis (`"s"`) and any
+single-unit axis benefit; keep the PR small rather than forcing every site.
+
+### 6. Multi-axis margin fix (+ new `dynamicLabelMargins`)
 
 Qt 6.12 fixes a `GraphsView` margin miscalculation when multiple series share the X and/or Y axis ([qt/qtgraphs commit on dev branch, see migrate-charting proposal §"Qt 6.12 Roadmap"](../archive/2026-05-15-migrate-charting-to-qt-graphs/proposal.md)). Decenza always shares axes across pressure/flow/temperature/weight series in the espresso graphs. Verify visual change after the upgrade — pre-migration screenshots may shift slightly.
+
+**New in 6.12 and worth trying here**: `GraphsView.dynamicLabelMargins`
+(`Q_PROPERTY(bool … REVISION(6, 12))`, `qgraphsview_p.h:87`; absent from 6.11's property list, so it
+is genuinely new). Docs: "By default, labels wider than the allocated margin overlap other graph
+elements. When enabled, the renderer reserves extra space for such labels and repositions axes to
+prevent overlap." Default `false`.
+
+Decenza's Y labels are widest in `HistoryShotGraph` / `ComparisonGraph` (dual-unit shared axes), and
+those are exactly the graphs where the `marginLeft`/`marginRight` values were hand-tuned during the
+migration. So flipping this on may (a) fix residual label overlap and (b) make some hand-tuned
+margins redundant — or fight them. Test it in the same PR as the margin-fix verification, and
+re-check item 2's leftmost-label complaint afterwards. `clipPlotArea` is **not** new (since 6.10,
+default `true`), so item 1's "gridlines spilling past the clip" theory is testable on 6.11 today and
+needs no upgrade.
 
 ## What Changes
 
@@ -78,7 +217,7 @@ Pure follow-up: one PR per item (or a small batch of related items), no architec
 
 ## Success Criteria
 
-- All deferred items either landed (item 3, 5, 6 likely) or formally closed as "not addressable in 6.12, accept gap or escalate to upstream"
+- All deferred items either landed (items 4, 5, 6 — item 3 depends on the Qt build feature) or formally closed as "not addressable in 6.12, accept gap or escalate to upstream". Items 1 and 2 are already closed by the 2026-07-29 verification above; only the upstream suggestion for item 1 remains.
 - No new bridge components added (bridges from Stage 0 are still the contract)
 - No FPS regression on Decent tablet
 

--- a/openspec/changes/charts-qt-6-12-polish/specs/charting/spec.md
+++ b/openspec/changes/charts-qt-6-12-polish/specs/charting/spec.md
@@ -1,0 +1,47 @@
+# charting Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Rendering Backend
+
+The charting subsystem SHALL use Qt Graphs (GPU-accelerated) as its sole rendering backend. Qt Charts (Graphics View-based) SHALL NOT be present in the build. Qt Graphs offers two 2D rendering backends — Quick Shapes (`USE_SHAPE_BACKEND`) and Canvas Painter (`USE_PAINTER_BACKEND`, Qt 6.12+) — and Decenza SHALL treat Quick Shapes as the backend it is guaranteed to have, selecting Canvas Painter only where the installed Qt was built with that feature enabled.
+
+#### Scenario: Build configuration omits Qt Charts
+- **WHEN** a developer inspects `CMakeLists.txt`
+- **THEN** `find_package(Qt6 ...)` SHALL include `Graphs` but NOT `Charts`
+- **AND** no source file SHALL `#include <QtCharts/...>` or reference `QtCharts::` namespaces
+- **AND** no QML file SHALL `import QtCharts`
+
+#### Scenario: Live shot graph renders on GPU
+- **WHEN** a user starts an espresso shot on the Decent tablet (Samsung SM-X210)
+- **THEN** `ShotGraph.qml` SHALL render via `GraphsView`
+- **AND** the render loop SHALL maintain ≥60 fps during the densest extraction phase
+- **AND** no Qt Charts symbols SHALL be loaded at runtime
+
+#### Scenario: Canvas Painter backend is only selected when the Qt build provides it
+- **WHEN** a developer intends to set `GraphsView.useCanvasPainter: true`
+- **THEN** they SHALL first confirm the installed Qt has the `graphs-2d-high-performance-backend` feature enabled (that feature is `AUTODETECT OFF` upstream, so a stock Qt may not have it)
+- **AND** a `GraphsView` SHALL NOT be left with `useCanvasPainter: true` in a build where the feature is absent, because `QGraphsView::setUseCanvasPainter()` is compiled out there and the assignment is a silent no-op
+- **AND** every graph SHALL continue to render correctly on the Quick Shapes backend regardless of the flag's value
+
+### Requirement: Performance Parity
+
+The migration from Qt Charts to Qt Graphs SHALL NOT regress graph rendering performance. Any performance claim attributed to a rendering-backend change SHALL be supported by evidence that the backend actually changed.
+
+#### Scenario: Live shot FPS maintained
+- **WHEN** a shot is running on the Decent tablet with a physical BLE scale reporting at 20 Hz
+- **AND** the `ShotGraph` is displaying live pressure, flow, temperature, and weight traces
+- **THEN** the median frame time SHALL be ≤16.7 ms (60 fps)
+- **AND** the 99th-percentile frame time SHALL be ≤33.3 ms (30 fps)
+- **AND** these metrics SHALL meet or beat the documented Qt Charts baseline in `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md`
+
+#### Scenario: History list scroll smoothness
+- **WHEN** a user scrolls the shot history list containing ≥200 entries
+- **AND** each row contains a `HistoryShotGraph`
+- **THEN** scroll FPS SHALL be ≥60 fps on the Decent tablet
+- **AND** SHALL meet or beat the Qt Charts baseline
+
+#### Scenario: A backend-attributed measurement proves the backend took effect
+- **WHEN** an FPS measurement is recorded in `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md` and attributed to the Canvas Painter backend
+- **THEN** the recording SHALL state how the backend was confirmed active (for example: `useCanvasPainterChanged` observed to fire, or the Qt build's feature state inspected)
+- **AND** a measurement that cannot show this SHALL be recorded as "backend unconfirmed" rather than attributed to Canvas Painter

--- a/openspec/changes/charts-qt-6-12-polish/tasks.md
+++ b/openspec/changes/charts-qt-6-12-polish/tasks.md
@@ -1,59 +1,114 @@
 # Tasks: Qt 6.12 polish for charts migration
 
-**Precondition**: `upgrade-qt-6-12` change archived and Decenza building cleanly on Qt 6.12 GA.
+**Precondition**: `upgrade-qt-6-12` change archived and Decenza building cleanly on Qt 6.12 GA
+(2026-09-22). That change does not exist yet.
 
-Each numbered section is a candidate PR. Items can ship independently; only the precondition above is shared.
+Each numbered section is a candidate PR. Items can ship independently; only the precondition above is
+shared. §1 and §2 are already resolved by the 2026-07-29 source verification — see the proposal's
+"Verification against Qt 6.12" table for what was checked and how.
 
-## 0. Pre-Qt 6.12 GA monitoring (active until 2026-09-22)
+## 0. Pre-Qt 6.12 GA monitoring
 
-Moved from `migrate-charting-to-qt-graphs` Pre-Stage 0 §P.4 when that change archived. These items run before the precondition above is met.
+Moved from `migrate-charting-to-qt-graphs` Pre-Stage 0 §P.4 when that change archived.
 
-- [ ] Watch `qt/qtgraphs.git` `dev` branch for landings up to feature freeze 2026-05-29. Two major items already landed: `QCanvasPainter` backend ([QTBUG-140734](https://qt-project.atlassian.net/browse/QTBUG-140734)) and declarative XYSeries data API (QTBUG-134005, QTBUG-141139).
-- [ ] At each 6.12 beta (2026-06-11 / 2026-07-16 / 2026-08-18), re-check `dev` log for any new legend / auto-ranging / dashed-stroke / coord-mapping landings. None present as of 2026-05-13; do not plan around them appearing.
-- [ ] If a new property or API lands that closes an item in §1–§6 below, annotate that section's checklist with the property name before 6.12 GA so the polish PRs can pick it up immediately.
+- [x] Watch `qt/qtgraphs.git` for landings up to feature freeze (actual freeze **2026-06-02**, not
+      05-29). Done 2026-07-29 against the `6.12` branch: `useCanvasPainter` + `dynamicLabelMargins`
+      on `GraphsView`, `values` / `valueMapping` / `valueMin` / `stepSize` on `XYSeries`,
+      `labelPostFormat` on `ValueAxis`, logarithmic axis support. Nothing for ticks or label anchors.
+- [x] Beta re-check for the legend / auto-ranging / dashed-stroke / coord-mapping gaps. Still absent
+      on the `6.12` branch — all four Stage 0 bridges stay ours. Do not re-check per beta; the branch
+      is feature-frozen, only bug fixes land now.
+- [ ] At RC (**2026-09-08**) confirm nothing in §3–§6 regressed, then close this section. Remaining
+      beta dates for reference: Beta 3 **2026-08-18**.
 
-## 1. Re-check tick-mark length API
+## 1. Tick-mark length — CLOSED, upstream suggestion only
 
-- [ ] Open Qt 6.12 GA docs for `GraphsTheme` and `GraphsLine` ([qt-project.org doc.qt.io/qt-6.12/qml-qtgraphs-graphstheme.html](https://doc.qt.io/qt-6.12/qml-qtgraphs-graphstheme.html) once GA)
-- [ ] Search `qt/qtgraphs.git` `dev` log for: `tickLength`, `tickVisible`, `labelsMargin`, `clipGridToPlotArea`, `tickWidth`
-- [ ] If a new property exists: set it in `qml/components/graphs/DecenzaGraphsTheme.qml`, build, on-device verify against the Stage 0 baseline screenshot
-- [ ] If no new property: file an upstream Qt suggestion citing the four levers tried (`subWidth: 0`, `mainWidth: 1`, `subTickCount: 0`, no custom overlay) and link this change
+No property exists and the geometry is not parameterized: `tickershader.frag` draws major ticks
+unconditionally over the full ticker item, which `axisrenderer.cpp` sizes to the axis rect. Details
+and line citations in the proposal §1.
 
-## 2. Re-check leftmost label alignment
+- [x] Verify 6.12 `GraphsTheme` / `GraphsLine` property set — unchanged (five members)
+- [x] Search the tree for `tickLength`, `tickVisible`, `labelsMargin`, `clipGridToPlotArea`,
+      `tickWidth` — only private/3D/bar-series hits
+- [ ] File the upstream Qt suggestion: expose a `tickLength` uniform + `GraphsLine` property
+      mirroring the existing private `AxisTicker.subTickLength`. Cite `tickershader.frag` `main()`
+      (major-line branch has no length gate), the four levers already tried (`subWidth: 0`,
+      `mainWidth: 1`, `subTickCount: 0`, no custom overlay), and this change. Gerrit/JIRA per
+      `reference_qt_gerrit` conventions — a JIRA suggestion, not a patch, unless we choose to write it
+- [ ] Independent of 6.12: test whether the residual strokes are gridlines by toggling
+      `clipPlotArea` (since 6.10, so testable on 6.11 today). If they vanish, item 1 was never a tick
+      problem and the upstream ask changes
 
-- [ ] Search Qt 6.12 docs and `qt/qtgraphs.git` log for `labelsAnchor`, `labelsAlignment`, `firstLabelAnchor`
-- [ ] If found: apply in `DecenzaGraphsTheme.qml` or per-axis; on-device verify the "0" label sits flush under the Y axis spine
-- [ ] If not: close this item as "accept gap"
+## 2. Leftmost label alignment — CLOSED, accept gap
 
-## 3. Flip `useCanvasPainter: true` on every migrated `GraphsView`
+- [x] Confirm no `labelsAnchor` / `labelsAlignment` / `firstLabelAnchor` on 6.12 `ValueAxis` or
+      `GraphsTheme`
+- [ ] After §6 enables `dynamicLabelMargins`, look once more at the "0" label position; if the reflow
+      fixed it, note that in the §6 PR and delete this section
 
-- [ ] `qml/pages/FlowCalibrationPage.qml`
-- [ ] `qml/components/SteamGraph.qml` (post-Stage 2)
-- [ ] `qml/components/ShotGraph.qml` (post-Stage 3a)
-- [ ] `qml/components/HistoryShotGraph.qml` (post-Stage 3b)
-- [ ] `qml/components/ComparisonGraph.qml` (post-Stage 3c)
-- [ ] `qml/components/ProfileGraph.qml` (post-Stage 3d)
-- [ ] Re-measure FPS on Decent tablet (Samsung SM-X210) at each flip; record in `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md`
+## 3. `useCanvasPainter` — resolve the build feature FIRST
+
+The property is `REVISION(6, 12)` on `GraphsView`, but both accessors are `#ifdef
+USE_PAINTER_BACKEND` and the setter is a silent no-op otherwise. The define comes from CMake feature
+`graphs-2d-high-performance-backend`, which is `AUTODETECT OFF`. Proposal §3 has the citations.
+
+- [ ] **Gate**: on the installed Qt 6.12, check whether the feature is on. Read
+      `<QtDir>/lib/cmake/Qt6Graphs/*Config*.cmake` (or `qtgraphs` `qconfig`-style feature header) for
+      `graphs_2d_high_performance_backend`; alternatively confirm `Qt6::CanvasPainter` is a link
+      dependency of `Qt6::Graphs`
+- [ ] If OFF: **do not write the flip PR.** Record the finding here, and raise the "build qtgraphs
+      from source with `-DFEATURE_graphs_2d_high_performance_backend=ON`" question in
+      `upgrade-qt-6-12` — it is a shipping-a-non-stock-Qt-module decision across Android/iOS/desktop,
+      not a polish PR
+- [ ] If ON: verify the property is actually live before measuring — set `useCanvasPainter: true` on
+      one graph and confirm the `useCanvasPainterChanged` signal fires (a no-op build emits nothing).
+      Only then trust any FPS number
+- [ ] Flip, one line per file: `qml/pages/FlowCalibrationPage.qml`,
+      `qml/components/SteamGraph.qml`, `ShotGraph.qml`, `HistoryShotGraph.qml`,
+      `ComparisonGraph.qml`, `ProfileGraph.qml` (all six are migrated; no stage gating left)
+- [ ] Re-measure FPS on Decent tablet (Samsung SM-X210) at each flip; record in
+      `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md`
 - [ ] Single PR titled `feat(charts): switch all GraphsView to QCanvasPainter (Qt 6.12)`
 
-## 4. Adopt declarative `XYSeries.data` for static/computed series
+## 4. Adopt declarative `XYSeries.values` for one-shot series
 
-- [ ] Audit each migrated graph for static / computed series (goal curves, preview lines)
-- [ ] Replace `Component.onCompleted: series.replace(...)` with `data: ...` binding where the data is QML-bindable
-- [ ] Keep `QXYSeries::replace()` from C++ for live ~5 Hz extraction series
-- [ ] Single PR per graph or one bundled PR if changes are small
+Property is **`values`** (`QVariantList`, `REVISION(6, 12)`), not `data`. `setValues()` converts once
+and calls `replace()`, so it costs the same as the C++ path.
+
+- [ ] `qml/components/HistoryShotGraph.qml:143-158` — replace the per-point `append()` loop over the
+      six series with one `values` assignment each. Highest-value site
+- [ ] `qml/pages/FlowCalibrationPage.qml:264-272` — same pattern, two series
+- [ ] `qml/components/ProfileGraph.qml:342-490` (`updateCurves()`) — build arrays, assign once. Do
+      last; largest rewrite
+- [ ] Check whether any of the above is evenly sampled in X; if so evaluate `valueMapping` +
+      `valueMin` + `stepSize` (numbers-only list) instead of point pairs
+- [ ] Keep `QXYSeries::replace()` from C++ for live ~5 Hz extraction series — do not touch
+- [ ] Do **not** touch `qml/components/graphs/DashedLineSeries.qml`; it is a `ShapePath` overlay, not
+      an `XYSeries`
+- [ ] One bundled PR if the diffs stay small; split `ProfileGraph` out if it grows
 
 ## 5. Adopt `ValueAxis.labelPostFormat`
 
-- [ ] Verify the property exists on Qt 6.12 GA `ValueAxis` / `LogValueAxis`
-- [ ] Replace `labelFormat: "%.1f"` + `titleText: "<unit>"` with `labelPostFormat: "%.1f <unit>"` where it improves readability
+- [x] Property confirmed present on 6.12 `ValueAxis`
+- [ ] Adopt only where one axis carries one unit — `FlowCalibrationPage.qml:50-51` (`"s"`) first
+- [ ] Leave the shared multi-unit axes (`"bar / mL/s"`, `"bar / mL·g/s"`: `ShotGraph.qml:147-148`,
+      `HistoryShotGraph.qml:446-448`, `SteamGraph.qml:135-136`, `ComparisonGraph.qml:373-374`) with
+      the unit in `titleText`
+- [ ] Any suffix that replaces a translated `titleText` (`ShotGraph.qml:136`,
+      `HistoryShotGraph.qml:437`, `SteamGraph.qml:124`) must stay a `TranslationManager.translate`
+      binding — never a hardcoded string
 - [ ] One PR
 
-## 6. Verify multi-axis margin fix
+## 6. Verify multi-axis margin fix + try `dynamicLabelMargins`
 
-- [ ] Take pre-upgrade screenshots of `ShotGraph`, `SteamGraph`, `ComparisonGraph` on Decent tablet (these share axes across multiple series)
-- [ ] After Qt 6.12 upgrade, take new screenshots
-- [ ] Document any visual margin change in the PR description for the `upgrade-qt-6-12` change (this verification doesn't need a separate PR)
+- [ ] Take pre-upgrade screenshots of `ShotGraph`, `SteamGraph`, `ComparisonGraph`,
+      `HistoryShotGraph` on Decent tablet (these share axes across multiple series)
+- [ ] After the Qt 6.12 upgrade, take new screenshots; document any margin change in the
+      `upgrade-qt-6-12` PR description
+- [ ] Try `dynamicLabelMargins: true` (new in 6.12, default `false`) on the dual-unit graphs; check
+      it does not fight the hand-tuned `marginLeft` / `marginRight` values from the migration. Remove
+      any margin override it makes redundant
+- [ ] Re-check §2's leftmost-label complaint with the new margins in place
 
 ## Cross-stage acceptance criteria
 


### PR DESCRIPTION
`charts-qt-6-12-polish` was written from the Qt 6.12 roadmap while the dev branch was still open. Qt 6.12 hit feature freeze on **2026-06-02** and Beta 2 shipped **2026-07-14**, so the `qt/qtgraphs` `6.12` branch is now what GA will ship. Checking each of the change's six deferred items against that branch found **three of the six assumptions wrong**. Docs-only — no code touched.

## Corrections

| # | Was | Verified on the 6.12 branch |
|---|---|---|
| 1 | maybe a new `tickLength` / `labelsMargin` | **No, and none is coming** — closed |
| 2 | maybe a new `labelsAnchor` | **No** — closed, accept gap |
| 3 | `useCanvasPainter: true`, one-line flip | Property is real but **compile-gated behind an off-by-default Qt feature** |
| 4 | new `XYSeries.data` | Property is **`values`**, plus three siblings the proposal missed |
| 5 | `ValueAxis.labelPostFormat` | **Confirmed**, `REVISION(6, 12)` |
| 6 | multi-axis margin fix | Unchanged; 6.12 also adds `GraphsView.dynamicLabelMargins` |

### Item 3 is the one that matters

`GraphsView` does declare `Q_PROPERTY(bool useCanvasPainter … REVISION(6, 12))` (`qgraphsview_p.h:86`) — it is simply missing from the QML doc page, so docs alone say "doesn't exist". But **both accessors are `#ifdef USE_PAINTER_BACKEND`**, and the setter is `Q_UNUSED(newUseCanvasPainter)` otherwise (`qgraphsview.cpp:1900-1925`). The define comes from CMake feature `graphs-2d-high-performance-backend`, which is **`AUTODETECT OFF`** with `CONDITION TARGET Qt6::CanvasPainter` (`src/configure.cmake:49-54`).

So on a stock Qt the flip is a **silent no-op** — and "we flipped it and measured nothing" would be indistinguishable from "the flag did nothing". The task list now gates that PR on inspecting the installed Qt's feature state first, and on observing `useCanvasPainterChanged` actually fire before any FPS number is trusted. If the feature is off, the fallback is a Qt-module-from-source decision that belongs in `upgrade-qt-6-12`, not in a polish PR.

### Item 1 is closed with a reason, not a shrug

There is no tick-length API and the geometry is not parameterized. `tickershader.frag` `main()` length-gates sub-ticks (`fragCoord.y < iResolution.y * subTickLength`) but draws major ticks unconditionally (`lines += createBars(fragCoord.x, spacing, tickLineWidth)`), and `axisrenderer.cpp` sizes the ticker item to the axis rect — so main-tick length is a function of the axis label band. `subTickLength` belongs to the private `AxisTicker` (`axisticker_p.h:36`) and `axisrenderer.cpp` overwrites it internally. Ticker and spine also share one colour, so there is no hide-ticks-keep-spine trick. All that remains is the upstream suggestion, and it now names the concrete ask.

### Item 4

Property is `values` (`QVariantList`, `REVISION(6, 12)`, `qxyseries.h:27`), and `setValues()` converts once then calls `replace()` (`qxyseries.cpp:729-743`) — same cost as the C++ path, so it is safe for one-shot series. Siblings `valueMapping` / `valueMin` / `stepSize` were missed entirely. Adoption sites now listed with line numbers (`HistoryShotGraph.qml:143-158` is the six-series per-point `append()` loop, the highest-value one). `DashedLineSeries` is removed as a candidate — it is a `ShapePath` overlay, not an `XYSeries`.

## Also in this PR

- **The change now validates.** It had no `specs/` directory, so `openspec validate` failed with "Change must have at least one delta" — pre-existing, reproduced by stashing. Added `specs/charting/spec.md` with two `MODIFIED` requirements: **Rendering Backend** gains a scenario for confirming the Canvas Painter feature before relying on `useCanvasPainter`, and **Performance Parity** gains one requiring a backend-attributed measurement to state how the backend was confirmed active. `openspec validate --all` → **135 passed, 0 failed**.
- Stale stage gating removed — all six graphs are migrated, zero `QtCharts` imports remain — and the schedule corrected to freeze 06-02 / Beta 2 07-14 / Beta 3 08-18 / RC 09-08 / GA 09-22.
- Recorded as not relevant: 6.12's `QLogValueAxis` and 3D panning. Still absent: built-in legend, dashed stroke style, pixel↔data mapping — all four Stage 0 bridges stay ours.

Deliberately **not** in the delta: tick-length and label-alignment. Those closed as accepted cosmetic gaps and the spec has never asserted anything about axis tick chrome; a requirement for them would be invented scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)