### PR TITLE
docs(openspec): propose upgrade-qt-6-12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *.jks
 *.keystore
 
-# Build directories
+# Build directories. Anchored to the repo root on purpose: unanchored `build-*/`
+# also matched `openspec/**/specs/build-config/`, silently ignoring delta specs for
+# the build-config capability (a `git add` of the change directory just skipped them).
 build/
-build-*/
+/build-*/
 cmake-build-*/
 
 # CTest artifacts (regenerated on every test run; a stray top-level Testing/

--- a/openspec/changes/charts-qt-6-12-polish/proposal.md
+++ b/openspec/changes/charts-qt-6-12-polish/proposal.md
@@ -10,11 +10,10 @@ This change collects every visual / API / performance item that was deferred dur
 
 Decenza will upgrade to Qt 6.12 in a separate `upgrade-qt-6-12` change after 6.12 GA (2026-09-22). This change runs after that upgrade lands.
 
-**`upgrade-qt-6-12` now exists** (`../upgrade-qt-6-12/`) and is blocked on a product decision of its
-own: Qt 6.12 raises the iOS minimum from 17.0 to iOS 18, dropping a device class including the iPad
-used for iOS testing here. Whichever way that goes, it decides when this change can start — and if it
-goes to "hold iOS on 6.11.1", the charts items still proceed, since every graph surface is shared and
-would be built by the 6.12 toolchain on Android and desktop.
+**`upgrade-qt-6-12` now exists** (`../upgrade-qt-6-12/`) and is ready to run at GA. It raised one
+product question — Qt 6.12 lifts the iOS minimum from 17.0 to iOS 18, dropping pre-A12 devices —
+which was decided on 2026-07-29: take iOS 18, one Qt version on every platform, and explain the
+inherited floor in the release notes. So the only thing gating this change is GA itself.
 
 ## Verification against Qt 6.12 (done 2026-07-29, Beta 2 tree)
 

--- a/openspec/changes/charts-qt-6-12-polish/proposal.md
+++ b/openspec/changes/charts-qt-6-12-polish/proposal.md
@@ -10,6 +10,12 @@ This change collects every visual / API / performance item that was deferred dur
 
 Decenza will upgrade to Qt 6.12 in a separate `upgrade-qt-6-12` change after 6.12 GA (2026-09-22). This change runs after that upgrade lands.
 
+**`upgrade-qt-6-12` now exists** (`../upgrade-qt-6-12/`) and is blocked on a product decision of its
+own: Qt 6.12 raises the iOS minimum from 17.0 to iOS 18, dropping a device class including the iPad
+used for iOS testing here. Whichever way that goes, it decides when this change can start — and if it
+goes to "hold iOS on 6.11.1", the charts items still proceed, since every graph surface is shared and
+would be built by the 6.12 toolchain on Android and desktop.
+
 ## Verification against Qt 6.12 (done 2026-07-29, Beta 2 tree)
 
 Every item below was checked against the actual `qt/qtgraphs` **`6.12` branch** (feature freeze

--- a/openspec/changes/charts-qt-6-12-polish/tasks.md
+++ b/openspec/changes/charts-qt-6-12-polish/tasks.md
@@ -1,7 +1,15 @@
 # Tasks: Qt 6.12 polish for charts migration
 
 **Precondition**: `upgrade-qt-6-12` change archived and Decenza building cleanly on Qt 6.12 GA
-(2026-09-22). That change does not exist yet.
+(2026-09-22). That change now exists — `../upgrade-qt-6-12/` — and is itself **blocked on a product
+decision**: Qt 6.12 raises the iOS minimum to iOS 18, which drops a device class including the iPad
+used for iOS testing. If that decision goes to "hold iOS on 6.11.1" or "defer the upgrade", this
+change stays deferred with it.
+
+Two of its §0 tasks feed directly into the sections below, so read them before starting here:
+whether Gerrit 735089 gets picked to 6.12 (irrelevant to charts, but it gates the upgrade PR), and
+**whether the installed Qt 6.12 has `graphs-2d-high-performance-backend` compiled in** — that answer
+is §3's gate below, and `upgrade-qt-6-12` is where it gets recorded.
 
 Each numbered section is a candidate PR. Items can ship independently; only the precondition above is
 shared. §1 and §2 are already resolved by the 2026-07-29 source verification — see the proposal's
@@ -52,14 +60,16 @@ The property is `REVISION(6, 12)` on `GraphsView`, but both accessors are `#ifde
 USE_PAINTER_BACKEND` and the setter is a silent no-op otherwise. The define comes from CMake feature
 `graphs-2d-high-performance-backend`, which is `AUTODETECT OFF`. Proposal §3 has the citations.
 
-- [ ] **Gate**: on the installed Qt 6.12, check whether the feature is on. Read
-      `<QtDir>/lib/cmake/Qt6Graphs/*Config*.cmake` (or `qtgraphs` `qconfig`-style feature header) for
-      `graphs_2d_high_performance_backend`; alternatively confirm `Qt6::CanvasPainter` is a link
-      dependency of `Qt6::Graphs`
-- [ ] If OFF: **do not write the flip PR.** Record the finding here, and raise the "build qtgraphs
-      from source with `-DFEATURE_graphs_2d_high_performance_backend=ON`" question in
-      `upgrade-qt-6-12` — it is a shipping-a-non-stock-Qt-module decision across Android/iOS/desktop,
-      not a polish PR
+- [ ] **Gate**: read the feature state recorded by `../upgrade-qt-6-12/` §0 (that change's fourth
+      decision task owns this check, so do not duplicate it here). If it has not been recorded yet,
+      check it the same way: read `<QtDir>/lib/cmake/Qt6Graphs/*Config*.cmake` (or `qtgraphs`
+      `qconfig`-style feature header) for `graphs_2d_high_performance_backend`, or confirm
+      `Qt6::CanvasPainter` is a link dependency of `Qt6::Graphs`
+- [ ] If OFF: **do not write the flip PR.** The "build qtgraphs from source with
+      `-DFEATURE_graphs_2d_high_performance_backend=ON`" question is already carried by
+      `../upgrade-qt-6-12/` (its proposal's default answer is **no**) — it is a
+      shipping-a-non-stock-Qt-module decision across Android/iOS/desktop, not a polish PR. Close this
+      section against that answer rather than re-litigating it here
 - [ ] If ON: verify the property is actually live before measuring — set `useCanvasPainter: true` on
       one graph and confirm the `useCanvasPainterChanged` signal fires (a no-op build emits nothing).
       Only then trust any FPS number

--- a/openspec/changes/charts-qt-6-12-polish/tasks.md
+++ b/openspec/changes/charts-qt-6-12-polish/tasks.md
@@ -1,15 +1,13 @@
 # Tasks: Qt 6.12 polish for charts migration
 
 **Precondition**: `upgrade-qt-6-12` change archived and Decenza building cleanly on Qt 6.12 GA
-(2026-09-22). That change now exists — `../upgrade-qt-6-12/` — and is itself **blocked on a product
-decision**: Qt 6.12 raises the iOS minimum to iOS 18, which drops a device class including the iPad
-used for iOS testing. If that decision goes to "hold iOS on 6.11.1" or "defer the upgrade", this
-change stays deferred with it.
+(2026-09-22). That change now exists — `../upgrade-qt-6-12/` — and is **ready, not blocked**: the iOS
+floor question it raised was decided on 2026-07-29 (take Qt 6.12's iOS 18 minimum, one Qt version
+everywhere), so nothing about the iOS decision defers the charts work.
 
-Two of its §0 tasks feed directly into the sections below, so read them before starting here:
-whether Gerrit 735089 gets picked to 6.12 (irrelevant to charts, but it gates the upgrade PR), and
-**whether the installed Qt 6.12 has `graphs-2d-high-performance-backend` compiled in** — that answer
-is §3's gate below, and `upgrade-qt-6-12` is where it gets recorded.
+One of its §0 items feeds directly into §3 below: **whether the installed Qt 6.12 has
+`graphs-2d-high-performance-backend` compiled in**. That answer is §3's gate, and `upgrade-qt-6-12` is
+where it gets recorded.
 
 Each numbered section is a candidate PR. Items can ship independently; only the precondition above is
 shared. §1 and §2 are already resolved by the 2026-07-29 source verification — see the proposal's

--- a/openspec/changes/upgrade-qt-6-12/proposal.md
+++ b/openspec/changes/upgrade-qt-6-12/proposal.md
@@ -1,0 +1,175 @@
+# Change: Upgrade Qt from 6.11.1 to 6.12
+
+## Status: BLOCKED ON A PRODUCT DECISION — Qt 6.12 drops iOS 17
+
+Qt 6.12 GA is **2026-09-22** (feature freeze was 2026-06-02; Beta 2 shipped 2026-07-14, Beta 3 is
+2026-08-18, RC 2026-09-08). The upgrade itself is routine, but **Qt 6.12 raises the iOS minimum from
+17.0 to iOS 18** — see §"iOS 18 is a hard floor" below. That is a user-facing support decision, not a
+build detail, and it needs Jeff's call before any work starts.
+
+## Why
+
+- **Unblocks `charts-qt-6-12-polish`.** Every item in that change is preconditioned on this one.
+  `ValueAxis.labelPostFormat`, `XYSeries.values`, and `GraphsView.dynamicLabelMargins` are all 6.12
+  APIs, already verified present on the `qt/qtgraphs` `6.12` branch.
+- **Deletes most of `android/qt-overrides/`.** Both TalkBack fixes we ship as a patched Qt platform
+  plugin + jar are now upstream **on the 6.12 branch** — see §"Android accessibility overrides".
+- **Qt Canvas Painter exits Technology Preview** and becomes a fully supported module. `CupFillView`
+  and its `JsCanvasPainterItem` wrapper (added in `upgrade-qt-6-11-1`) stop depending on a TP API
+  that can shift between minors — the `synchronize()` → `synchronizeData()` rename we absorbed in
+  6.11.1 is exactly the class of churn that stops here.
+- **6.12 is the next commercial LTS**, so it is where Qt's own bug-fix attention goes next.
+- Minor wins we get for free: faster `QDateTime` parsing in Qt Core (shot-history and DYE metadata
+  paths), a new `Color` QML singleton (`Theme.qml` hand-rolls colour math today), `QMap`/`QMultiMap`
+  relational operators, `AnimatedImage.loops` + `finished()`.
+
+## iOS 18 is a hard floor
+
+Qt 6.12's iOS page states **"iOS 18 or higher (including iOS 26)"** with **"Xcode 16 (iOS 18 SDK) or
+higher"**. Qt 6.11 was iOS 17. Consequences:
+
+1. **`CMakeLists.txt:160` sets `CMAKE_OSX_DEPLOYMENT_TARGET "17.0"` for iOS** and must go to 18.0.
+   The `build-config` spec's "iOS Minimum Deployment Target" requirement changes with it.
+2. **Jeff's iOS test device stops working.** The test iPad is an **iPad7,4** (iPad Pro 10.5", A10X),
+   which tops out at iPadOS 17 — iPadOS 18 requires A12 or newer. A Qt 6.12 build cannot be installed
+   on it at all, so the `devicectl install` deploy path in `project_ios_deploy_workflow` dies with
+   the upgrade. Testing iOS 2.x would need newer hardware, and the iOS Simulator is not an option on
+   this Mac (Qt's iOS simulator libraries are x86_64-only against an Apple Silicon host).
+3. **Existing iOS users on 17 stop receiving updates.** App Store builds would raise their minimum
+   OS, and iOS 17 devices silently stop being offered the new version.
+4. macOS minimum also rises to **14.4** (from 13). Not a problem for this Mac (macOS 26) but it is a
+   published support change.
+
+**Options, for Jeff to choose:**
+
+- **(a) Take iOS 18.** Accept the device-support loss, get 6.12 everywhere, buy or borrow an A12+
+  iPad for testing. Android is the primary platform (`project_android_is_primary_platform`), and the
+  iOS user base is small, so the practical cost may be low — but it is real and it is permanent.
+- **(b) Upgrade everything except iOS**, keeping the iOS workflow on 6.11.1. Costs: two Qt versions in
+  CI, a second `install-qt-action` version pin, and a divergence risk in shared C++/QML (a 6.12-only
+  API used anywhere non-`#ifdef`'d breaks the iOS build). The Home Screen widget work has iOS as its
+  driver (`feedback_ios_primary_driver`), so the iOS build cannot be allowed to rot.
+- **(c) Defer the whole upgrade** past 6.12 and stay on 6.11.1 until the iOS 17 install base is
+  negligible. `charts-qt-6-12-polish` stays deferred with it.
+
+This proposal is written for **(a)** — the single-version path — and flags the (b) branch points in
+`tasks.md`. Nothing else in the change depends on which option is chosen.
+
+## Android accessibility overrides — delete two thirds, keep the crash patch
+
+`android/qt-overrides/` ships a patched Qt Android platform plugin (`.so`) plus a patched
+`Qt6Android.jar` to fix three unfixed-upstream bugs. Verified against the `qt/qtbase` **`6.12`
+branch** (not `dev`, and not the doc pages):
+
+| Bug | Upstream on 6.12? | Evidence |
+|---|---|---|
+| **QTBUG-145786** keyboard opens on a11y focus (focus trap) | **Yes** | `41e6aecb7cd3`, 2026-06-23, "Android a11y: do not open keyboard on focus when TalkBack is enabled". Dev commit `e019acaaae87` carries `Pick-to: 6.12 6.11` |
+| **QTBUG-118858** typed/deleted characters not spoken under TalkBack | **Yes** | `505853d02184`, 2026-07-16, "Android a11y: announce text edits so screen readers echo typing". Touches **both** `src/plugins/platforms/android/` and `src/android/jar/…` — the same two artifacts our override patches. Dev commit `66acbeda7c59` carries `Pick-to: 6.12 6.11` |
+| **QTBUG-140490 / QTBUG-144207** `qFatal` abort on contended `AndroidDeadlockProtector` | **No** | `qandroidplatformopenglwindow.cpp:68` on the `6.12` branch still reads `qFatal("Failed to acquire deadlock protector for %s.", funcName);`. Gerrit **735089** (the real fix, which removes the protector from the EGL/Vk surface paths) has no `Pick-to:` footer and targets `dev` — i.e. 6.13 |
+
+So the override **cannot simply be deleted**. What changes:
+
+- **Delete the `Qt6Android.jar` override entirely.** Its only purpose was the a11y Java classes
+  (`QtAccessibilityDelegate` / `QtAccessibilityInterface` / `QtNativeAccessibility`) that send
+  `TYPE_VIEW_TEXT_CHANGED`; 6.12 ships that upstream. Stock jar from here on.
+- **Rebuild the `.so` from Qt 6.12 sources carrying only the crash patch** (`358540b2` in
+  `skialpine/qtbase`, rebased onto the 6.12 tag), dropping the 12 a11y commits. The crash fix is
+  C++-only, so the `.so` alone is sufficient once the jar override is gone.
+- **Update `BUILT_AGAINST_QT`** in the same commit as the new binary. `android-release.yml`
+  (≈:190-215) *fails the build* when `BUILT_AGAINST_QT` ≠ `env.QT_VERSION`, so a Qt bump without
+  touching the override gives a red build rather than an APK that dies at startup — that guard is
+  working as designed and must not be loosened.
+- **Better outcome, worth one attempt first**: ask for `735089` to be picked to 6.12. Both a11y
+  patches went upstream through the same Gerrit account (`skialpine`, see `reference_qt_gerrit`), so
+  requesting a `Pick-to: 6.12` on a crash fix is a reasonable ask. If it lands, `android/qt-overrides/`
+  is deleted outright — the `.so`, the jar, `BUILT_AGAINST_QT`, and the workflow step — which is the
+  README's own stated preference over rebuilding. Try this **before** rebuilding anything.
+
+The crash matters enough to justify the remaining patch: **9 of 42** Android crash reports since
+2026-01-18, and **2 of 2** on 6.11.1 builds. Reporting is opt-in, so that is a floor.
+
+Also note two a11y improvements 6.12 brings that we did *not* patch and should re-check on device,
+since they may change TalkBack behaviour on screens we tuned: `0e3e5d8aacb0` "Inform TalkBack of
+scrolled viewport", `cbd6b48998ce` "Update TalkBack with ScrollingPositionChanged",
+`56ae71c6cb27` "Implement expandable/expanded state", `a52d5d20893f` "Map
+QAccessible::ButtonDropDown to correct classname".
+
+## What Changes
+
+- **CI workflows** (7 files: 6 platform + `nightly-sanitizers.yml`): bump `version: '6.11.1'` →
+  `'6.12.x'`; `android-release.yml` bumps `env.QT_VERSION`. Module lists need no change —
+  `qtcanvaspainter` is already listed everywhere and stays a module in 6.12.
+- **`java-version: '17'` → `'21'`** in `android-release.yml:69`. Qt 6.12 requires **JDK 21**.
+- **NDK**: Qt 6.12 pins Clang 17.0.2 / **NDK r27c (27.2.12479018)** — the same revision 6.11.1 used,
+  and the workflow already derives `QT_NDK_VERSION` from Qt's own toolchain file (≈:88-97), so this
+  should be a no-op. Verify rather than assume.
+- **Windows sccache key**: `sccache-windows-x64-qt6.11.1-vs2026` → `…-qt6.12.x-vs2026`, so a stale
+  cache cannot be hit.
+- **Windows `aqtsource` pin** (`windows-release.yml:80-85`, `TODO(qt-6.11)`): the pin exists because
+  aqtinstall 3.3.0 could not parse the per-arch Windows online-installer layout for 6.11.x. Re-test
+  with PyPI head against 6.12; drop the pin if it works, re-point it if not.
+- **iOS Xcode pin**: `ios-release.yml` pins Xcode 26.4.1 for a libc++ ABI reason. Qt 6.12 requires
+  Xcode 16+, which 26.4.1 satisfies; verify the pin is still needed at all against 6.12's prebuilt
+  binaries.
+- **`CMakeLists.txt`**: iOS deployment target 17.0 → 18.0 (option (a)); check for new `QTP` policies
+  introduced in 6.12 and set them NEW inside the existing `VERSION_GREATER_EQUAL "6.5.0"` guard;
+  `cmake_minimum_required(VERSION 3.21)` stays valid (Qt 6.12 requires ≥ 3.16 in that command) but
+  **CMake 3.25 is the recommended configuring tool version** — confirm the CMake that Qt Creator and
+  each runner actually invoke is ≥ 3.25.
+- **`android/qt-overrides/`**: delete `Qt6Android.jar`, rebuild the `.so` against 6.12 with the crash
+  patch only, update `BUILT_AGAINST_QT` and the README (three bugs → one). Or delete the directory
+  entirely if Gerrit 735089 is picked to 6.12.
+- **Docs and metadata**: `CLAUDE.md` (Qt version + `C:/Qt/6.11.1/…`, `~/Qt/6.11.1/Src` paths),
+  `CLAUDE.local.md` build-dir names (Jeff's, uncommitted), `README.md` badge and install minimum,
+  `openspec/config.yaml` tech-stack line, `docs/CLAUDE_MD/PLATFORM_BUILD.md`,
+  `docs/CLAUDE_MD/TESTING.md`, `docs/IOS_CI_SETUP.md`, `docs/IOS_CI_FOR_CLAUDE.md`,
+  `docs/CLAUDE_MD/BUILD_PERFORMANCE.md` if its numbers were measured on 6.11.1.
+- **Local installs**: Qt 6.12 on the Windows dev machine and on Jeff's Mac (macOS + iOS targets),
+  plus a Qt Creator kit. `CLAUDE.local.md` notes that
+  `-DDECENZA_MACOS_CODESIGN_IDENTITY=…` must go in the kit's **Initial Configuration**, since a fresh
+  cache is what a new-Qt build directory is.
+
+## Qt 6.11 → 6.12 delta relevant to Decenza
+
+Minor upgrade, binary compatible. Audited, and the only source-affecting items are the platform
+minimums above. Specifically:
+
+- **Qt Bluetooth**: no new API, but three Android changes touch code paths we depend on and want
+  on-device verification, not just a green build — `Android scan record parsing: fix length and type
+  extraction`, `Android scan record parsing: add length checks when extracting UUIDs`, and
+  `Android/BLE: defer canceled() to match classic scan` (that last one changes
+  `QBluetoothDeviceDiscoveryAgent::canceled()` timing, and our scan-stop path orders on it). Also
+  `BTLE: do not log CSRK and MAC` removes fields from Qt's BLE logging, and
+  `Bluetooth Darwin: check size before parsing manufacturer data` affects macOS scanning. Nothing
+  about descriptors/CCCD, so the native-CoreBluetooth iOS scale transport
+  (`project_ios_scale_transport_revisit`) still cannot be retired.
+- **MQTT: unaffected.** Decenza uses Eclipse Paho C (`src/network/mqttclient.cpp`), not Qt MQTT —
+  and Qt does not ship Qt MQTT binaries to open-source users anyway (no `qtmqtt` in the addons
+  repo), so this is not the moment to reconsider.
+- **Qt Graphs**: `labelPostFormat`, `XYSeries.values` + `valueMapping`/`valueMin`/`stepSize`,
+  `GraphsView.dynamicLabelMargins`, `useCanvasPainter` (compile-gated, see below), `QLogValueAxis`,
+  a multi-axis margin fix. Still no built-in legend, dashed-stroke style, or pixel↔data mapping, so
+  all four Stage 0 bridges stay ours.
+- **The Canvas Painter Graphs backend is off in stock Qt.** `graphs-2d-high-performance-backend` is
+  `AUTODETECT OFF` upstream, and `QGraphsView::setUseCanvasPainter()` is compiled out without it, so
+  `useCanvasPainter: true` is a silent no-op on a stock build. This change's job is only to
+  **record which state the installed 6.12 is in**; whether to build `qtgraphs` from source to get the
+  backend is a shipping-a-non-stock-Qt-module decision that belongs here rather than in a polish PR,
+  and the default answer is no.
+- **New modules we do not want**: Qt Qml Design Support (design tooling), HarmonyOS (Technology
+  Preview). No action.
+
+## Impact
+
+- **Affected specs**: `build-config` (Qt version requirement, iOS deployment target, and — new — the
+  Android platform-override policy that ties `BUILT_AGAINST_QT` to the Qt version).
+- **Affected code**: `.github/workflows/*.yml` (7), `CMakeLists.txt`, `android/qt-overrides/*`,
+  `CLAUDE.md`, `README.md`, `openspec/config.yaml`, four docs under `docs/`.
+- **Risk**: **Medium-high**, and unusually so for a Qt minor. Not the API surface — the platform
+  floor. iOS 18 removes a device class and Jeff's only test device; the Android override rebuild has
+  a failure mode (stale/mismatched plugin) that bricks the app at startup for every user, which is
+  why the CI guard fails the build instead of warning.
+- **Unblocks**: `charts-qt-6-12-polish` (all six items).
+- **Verification**: full local suite via `mcp__qtcreator__run_tests` (scope `all`) — no CI job builds
+  or tests a PR — plus the qmllint gate, plus a CI test build of **iOS and Android specifically**,
+  since their code is `#ifdef`-guarded and only the tag-push release workflows compile it.

--- a/openspec/changes/upgrade-qt-6-12/proposal.md
+++ b/openspec/changes/upgrade-qt-6-12/proposal.md
@@ -1,11 +1,19 @@
 # Change: Upgrade Qt from 6.11.1 to 6.12
 
-## Status: BLOCKED ON A PRODUCT DECISION — Qt 6.12 drops iOS 17
+## Status: READY — starts after Qt 6.12 GA (2026-09-22)
 
 Qt 6.12 GA is **2026-09-22** (feature freeze was 2026-06-02; Beta 2 shipped 2026-07-14, Beta 3 is
-2026-08-18, RC 2026-09-08). The upgrade itself is routine, but **Qt 6.12 raises the iOS minimum from
-17.0 to iOS 18** — see §"iOS 18 is a hard floor" below. That is a user-facing support decision, not a
-build detail, and it needs Jeff's call before any work starts.
+2026-08-18, RC 2026-09-08).
+
+**Decision taken 2026-07-29: take iOS 18.** Qt 6.12 raises the iOS minimum from 17.0 to iOS 18, and
+Decenza follows it on one Qt version across every platform. Holding iOS back or deferring the whole
+upgrade were both considered and rejected — the world moves on, and paying for two Qt versions in CI
+to keep a 2017 iPad alive is the wrong trade.
+
+**The one obligation that comes with it**: the release notes must say plainly *why* the iOS minimum
+rose — it is Qt's floor, inherited from the framework upgrade, not a Decenza choice — and name the
+device classes affected, so an iOS 17 user who stops getting updates can see the cause. See §"iOS 18
+is a hard floor" and `tasks.md` §2.
 
 ## Why
 
@@ -40,20 +48,26 @@ higher"**. Qt 6.11 was iOS 17. Consequences:
 4. macOS minimum also rises to **14.4** (from 13). Not a problem for this Mac (macOS 26) but it is a
    published support change.
 
-**Options, for Jeff to choose:**
+**Decided (2026-07-29): take iOS 18, single Qt version everywhere.** Recorded here so the two
+rejected options are not re-proposed later:
 
-- **(a) Take iOS 18.** Accept the device-support loss, get 6.12 everywhere, buy or borrow an A12+
-  iPad for testing. Android is the primary platform (`project_android_is_primary_platform`), and the
-  iOS user base is small, so the practical cost may be low — but it is real and it is permanent.
-- **(b) Upgrade everything except iOS**, keeping the iOS workflow on 6.11.1. Costs: two Qt versions in
-  CI, a second `install-qt-action` version pin, and a divergence risk in shared C++/QML (a 6.12-only
-  API used anywhere non-`#ifdef`'d breaks the iOS build). The Home Screen widget work has iOS as its
-  driver (`feedback_ios_primary_driver`), so the iOS build cannot be allowed to rot.
-- **(c) Defer the whole upgrade** past 6.12 and stay on 6.11.1 until the iOS 17 install base is
-  negligible. `charts-qt-6-12-polish` stays deferred with it.
+- **Rejected — upgrade everything except iOS**, keeping the iOS workflow on 6.11.1. Costs two Qt
+  versions in CI, a second `install-qt-action` pin, and a standing divergence risk in shared C++/QML
+  (any 6.12-only API used outside an `#ifdef` breaks the iOS build silently until a tag push). The
+  Home Screen widget has iOS as its driver (`feedback_ios_primary_driver`), so a rotting iOS build is
+  not survivable.
+- **Rejected — defer the upgrade** until the iOS 17 install base is negligible. That parks
+  `charts-qt-6-12-polish` indefinitely and accumulates Qt debt for a shrinking device class.
 
-This proposal is written for **(a)** — the single-version path — and flags the (b) branch points in
-`tasks.md`. Nothing else in the change depends on which option is chosen.
+**What the decision obliges us to do**, and the only part that is not mechanical:
+
+- **Say why, in the release notes.** The iOS minimum rose because Qt 6.12 requires iOS 18 — an
+  upstream framework floor Decenza inherits, not a product decision to drop anyone. Name the affected
+  devices (pre-A12: iPad Pro 1st/2nd gen, iPad 6th gen, iPhone X and earlier) so a user who stops
+  seeing updates can find the reason instead of assuming the app broke. This is the whole ask: the
+  cause is external, and the notes should make that legible without sounding defensive.
+- **Get an A12+ iPad for testing.** Not a blocker for starting, but iOS ships untested without it,
+  and the Simulator is not available on this Mac (`project_qt_ios_simulator_gap`).
 
 ## Android accessibility overrides — delete two thirds, keep the crash patch
 
@@ -111,7 +125,10 @@ QAccessible::ButtonDropDown to correct classname".
 - **iOS Xcode pin**: `ios-release.yml` pins Xcode 26.4.1 for a libc++ ABI reason. Qt 6.12 requires
   Xcode 16+, which 26.4.1 satisfies; verify the pin is still needed at all against 6.12's prebuilt
   binaries.
-- **`CMakeLists.txt`**: iOS deployment target 17.0 → 18.0 (option (a)); check for new `QTP` policies
+- **Release notes**: an entry stating that the iOS minimum is now 18 **because Qt 6.12 requires it**,
+  with the affected device list. Per `feedback_release_notes_user_visible` this is exactly the kind of
+  proven user-visible change that belongs there.
+- **`CMakeLists.txt`**: iOS deployment target 17.0 → 18.0; check for new `QTP` policies
   introduced in 6.12 and set them NEW inside the existing `VERSION_GREATER_EQUAL "6.5.0"` guard;
   `cmake_minimum_required(VERSION 3.21)` stays valid (Qt 6.12 requires ≥ 3.16 in that command) but
   **CMake 3.25 is the recommended configuring tool version** — confirm the CMake that Qt Creator and

--- a/openspec/changes/upgrade-qt-6-12/specs/build-config/spec.md
+++ b/openspec/changes/upgrade-qt-6-12/specs/build-config/spec.md
@@ -1,0 +1,64 @@
+# build-config Specification (delta)
+
+**Note**: the iOS scenarios below assume decision **(a)** from `proposal.md` §"iOS 18 is a hard
+floor" — one Qt version across all platforms. If (b) is chosen (iOS held on 6.11.1), the framework
+requirement and the iOS deployment-target requirement both need rewriting to name two Qt versions,
+and this delta must be revised before implementation starts.
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Qt 6.11.1 as Build Framework`
+- TO: `### Requirement: Qt 6.12 as Build Framework`
+
+## MODIFIED Requirements
+
+### Requirement: Qt 6.12 as Build Framework
+The system SHALL be built with Qt 6.12 across all supported platforms (Windows, macOS, iOS, Android, Linux x64, Linux arm64).
+
+#### Scenario: Windows desktop build
+- **WHEN** the developer configures CMake with `-DCMAKE_PREFIX_PATH="C:/Qt/6.12/msvc2022_64"`
+- **THEN** CMake finds all required Qt modules and the project builds without errors
+
+#### Scenario: CI platform build
+- **WHEN** a release tag is pushed
+- **THEN** all six platform workflows (Windows, macOS, iOS, Android, Linux, Linux arm64) install Qt 6.12 via `jurplel/install-qt-action@v4` and produce a successful build artifact
+- **AND** `nightly-sanitizers.yml` installs the same Qt version, so the nightly ASan/UBSan run exercises the version the releases ship
+
+#### Scenario: Android toolchain matches what Qt 6.12 requires
+- **WHEN** `android-release.yml` runs
+- **THEN** it provisions **JDK 21** (Qt 6.12's required JDK; Qt 6.11.1 needed only 17)
+- **AND** the NDK revision it resolves SHALL be the one Qt's own toolchain file names, rather than a hardcoded guess
+
+### Requirement: iOS Minimum Deployment Target
+The iOS build SHALL target iOS 18.0 as the minimum deployment target, matching the minimum iOS version required by Qt 6.12.
+
+#### Scenario: iOS CMake configure
+- **WHEN** CMake is configured for the iOS platform
+- **THEN** `CMAKE_OSX_DEPLOYMENT_TARGET` SHALL be `18.0`
+- **AND** the accompanying comment SHALL state that the floor comes from Qt 6.12, not from Decenza's own API use
+
+#### Scenario: A device below the floor is not silently unsupported
+- **WHEN** the iOS deployment target rises above what an existing test or user device can run
+- **THEN** the change that raises it SHALL record which device classes are dropped
+- **AND** SHALL NOT be merged on the assumption that "the build is green" means iOS is still covered — a green iOS build proves compilation, not that any available device can run it
+
+## ADDED Requirements
+
+### Requirement: Patched Qt Platform Artifacts Are Version-Locked
+Where Decenza ships a patched Qt artifact (an Android platform plugin or Qt jar) to fix an upstream bug, that artifact SHALL be locked to the exact Qt version it was built from, and the build SHALL fail rather than package a mismatched one.
+
+#### Scenario: Qt version is bumped without dealing with the override
+- **WHEN** `env.QT_VERSION` in `android-release.yml` no longer matches `android/qt-overrides/BUILT_AGAINST_QT`
+- **THEN** the workflow SHALL fail with an explicit error
+- **AND** SHALL NOT fall back to the stock artifact or continue with a warning, because a stale plugin links against Qt private symbols and produces an APK that dies at startup on every device
+
+#### Scenario: An override's upstream bug is fixed
+- **WHEN** a Qt upgrade includes the upstream fix for a bug an override patches
+- **THEN** that portion of the override SHALL be deleted rather than rebuilt
+- **AND** the deletion SHALL be justified by the fix's presence on the release branch being upgraded to — not by its presence on `dev`, and not by a doc page or changelog entry
+- **AND** where only some of an override's patches are upstream, the remaining ones SHALL be rebuilt against the new Qt and the README updated to list only the bugs still being patched
+
+#### Scenario: A patched behavior is verified on device after the override is dropped
+- **WHEN** an override that fixed a user-visible behavior is removed because upstream fixed it
+- **THEN** that behavior SHALL be verified on a real device before release
+- **AND** a regression in the upstream fix SHALL be treated as a blocker for the upgrade, restoring the patch

--- a/openspec/changes/upgrade-qt-6-12/specs/build-config/spec.md
+++ b/openspec/changes/upgrade-qt-6-12/specs/build-config/spec.md
@@ -1,9 +1,6 @@
 # build-config Specification (delta)
 
-**Note**: the iOS scenarios below assume decision **(a)** from `proposal.md` §"iOS 18 is a hard
-floor" — one Qt version across all platforms. If (b) is chosen (iOS held on 6.11.1), the framework
-requirement and the iOS deployment-target requirement both need rewriting to name two Qt versions,
-and this delta must be revised before implementation starts.
+Decided 2026-07-29: one Qt version across every platform, taking Qt 6.12's iOS 18 floor with it.
 
 ## RENAMED Requirements
 
@@ -41,6 +38,12 @@ The iOS build SHALL target iOS 18.0 as the minimum deployment target, matching t
 - **WHEN** the iOS deployment target rises above what an existing test or user device can run
 - **THEN** the change that raises it SHALL record which device classes are dropped
 - **AND** SHALL NOT be merged on the assumption that "the build is green" means iOS is still covered — a green iOS build proves compilation, not that any available device can run it
+
+#### Scenario: A raised platform minimum is explained to users
+- **WHEN** a release raises the minimum OS version on any platform
+- **THEN** the release notes SHALL state the new minimum, the cause, and the device classes affected
+- **AND** where the cause is an upstream framework requirement rather than a Decenza decision, the notes SHALL say so plainly, so a user who stops receiving updates can identify why
+- **AND** SHALL state which platforms are unaffected, so a single-platform floor is not read as an app-wide one
 
 ## ADDED Requirements
 

--- a/openspec/changes/upgrade-qt-6-12/tasks.md
+++ b/openspec/changes/upgrade-qt-6-12/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Upgrade Qt from 6.11.1 to 6.12
+
+**Do not start §2 onward until §0 is answered.** Qt 6.12 drops iOS 17, which removes a device class
+and Jeff's only iOS test device. Everything else is routine.
+
+Qt 6.12 GA is **2026-09-22**. Beta 3 **2026-08-18**, RC **2026-09-08**.
+
+## 0. Decisions required before any work
+
+- [ ] **iOS floor**: pick (a) take iOS 18 everywhere, (b) upgrade all platforms except iOS and hold
+      iOS on 6.11.1, or (c) defer the whole upgrade. Proposal §"iOS 18 is a hard floor" has the
+      trade-offs. Tasks below assume **(a)**; each (b)-divergent task is marked `[(b) differs]`
+- [ ] If (a): decide how iOS gets tested at all — an A12+ iPad is required, since the iPad7,4 cannot
+      install a 6.12 build and the iOS Simulator is unusable on this Mac
+      (`project_qt_ios_simulator_gap`). The Home Screen widget has iOS as its driver, so "we'll test
+      it later" is not an option
+- [ ] **Gerrit 735089 first**: ask for the `AndroidDeadlockProtector` fix to be picked to 6.12 before
+      rebuilding any override. If it lands, `android/qt-overrides/` is deleted outright and §4 shrinks
+      to a deletion. Both a11y patches went upstream through the same account, so this is a
+      reasonable ask — and it is the README's own stated preference over rebuilding
+- [ ] **Canvas Painter Graphs backend**: after installing 6.12, record whether
+      `graphs-2d-high-performance-backend` is ON in the shipped Qt (read
+      `<QtDir>/lib/cmake/Qt6Graphs/*Config*.cmake`, or check whether `Qt6::CanvasPainter` is a link
+      dependency of `Qt6::Graphs`). Default answer to "should we build qtgraphs from source to get
+      it" is **no**; record the finding so `charts-qt-6-12-polish` §3 can act on it either way
+
+## 1. Prerequisites
+
+- [ ] Install Qt 6.12 on Jeff's Mac (macOS + iOS targets) via Qt Maintenance Tool, including **Qt
+      Canvas Painter** and **Qt Graphs**
+- [ ] Install Qt 6.12 on the Windows dev machine (MSVC 2022 x64), same addons
+- [ ] Create the Qt Creator kits. Put `-DDECENZA_MACOS_CODESIGN_IDENTITY=DFA23C5D…` in the kit's
+      **Initial Configuration**, not just the cache — a new Qt means a fresh build directory, and
+      Initial Configuration is the only place that survives a cache wipe (`CLAUDE.local.md`). Without
+      it, macOS silently blocks LAN traffic and the WiFi scale "breaks"
+- [ ] Confirm the `cmake` each toolchain actually invokes is **≥ 3.25** (Qt 6.12 requires ≥ 3.16 in
+      `cmake_minimum_required` — ours says 3.21, still fine — but recommends 3.25 for the configuring
+      tool). Qt ships one at `~/Qt/Tools/CMake/CMake.app/Contents/bin`
+- [ ] Verify Qt 6.12 is installable through `install-qt-action`/aqtinstall at all before touching
+      seven workflows: dry-run one workflow via `workflow_dispatch` on the branch
+
+## 2. Source changes
+
+- [ ] `CMakeLists.txt`:
+  - [ ] iOS `CMAKE_OSX_DEPLOYMENT_TARGET "17.0"` → `"18.0"` (line ≈160) and update its comment to say
+        Qt 6.12 requires iOS 18 `[(b) differs: keep 17.0 while iOS stays on 6.11.1]`
+  - [ ] After the first configure, check for new `QTP` policy warnings and set any new ones NEW inside
+        the existing `Qt6_VERSION VERSION_GREATER_EQUAL "6.5.0"` guard (≈:129-132). Zero policy
+        warnings is a `build-config` spec requirement, so this is not optional
+  - [ ] Confirm `QT_ANDROID_COMPILE_SDK_VERSION "android-35"` (≈:1128) is still what 6.12 wants;
+        `ANDROID_MIN_SDK_VERSION 28` is unchanged in 6.12 (API 28-36 supported)
+- [ ] `CLAUDE.md`: Qt version, `C:/Qt/6.11.1/msvc2022_64`, `~/Qt/6.11.1/Src` (both the path and the
+      "read it instead of guessing" instruction), and any build command quoting a 6.11.1 path
+- [ ] `README.md`: Qt badge → 6.12+, install-step minimum → 6.12
+- [ ] `openspec/config.yaml`: tech-stack line `Qt 6.11.1` → `Qt 6.12`
+- [ ] `docs/CLAUDE_MD/PLATFORM_BUILD.md`, `docs/CLAUDE_MD/TESTING.md`, `docs/IOS_CI_SETUP.md`,
+      `docs/IOS_CI_FOR_CLAUDE.md`: Qt version and example build-directory names
+      (`build/Qt_6_11_1_for_macOS_Debug` → 6.12)
+- [ ] `docs/CLAUDE_MD/BUILD_PERFORMANCE.md`: if its measurements were taken on 6.11.1, either
+      re-measure or label them as 6.11.1 numbers rather than leaving them to be read as current
+- [ ] Tell Jeff to update `CLAUDE.local.md` build-dir paths himself (uncommitted, his file)
+
+## 3. CI workflows (7 files)
+
+- [ ] `windows-release.yml`: `version: '6.11.1'` → 6.12; sccache key
+      `sccache-windows-x64-qt6.11.1-vs2026` → `…-qt6.12.x-vs2026`; **re-test the `aqtsource` pin**
+      (≈:80-85, `TODO(qt-6.11)`) against PyPI-head aqtinstall on 6.12 and drop it if it works
+- [ ] `macos-release.yml`: version bump
+- [ ] `ios-release.yml`: version bump; re-check whether the Xcode 26.4.1 pin is still needed for
+      6.12's prebuilt iOS binaries (Qt 6.12 requires Xcode 16+, which it satisfies either way)
+      `[(b) differs: this file stays on 6.11.1 entirely]`
+- [ ] `android-release.yml`: `env.QT_VERSION` bump; **`java-version: '17'` → `'21'`** (≈:69 — Qt 6.12
+      requires JDK 21); confirm the derived `QT_NDK_VERSION` (≈:88-97) resolves to r27c
+      `27.2.12479018`, the same revision 6.11.1 used
+- [ ] `linux-release.yml`, `linux-arm64-release.yml`: version bump
+- [ ] `nightly-sanitizers.yml`: version bump (easy to miss — it is not one of the six platform
+      workflows)
+- [ ] Module lists need **no** change: `qtcanvaspainter` is already in all seven and remains a module
+      in 6.12
+- [ ] Trigger all seven via `workflow_dispatch` on the branch and confirm green before merge
+
+## 4. Android platform overrides
+
+Depends on the §0 Gerrit-735089 answer.
+
+**If 735089 is picked to 6.12** — delete the whole mechanism:
+- [ ] `git rm -r android/qt-overrides/`
+- [ ] Remove the override + validation step from `android-release.yml` (≈:190-215)
+- [ ] Note in the PR that three upstream bugs closed and the patch mechanism is gone
+
+**If not** — shrink it to the crash patch only:
+- [ ] Rebase `358540b2` (crash fix) from `skialpine/qtbase` onto the qtbase 6.12 tag; **drop the 12
+      a11y commits** — QTBUG-118858 and QTBUG-145786 are upstream on 6.12 (`505853d02184`,
+      `41e6aecb7cd3`)
+- [ ] Rebuild `libplugins_platforms_qtforandroid_arm64-v8a.so` via Qt's own `configure` +
+      `cmake --build . --target QAndroidIntegrationPlugin` (never a hand-rolled CMake — a mismatched
+      feature define crashes devices; see the README)
+- [ ] **Delete `android/qt-overrides/Qt6Android.jar`** — it existed only for the a11y Java classes,
+      now stock
+- [ ] Remove the jar handling from `android-release.yml` while keeping the `.so` copy and the
+      `BUILT_AGAINST_QT` guard
+- [ ] Update `BUILT_AGAINST_QT` to the exact 6.12 version **in the same commit as the new binary**
+- [ ] Rewrite `android/qt-overrides/README.md`: three bugs → one, drop the jar section, update the
+      qtbase SHA, and keep the `strings`-based verification recipe (check `[decenza-patch]` present
+      **and** stock `Failed to acquire deadlock protector for %s.` absent)
+- [ ] Verify the guard still fails a mismatched build (temporarily set `BUILT_AGAINST_QT` wrong in a
+      throwaway `workflow_dispatch` run) — it is the only thing standing between a stale plugin and an
+      APK that dies at startup for every user
+
+## 5. Verification
+
+- [ ] Full local suite: `mcp__qtcreator__run_tests` scope `all`, zero failures, zero WARN lines. No
+      CI job builds or tests a PR, so this is the gate
+- [ ] qmllint clean per `QML_GOTCHAS.md` — diff per-file/per-category sets, do not read totals
+- [ ] Build Debug on macOS and confirm ASan/UBSan instrumentation still engages on 6.12
+- [ ] CI test builds of **iOS and Android** specifically: their code is `#ifdef`-guarded and only the
+      tag-push release workflows compile it
+- [ ] `openspec validate --all` passes after the `build-config` delta lands
+
+## 6. On-device verification (Android first — it is the primary platform)
+
+- [ ] **TalkBack**, on the Samsung tablet, with the a11y overrides now stock: typing echo in an
+      editable field (QTBUG-118858) and no keyboard-on-focus trap (QTBUG-145786). These are the two
+      behaviours we shipped patches for; if upstream's version regresses either, that is a blocker
+      and the a11y patches go back
+- [ ] Re-check TalkBack on screens we tuned, for 6.12's *new* a11y behaviour we never had:
+      scrolled-viewport announcements (`0e3e5d8aacb0`, `cbd6b48998ce`), expandable/expanded state
+      (`56ae71c6cb27`), `ButtonDropDown` classname (`a52d5d20893f`)
+- [ ] **BLE scanning on Android**: 6.12 changes scan-record UUID/length parsing and defers
+      `canceled()` to match classic scan. Confirm the DE1 and every scale still appear in discovery,
+      and that our scan-stop path still behaves when it orders on `canceled()`. Use the real machine
+      (`mcp__de1__*`), and remember every operation starts from the GHC button
+      (`project_jeff_de1_has_ghc`)
+- [ ] Pull a full shot end-to-end on Android: graphs render, weight arrives, shot saves, Visualizer
+      upload succeeds
+- [ ] macOS smoke test: simulator extraction end-to-end; `JsCanvasPainterItem` initialises on Metal
+      with no slow-record warnings now that Canvas Painter is out of Technology Preview
+- [ ] WiFi scale on the macOS debug build — proves the re-signing identity took (`codesign -dvvv …
+      | grep TeamIdentifier` → `VDSK39AZYD`)
+- [ ] iOS, if (a): install on an A12+ device, confirm launch, BLE scale, and the Home Screen widget
+      snapshot path
+
+## 7. Follow-ups
+
+- [ ] Update `charts-qt-6-12-polish` `tasks.md`: mark the precondition met, and fill in §3's gate with
+      the §0 Canvas-Painter-backend finding
+- [ ] Open the PR, run `/pr-review-toolkit:review-pr`, then merge with `/merge-pr`
+- [ ] Archive this change as the final commit on the same PR (`feedback_archive_last_commit_on_pr`)

--- a/openspec/changes/upgrade-qt-6-12/tasks.md
+++ b/openspec/changes/upgrade-qt-6-12/tasks.md
@@ -1,19 +1,21 @@
 # Tasks: Upgrade Qt from 6.11.1 to 6.12
 
-**Do not start §2 onward until §0 is answered.** Qt 6.12 drops iOS 17, which removes a device class
-and Jeff's only iOS test device. Everything else is routine.
+Work starts at Qt 6.12 GA (**2026-09-22**; Beta 3 **2026-08-18**, RC **2026-09-08**). Nothing here is
+blocked.
 
-Qt 6.12 GA is **2026-09-22**. Beta 3 **2026-08-18**, RC **2026-09-08**.
+## 0. Decisions
 
-## 0. Decisions required before any work
-
-- [ ] **iOS floor**: pick (a) take iOS 18 everywhere, (b) upgrade all platforms except iOS and hold
-      iOS on 6.11.1, or (c) defer the whole upgrade. Proposal §"iOS 18 is a hard floor" has the
-      trade-offs. Tasks below assume **(a)**; each (b)-divergent task is marked `[(b) differs]`
-- [ ] If (a): decide how iOS gets tested at all — an A12+ iPad is required, since the iPad7,4 cannot
-      install a 6.12 build and the iOS Simulator is unusable on this Mac
-      (`project_qt_ios_simulator_gap`). The Home Screen widget has iOS as its driver, so "we'll test
-      it later" is not an option
+- [x] **iOS floor — decided 2026-07-29: take iOS 18, one Qt version on every platform.** Qt 6.12
+      requires iOS 18, so Decenza inherits that floor. Holding iOS on 6.11.1 and deferring the
+      upgrade were both rejected; proposal §"iOS 18 is a hard floor" records why, so they are not
+      re-proposed
+- [ ] **Carries one obligation, tracked in §2**: the release notes must state that the iOS minimum
+      rose *because of the Qt upgrade* — an upstream floor, not a decision to drop anyone — and name
+      the affected devices. Do not ship the upgrade without it
+- [ ] Acquire an **A12+ iPad** for iOS testing. Not a blocker for starting, but the iPad7,4 cannot
+      install a 6.12 build at all and the Simulator is unusable on this Mac
+      (`project_qt_ios_simulator_gap`), so iOS ships untested until this exists. The Home Screen
+      widget has iOS as its driver, which makes "test it later" expensive
 - [ ] **Gerrit 735089 first**: ask for the `AndroidDeadlockProtector` fix to be picked to 6.12 before
       rebuilding any override. If it lands, `android/qt-overrides/` is deleted outright and §4 shrinks
       to a deletion. Both a11y patches went upstream through the same account, so this is a
@@ -43,7 +45,7 @@ Qt 6.12 GA is **2026-09-22**. Beta 3 **2026-08-18**, RC **2026-09-08**.
 
 - [ ] `CMakeLists.txt`:
   - [ ] iOS `CMAKE_OSX_DEPLOYMENT_TARGET "17.0"` → `"18.0"` (line ≈160) and update its comment to say
-        Qt 6.12 requires iOS 18 `[(b) differs: keep 17.0 while iOS stays on 6.11.1]`
+        Qt 6.12 requires iOS 18
   - [ ] After the first configure, check for new `QTP` policy warnings and set any new ones NEW inside
         the existing `Qt6_VERSION VERSION_GREATER_EQUAL "6.5.0"` guard (≈:129-132). Zero policy
         warnings is a `build-config` spec requirement, so this is not optional
@@ -59,6 +61,17 @@ Qt 6.12 GA is **2026-09-22**. Beta 3 **2026-08-18**, RC **2026-09-08**.
 - [ ] `docs/CLAUDE_MD/BUILD_PERFORMANCE.md`: if its measurements were taken on 6.11.1, either
       re-measure or label them as 6.11.1 numbers rather than leaving them to be read as current
 - [ ] Tell Jeff to update `CLAUDE.local.md` build-dir paths himself (uncommitted, his file)
+- [ ] **Release notes — the §0 obligation.** State that iOS now requires **iOS 18 or newer**, that the
+      cause is the **Qt 6.12 framework upgrade** (Qt dropped iOS 17 support; every Qt app on 6.12
+      inherits the same floor), and name the devices that cannot go to iOS 18 (pre-A12: iPad Pro
+      1st/2nd gen, iPad 6th gen, iPhone X and earlier). Factual and short — the cause is external, so
+      say so without apologising or padding. An iOS 17 user who stops seeing updates should be able to
+      find this line and understand it. Android, desktop and Linux users are unaffected; say that too,
+      so nobody reads a platform floor as an app-wide one
+- [ ] Check whether the wiki manual states a minimum iOS version anywhere
+      (https://github.com/Kulitorum/Decenza/wiki/Manual — separate repo, `Kulitorum/Decenza.wiki.git`).
+      If it does, update it in the same change; per `project_wiki_edits_held_for_release`, ask before
+      pushing the wiki edit
 
 ## 3. CI workflows (7 files)
 
@@ -68,7 +81,6 @@ Qt 6.12 GA is **2026-09-22**. Beta 3 **2026-08-18**, RC **2026-09-08**.
 - [ ] `macos-release.yml`: version bump
 - [ ] `ios-release.yml`: version bump; re-check whether the Xcode 26.4.1 pin is still needed for
       6.12's prebuilt iOS binaries (Qt 6.12 requires Xcode 16+, which it satisfies either way)
-      `[(b) differs: this file stays on 6.11.1 entirely]`
 - [ ] `android-release.yml`: `env.QT_VERSION` bump; **`java-version: '17'` → `'21'`** (≈:69 — Qt 6.12
       requires JDK 21); confirm the derived `QT_NDK_VERSION` (≈:88-97) resolves to r27c
       `27.2.12479018`, the same revision 6.11.1 used


### PR DESCRIPTION
Creates the `upgrade-qt-6-12` change — the precondition every item in `charts-qt-6-12-polish` waits on. Qt 6.12 GA is **2026-09-22** and its branch is feature-frozen, so the delta was verified against `qt/qtbase` and `qt/qtgraphs` at `ref=6.12` rather than guessed from roadmaps. Docs-only.

**The change is marked BLOCKED on a product decision**, because one finding is not a build detail.

## Qt 6.12 drops iOS 17

Qt 6.12's iOS page: **"iOS 18 or higher (including iOS 26)"**, **"Xcode 16 (iOS 18 SDK) or higher"**. Qt 6.11 was iOS 17. So:

- `CMakeLists.txt:160` must go from `CMAKE_OSX_DEPLOYMENT_TARGET "17.0"` to `"18.0"`.
- **The iPad7,4 used for iOS testing here cannot run iPadOS 18 at all** (A10X; iPadOS 18 needs A12+). The `devicectl install` deploy path stops working, and the iOS Simulator is not an option on this Mac.
- Existing iOS 17 users stop being offered updates.
- macOS minimum also rises to 14.4.

The proposal lays out three options — take iOS 18, hold iOS on 6.11.1 while everything else moves, or defer the upgrade — and is written for the first, with each divergent task marked `[(b) differs]`. Nothing else in the change depends on which is chosen. **This needs your call before work starts.**

## The Android accessibility overrides mostly go away — but not the crash patch

Verified on the **`6.12` branch**, not `dev` and not a changelog:

| Bug | On 6.12? | Evidence |
|---|---|---|
| QTBUG-145786 keyboard opens on a11y focus | **Yes** | `41e6aecb7cd3` (2026-06-23); dev commit carries `Pick-to: 6.12 6.11` |
| QTBUG-118858 typed characters not spoken | **Yes** | `505853d02184` (2026-07-16), touching **both** the platform plugin and the jar — the same two artifacts we patch |
| QTBUG-140490 / QTBUG-144207 `AndroidDeadlockProtector` abort | **No** | `qandroidplatformopenglwindow.cpp:68` on `6.12` still reads `qFatal("Failed to acquire deadlock protector for %s.", …)`. Gerrit 735089 has no `Pick-to:` footer, so it targets `dev` = 6.13 |

So: **delete the `Qt6Android.jar` override outright** (it existed only for the a11y Java classes), and rebuild the `.so` from 6.12 carrying the crash patch alone — dropping the 12 a11y commits. The tasks first try the better outcome: ask for 735089 to be picked to 6.12, in which case `android/qt-overrides/` is deleted entirely, which is the README's own stated preference over rebuilding. The crash is worth the remaining patch: 9 of 42 Android reports since 2026-01-18, and 2 of 2 on 6.11.1 builds.

The tasks also require verifying both TalkBack behaviours on device *after* going stock — an upstream regression restores the patch — plus re-checking 6.12's new a11y behaviour we never had (scrolled-viewport announcements, expandable state, `ButtonDropDown` classname).

## Also captured

- **JDK 17 → 21** (`android-release.yml:69`) — a 6.12 requirement.
- **`nightly-sanitizers.yml`** is a 7th workflow to bump; "the six platform workflows" misses it.
- Re-test the Windows `aqtsource` pin (`TODO(qt-6.11)`) against 6.12 and drop it if PyPI head works.
- **Qt Bluetooth**: no new API, but 6.12 changes Android scan-record UUID/length parsing and defers `canceled()` to match classic scan — our scan-stop path orders on that signal, so on-device discovery verification is a task, not an assumption. Nothing about CCCD, so the native-CoreBluetooth iOS scale transport still can't be retired.
- Record whether the shipped Qt has `graphs-2d-high-performance-backend` compiled in, which is what `charts-qt-6-12-polish` §3 is gated on. Default answer to "build qtgraphs from source for it" is no.
- MQTT is unaffected — Decenza uses Eclipse Paho C, and Qt ships no open-source `qtmqtt` binaries anyway.
- CMake: our `cmake_minimum_required(VERSION 3.21)` stays valid (6.12 needs ≥3.16 there), but 3.25 is the recommended *configuring tool* version — a task confirms what each toolchain actually invokes.

## build-config delta

`RENAMED` the framework requirement to Qt 6.12, `MODIFIED` it (adding a scenario for the Android JDK/NDK toolchain and one for `nightly-sanitizers.yml`), `MODIFIED` the iOS deployment target to 18.0 with a scenario saying a green iOS build proves compilation and not device coverage, and `ADDED` **Patched Qt Platform Artifacts Are Version-Locked**: fail the build on a `BUILT_AGAINST_QT` mismatch rather than falling back to stock, delete rather than rebuild when upstream fixes a bug, justify that deletion from the release branch rather than `dev`, and verify the behaviour on device after dropping a patch.

`openspec validate --all` → **136 passed, 0 failed**.

## One incidental fix

`.gitignore`'s unanchored `build-*/` also matched `openspec/**/specs/build-config/`, so `git add` of a change directory **silently skipped its build-config delta spec** — which is how this PR nearly shipped without its spec file. The pattern protected nothing (the only `build-*` directories in the tree are those three spec dirs), so it is now anchored to the repo root as `/build-*/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)