### PR TITLE
Guard GHCSimulator by name too, cap spike-rejection runs, collapse three periodic log lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -857,6 +857,7 @@ set(HEADERS
     src/core/widgetlibrary.h
     src/core/batterymanager.h
     src/core/memorymonitor.h
+    src/core/logcollapse.h
     src/core/sanitizers.h
     src/core/accessibilitymanager.h
     src/core/autowakemanager.h

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -847,25 +847,36 @@ ApplicationWindow {
         function onScaleMultiplierChanged() { root.updateScale() }
         function onPageScaleMultiplierChanged() { root.updateScale() }
     }
-    // Raise all application windows together when this window is activated.
+    // GHCSimulator has TWO independent ways of not being usable, and a guard for one does not
+    // cover the other. Both are live configurations, so both tests are required:
     //
-    // Guard the MEMBER, not the name. `typeof GHCSimulator !== "undefined" && GHCSimulator` looks
-    // equivalent and is not: the type is registered wherever DECENZA_SIMULATOR is defined, but the
-    // instance exists only on a debug Windows/macOS build, and a registered-but-uninstanced
-    // singleton resolves to a TRUTHY wrapper whose member reads come back undefined. That guard
-    // therefore passed on Linux, on Windows/macOS Release and on Android/iOS Debug, and the call
-    // below threw a TypeError on every window activation. See decenzaOptionalSingleton() in
-    // src/core/contextsingletons_qml.h for the Qt sources.
+    //   1. The TYPE is absent. Registration is inside `#ifdef DECENZA_SIMULATOR`
+    //      (src/core/contextsingletons_qml.h), which a production Android/iOS build does not
+    //      define — so the name resolves to nothing and reading a member off it throws
+    //      `ReferenceError: GHCSimulator is not defined`. Only `typeof` survives this: an
+    //      unresolvable identifier makes V4 clear the exception and answer "undefined"
+    //      (qtdeclarative/src/qml/jsruntime/qv4runtime.cpp:1746-1754, Runtime::TypeofName::call).
+    //   2. The type is registered but the INSTANCE is null — Linux any config, Windows/macOS
+    //      Release, Android/iOS Debug. Here the name is a TRUTHY wrapper and only member reads
+    //      come back undefined, so `typeof` alone passes and the call throws a TypeError. See
+    //      decenzaOptionalSingleton() in src/core/contextsingletons_qml.h for the Qt sources.
+    //
+    // The member-only guard shipped in 2.0.1 and threw case 1 three times on every tablet
+    // launch (two ReferenceErrors plus a dead Connections whose target never resolved). One
+    // property, so the two call sites below cannot drift apart again.
+    readonly property bool ghcSimulatorLive: typeof GHCSimulator !== "undefined"
+                                             && GHCSimulator.mainWindowActivated !== undefined
+
+    // Raise all application windows together when this window is activated.
     onActiveChanged: {
-        if (active && GHCSimulator.mainWindowActivated !== undefined) {
+        if (active && root.ghcSimulatorLive) {
             GHCSimulator.mainWindowActivated()
         }
     }
 
     // Listen for GHC window activation to raise ourselves (simulator mode only).
-    // Same rule: a truthy-but-empty wrapper is not a valid Connections target.
     Connections {
-        target: GHCSimulator.mainWindowActivated !== undefined ? GHCSimulator : null
+        target: root.ghcSimulatorLive ? GHCSimulator : null
         function onRaiseMainWindow() {
             root.raise()
         }

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -678,10 +678,16 @@ void DE1Device::parseWaterLevel(const QByteArray& data) {
     // Only emit when water level changes by at least 0.5% or ml changes
     if (qAbs(m_waterLevel - m_lastEmittedWaterLevel) >= 0.5
         || m_waterLevelMl != m_lastEmittedWaterLevelMl) {
-        WATER_LOG(QStringLiteral("raw=%1 mm displayed=%2 mm %3 ml")
-                      .arg(rawMm, 0, 'f', 1)
-                      .arg(m_waterLevelMm, 0, 'f', 1)
-                      .arg(m_waterLevelMl));
+        // Log on a coarser gate than the emit — see m_lastLoggedWaterLevelMm. 2 mm is above the
+        // sensor's idle dither and below anything a person would call a change in level: a refill,
+        // a shot's worth of draw, or the tank running down all clear it within a line or two.
+        if (qAbs(m_waterLevelMm - m_lastLoggedWaterLevelMm) >= WATER_LEVEL_LOG_HYSTERESIS_MM) {
+            WATER_LOG(QStringLiteral("raw=%1 mm displayed=%2 mm %3 ml")
+                          .arg(rawMm, 0, 'f', 1)
+                          .arg(m_waterLevelMm, 0, 'f', 1)
+                          .arg(m_waterLevelMl));
+            m_lastLoggedWaterLevelMm = m_waterLevelMm;
+        }
         m_lastEmittedWaterLevel = m_waterLevel;
         m_lastEmittedWaterLevelMl = m_waterLevelMl;
         emit waterLevelChanged();
@@ -1571,11 +1577,24 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
     } else {
         tag = QStringLiteral("keepalive");
     }
-    MMR_LOG(QStringLiteral("%1: 0x%2 = %3%4")
-                .arg(tag)
-                .arg(address, 6, 16, QLatin1Char('0'))
-                .arg(value)
-                .arg(reasonSuffix));
+    const QString msg = QStringLiteral("%1: 0x%2 = %3%4")
+        .arg(tag)
+        .arg(address, 6, 16, QLatin1Char('0'))
+        .arg(value)
+        .arg(reasonSuffix);
+
+    // Only the keepalive tag is collapsed. "write" is by definition a value that changed and
+    // "retry-write" means something already went wrong — both are rare and both are the lines a
+    // wedge investigation reads (#1309), so they always print. The keepalive is the one that says
+    // the same thing every minute for as long as the app runs.
+    if (tag == QLatin1String("keepalive")) {
+        int suppressed = 0;
+        const QString key = QString::number(address, 16);
+        if (m_keepaliveLog.shouldLog(key, msg, QDateTime::currentMSecsSinceEpoch(), &suppressed))
+            MMR_LOG(msg + m_keepaliveLog.suffix(suppressed));
+    } else {
+        MMR_LOG(msg);
+    }
 
     m_lastMMRValues.insert(address, value);
     m_transport->write(DE1::Characteristic::WRITE_TO_MMR, buildMMRPayload(address, value));

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -13,6 +13,7 @@
 #include <QString>
 #include <QTimer>
 
+#include "../core/logcollapse.h"
 #include "protocol/de1characteristics.h"
 
 // High-priority custom event posted by WeightProcessor to bypass the normal
@@ -474,6 +475,12 @@ private:
     // changes fan out into the same MMR). Cleared on transport disconnect so
     // a reconnect re-writes real values rather than trusting stale ones.
     QHash<uint32_t, uint32_t> m_lastMMRValues;
+    // Keepalive writes re-assert an unchanged value every 60 s forever (BatteryManager's USB-charger
+    // refresh — the DE1 auto-disables the port after 10 minutes, so the re-assert is load-bearing
+    // and cannot be dropped). Its LOG line, repeated 3,042 times in a 48-hour capture for 15% of the
+    // whole log, can be. One line per 10 minutes carrying the count; a value CHANGE still prints
+    // immediately, because that is the event worth seeing.
+    LogCollapse m_keepaliveLog{10 * 60 * 1000};
     // Pending writeMMRVerified() entries keyed by address. Each tracks the
     // expected value and remaining retry budget; cleared when a read-back
     // matches or retries are exhausted, and on transport disconnect.
@@ -508,6 +515,14 @@ private:
     int m_waterLevelMl = 0;       // Volume in ml (from CAD lookup table)
     double m_lastEmittedWaterLevel = -1.0;  // Throttle: only emit when change >= 0.5%
     int m_lastEmittedWaterLevelMl = -1;    // Throttle: also emit when ml changes (color thresholds)
+    // Last water level LOGGED, which is not the last one EMITTED. The signal has to follow the
+    // sensor closely (the refill warning and the tank colour band key off it), but the sensor
+    // dithers roughly +/-1 mm continuously and each 1 mm step is a ~28 ml step in the CAD table, so
+    // "changed" is true about twice a second forever: 2,828 log lines in a 48-hour capture, 14% of
+    // the whole log, describing a tank nobody touched. Logging gets its own hysteresis; emitting
+    // keeps the old behaviour.
+    double m_lastLoggedWaterLevelMm = -1000.0;
+    static constexpr double WATER_LEVEL_LOG_HYSTERESIS_MM = 2.0;
     QString m_firmwareVersion;
     int m_firmwareBuildNumber = 0;
     int m_machineModel = 0;

--- a/src/core/logcollapse.h
+++ b/src/core/logcollapse.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+
+// Collapses a repeating log line to one entry per window, carrying the count of what it stood in
+// for.
+//
+// WHY THIS EXISTS AS ONE CLASS
+// ----------------------------
+// Three unrelated periodic sources — the MMR USB-charger keepalive (60 s), the memory sampler
+// (60 s) and the ShotServer request log (a 5 s browser poll) — each wanted the same behaviour, and
+// each was about to grow its own copy of it. In a 48-hour tablet capture they were 3,147 + 3,107 +
+// 954 lines, 35% of the entire log, and every line was near-identical to the one before it. A
+// fourth copy of "remember the last text, count repeats, print a summary" is exactly the drift the
+// centralize rule in CLAUDE.md is about, so it lives here and they call it.
+//
+// It is deliberately NOT a general log filter and NOT tied to a category: callers keep their own
+// qDebug()/qWarning() and their own wording. All this decides is whether to speak.
+//
+// NO TIMERS
+// ---------
+// The window is checked against the message's own arrival, not driven by a QTimer — a suppressed
+// run is flushed by the next message in that run, not by a clock. That keeps this a pure decision
+// function with no ownership, no thread affinity and nothing to stop, and it is why a source that
+// falls silent mid-window simply stops: its last suppressed count is folded into the next line it
+// does emit. For a periodic source (which is all three callers) the difference is one line at the
+// end of the run, and in exchange there is no timer to leak or fire after teardown.
+class LogCollapse
+{
+public:
+    // `windowMs` is the minimum spacing between emitted lines for a given key while the text is
+    // unchanged. A CHANGED text always emits immediately regardless of the window — a value that
+    // moved is the interesting event, and holding it back is how a collapser turns into a bug.
+    explicit LogCollapse(qint64 windowMs) : m_windowMs(windowMs) {}
+
+    // Returns true when the caller should log, and sets `suppressed` to how many identical lines
+    // were swallowed since the last emit (0 on the first line, or when the text changed).
+    //
+    // `nowMs` is passed in rather than read from a clock so the caller can reuse a timestamp it
+    // already has, and so this is testable without waiting.
+    bool shouldLog(const QString& key, const QString& text, qint64 nowMs, int* suppressed)
+    {
+        Entry& e = m_entries[key];
+        const bool changed = (e.text != text);
+        const bool windowElapsed = (nowMs - e.lastEmitMs) >= m_windowMs;
+
+        if (!e.everEmitted || changed || windowElapsed) {
+            if (suppressed)
+                *suppressed = e.suppressed;
+            e.text = text;
+            e.lastEmitMs = nowMs;
+            e.suppressed = 0;
+            e.everEmitted = true;
+            return true;
+        }
+
+        e.suppressed++;
+        if (suppressed)
+            *suppressed = 0;
+        return false;
+    }
+
+    // Convenience for the common shape: " (+N identical in the last M s)" or an empty string.
+    // Centralized so the three callers cannot word the same annotation three ways — which is what
+    // happened to the [USB Scale] prefix (73 hand-written sites, 21 of them drifted).
+    static QString suffix(int suppressed, qint64 windowMs)
+    {
+        if (suppressed <= 0)
+            return QString();
+        return QStringLiteral(" (+%1 identical in the last %2 s)")
+            .arg(suppressed)
+            .arg(windowMs / 1000);
+    }
+
+    QString suffix(int suppressed) const { return suffix(suppressed, m_windowMs); }
+
+private:
+    struct Entry
+    {
+        QString text;
+        qint64 lastEmitMs = 0;
+        int suppressed = 0;
+        bool everEmitted = false;
+    };
+
+    qint64 m_windowMs;
+    QHash<QString, Entry> m_entries;
+};

--- a/src/core/memorymonitor.cpp
+++ b/src/core/memorymonitor.cpp
@@ -54,7 +54,8 @@ void MemoryMonitor::onSampleTimerTick()
         m_firstSample = false;
     }
 
-    if (rss > m_peakRss)
+    const bool newPeak = (rss > m_peakRss);
+    if (newPeak)
         m_peakRss = rss;
 
     MemorySample sample;
@@ -69,8 +70,26 @@ void MemoryMonitor::onSampleTimerTick()
     double rssMB = rss / (1024.0 * 1024.0);
     double peakMB = m_peakRss / (1024.0 * 1024.0);
 
+    // Sampling stays at 60 s — the ring buffer behind getMemorySummary() is what makes a leak
+    // visible after the fact, and coarsening it would blunt exactly the thing this class is for.
+    // The LOG line is what gets collapsed: 3,107 lines in a 48-hour capture, 15% of the whole log,
+    // and for 16 of those hours it reported the same plateau over and over (RSS drifting inside a
+    // 5 MB band, QObjects pinned at 9,605).
+    //
+    // The gate text is QUANTIZED rather than the message itself, because the message never repeats
+    // byte-for-byte — RSS moves 0.1 MB between any two samples. Bucketing to 5 MB of RSS and 25
+    // QObjects means "same plateau" collapses while a real step change prints at once. A new peak
+    // always prints: it is the one sample that cannot be reconstructed from a later line.
+    const QString gate = QStringLiteral("rss%1|obj%2")
+                             .arg(static_cast<int>(rssMB / 5.0))
+                             .arg(objCount / 25);
+    int suppressed = 0;
+    const bool speak = m_logCollapse.shouldLog(QStringLiteral("sample"), gate,
+                                               sample.timestampMs, &suppressed)
+                       || newPeak;
+    if (speak) {
+        const QByteArray tail = m_logCollapse.suffix(suppressed).toUtf8();
 #ifdef Q_OS_ANDROID
-    {
         QJniObject runtime = QJniObject::callStaticObjectMethod(
             "java/lang/Runtime", "getRuntime", "()Ljava/lang/Runtime;");
         if (runtime.isValid()) {
@@ -79,15 +98,17 @@ void MemoryMonitor::onSampleTimerTick()
             jlong max   = runtime.callMethod<jlong>("maxMemory");
             double javaUsedMB = (total - free) / (1024.0 * 1024.0);
             double javaMaxMB  = max / (1024.0 * 1024.0);
-            qDebug("[Memory] RSS: %.1f MB  Java heap: %.1f / %.1f MB  QObjects: %d  peak: %.1f MB",
-                   rssMB, javaUsedMB, javaMaxMB, objCount, peakMB);
+            qDebug("[Memory] RSS: %.1f MB  Java heap: %.1f / %.1f MB  QObjects: %d  peak: %.1f MB%s",
+                   rssMB, javaUsedMB, javaMaxMB, objCount, peakMB, tail.constData());
         } else {
-            qDebug("[Memory] RSS: %.1f MB, QObjects: %d, peak: %.1f MB", rssMB, objCount, peakMB);
+            qDebug("[Memory] RSS: %.1f MB, QObjects: %d, peak: %.1f MB%s", rssMB, objCount, peakMB,
+                   tail.constData());
         }
-    }
 #else
-    qDebug("[Memory] RSS: %.1f MB, QObjects: %d, peak: %.1f MB", rssMB, objCount, peakMB);
+        qDebug("[Memory] RSS: %.1f MB, QObjects: %d, peak: %.1f MB%s", rssMB, objCount, peakMB,
+               tail.constData());
 #endif
+    }
 
     emit sampleTaken();
 

--- a/src/core/memorymonitor.h
+++ b/src/core/memorymonitor.h
@@ -9,6 +9,8 @@
 #include <QJsonArray>
 #include <QElapsedTimer>
 
+#include "logcollapse.h"
+
 class QQmlApplicationEngine;
 
 struct MemorySample {
@@ -72,6 +74,10 @@ private:
     quint64 m_startupRss = 0;
     int m_lastQObjectCount = 0;
     bool m_firstSample = true;
+
+    // Collapses the per-sample log line while a plateau holds — see onSampleTimerTick(). Sampling
+    // itself is untouched; this only decides whether the sample is worth a line.
+    LogCollapse m_logCollapse{10 * 60 * 1000};
 
     // Per-class QObject tracking
     QHash<QString, int> m_classCounts;          // Current snapshot

--- a/src/models/shotdatamodel.cpp
+++ b/src/models/shotdatamodel.cpp
@@ -131,6 +131,7 @@ void ShotDataModel::clear() {
     m_cumulativeWeightPoints.clear();
     m_weightFlowRatePoints.clear();
     m_weightFlowRateRawPoints.clear();
+    m_consecutiveSpikeRejections = 0;
 
     // Reset goal segments - keep first segment with capacity
     m_pressureGoalSegments.clear();
@@ -194,6 +195,8 @@ void ShotDataModel::clearWeightData() {
     if (m_fastWeightFlow) m_fastWeightFlow->clear();
     m_lastFlushedWeight = 0;
     m_lastFlushedWeightFlow = 0;
+    // The anchor these counted against is gone, so a run in progress no longer means anything.
+    m_consecutiveSpikeRejections = 0;
     qDebug() << "ShotDataModel: Cleared pre-tare weight data";
 }
 
@@ -301,6 +304,22 @@ void ShotDataModel::addWeightSample(double time, double weight) {
 
     // Spike filtering: reject readings that jump unrealistically from the last value
     // Max reasonable flow is ~5g/s, so anything faster is likely a scale glitch
+    //
+    // The comparison anchor is the last ACCEPTED point, which is only meaningful for an isolated
+    // glitch. A sustained move — cup nudged, second vessel set down, a real fast pour — fails the
+    // test on its first sample and then keeps failing, because every later sample is still measured
+    // against the pre-move anchor while the true weight walks further away. The filter recovers
+    // only by accident, once deltaTime has grown enough to dilute the rate below the threshold.
+    //
+    // A 2026-07-29 shot log shows the cost: 30 consecutive rejections over 2.0 s, all measured
+    // against a frozen 39.94 g while the scale climbed to 61.68 g. The weight series had a 2-second,
+    // 21-gram hole in it and the log had 30 near-identical WARN lines.
+    //
+    // So: cap the run. After kMaxConsecutiveRejections the move is no longer treated as a glitch —
+    // a glitch does not persist across four samples — and the sample is accepted, which re-anchors
+    // the filter on reality. Report once at the start of a run and once when it ends, never per
+    // sample.
+    constexpr int kMaxConsecutiveRejections = 3;
     if (!m_weightPoints.isEmpty()) {
         double lastWeight = m_weightPoints.last().y();
         double lastTime = m_weightPoints.last().x();
@@ -311,15 +330,31 @@ void ShotDataModel::addWeightSample(double time, double weight) {
         // Minimum deltaTime of 0.05s to avoid division issues
         if (deltaTime > 0.05) {
             double changeRate = deltaWeight / deltaTime;
-            if (changeRate > 10.0) {
-                qWarning() << "ShotDataModel: Rejecting spike - weight:" << weight
-                           << "lastWeight:" << lastWeight
-                           << "deltaWeight:" << deltaWeight
-                           << "deltaTime:" << deltaTime
-                           << "rate:" << changeRate << "g/s";
+            if (changeRate > 10.0 && m_consecutiveSpikeRejections < kMaxConsecutiveRejections) {
+                if (m_consecutiveSpikeRejections == 0) {
+                    m_firstRejectedWeight = weight;
+                    qWarning() << "ShotDataModel: Rejecting spike - weight:" << weight
+                               << "lastWeight:" << lastWeight
+                               << "deltaWeight:" << deltaWeight
+                               << "deltaTime:" << deltaTime
+                               << "rate:" << changeRate << "g/s";
+                }
+                m_consecutiveSpikeRejections++;
                 return;
             }
         }
+    }
+
+    if (m_consecutiveSpikeRejections > 0) {
+        // Either the reading came back into range on its own (an isolated glitch, which is what the
+        // filter is for) or the run hit the cap and this sample is being accepted despite the rate.
+        qWarning() << "ShotDataModel: Spike run ended after" << m_consecutiveSpikeRejections
+                   << "rejected sample(s) - first rejected:" << m_firstRejectedWeight
+                   << "accepting:" << weight
+                   << (m_consecutiveSpikeRejections >= kMaxConsecutiveRejections
+                           ? "(cap reached - treating as a real move, re-anchoring)"
+                           : "(back in range)");
+        m_consecutiveSpikeRejections = 0;
     }
 
     // Store cumulative weight for export (visualizer, shot history)

--- a/src/models/shotdatamodel.h
+++ b/src/models/shotdatamodel.h
@@ -140,6 +140,12 @@ private:
     QVector<QPointF> m_weightFlowRatePoints;  // Flow rate from scale (g/s) - for visualizer export
     QVector<QPointF> m_weightFlowRateRawPoints;  // Raw (pre-smoothing) copy for by_weight_raw export
 
+    // Spike-filter burst state — see addWeightSample(). The filter compares each sample against
+    // the last ACCEPTED point, so a run of rejections keeps measuring against an ever-staler
+    // anchor; these two track the run so it can be broken and reported once instead of per sample.
+    int m_consecutiveSpikeRejections = 0;
+    double m_firstRejectedWeight = 0.0;
+
     // Fast renderers for live data series (QSGGeometryNode, pre-allocated VBO)
     QPointer<FastLineRenderer> m_fastPressure;
     QPointer<FastLineRenderer> m_fastFlow;

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -1118,9 +1118,27 @@ void ShotServer::handleRequest(QTcpSocket* socket, const QByteArray& request)
     QString method = requestLine[0];
     QString path = requestLine[1];
 
-    // Don't log polling requests (too noisy)
-    if (!path.startsWith("/api/debug") && path != "/api/settings/mqtt/status" && path != "/api/telemetry") {
-        qDebug() << "ShotServer:" << method << path;
+    // Two tiers, because "too noisy" covers two different things.
+    //
+    // Tier 1, never logged: endpoints a page polls on a fixed interval purely to refresh a readout.
+    // Nothing about the Nth identical status GET is diagnostic. /api/power/status joined this list
+    // after a 48-hour capture where a 5 s poll from an open page produced 431 log lines — the
+    // single largest entry under this tag — while the hand-maintained list above it happened not to
+    // mention it. A blocklist only suppresses what somebody remembered to add.
+    //
+    // Tier 2, collapsed: everything else. Real navigation and MCP calls stay visible and prompt (a
+    // path not seen in the last minute logs immediately), while a burst of the same request folds
+    // into one line with a count. That is the general rule, so the next endpoint someone polls
+    // costs one line a minute instead of thousands, with no list to update.
+    const bool neverLog = path.startsWith("/api/debug")
+                          || path == "/api/settings/mqtt/status"
+                          || path == "/api/telemetry"
+                          || path == "/api/power/status";
+    if (!neverLog) {
+        const QString line = QStringLiteral("ShotServer: %1 %2").arg(method, path);
+        int suppressed = 0;
+        if (m_requestLog.shouldLog(line, line, QDateTime::currentMSecsSinceEpoch(), &suppressed))
+            qDebug().noquote() << line + m_requestLog.suffix(suppressed);
     }
 
     // Auth middleware: when security is enabled, check session before routing

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -12,6 +12,8 @@
 #include <QSet>
 #include <QFile>
 #include <QJsonObject>
+
+#include "../core/logcollapse.h"
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QDateTime>
@@ -149,6 +151,11 @@ private slots:
     void onThemeChanged();
 
 private:
+    // Collapses repeated identical request lines — see handleRequest(). One minute, not the ten
+    // used by the periodic samplers: a request is user-driven, so a path that has been quiet
+    // should log the moment it comes back.
+    LogCollapse m_requestLog{60 * 1000};
+
     // On Android, Wi-Fi filters incoming UDP broadcast/multicast frames unless
     // the app holds a WifiManager.MulticastLock. Without this, discovery
     // requests silently never reach us. No-op on other platforms.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -951,6 +951,11 @@ else()
     target_link_libraries(tst_difluidr1 PRIVATE OpenSSL::Crypto)
 endif()
 
+# --- tst_logcollapse: the shared repeat-collapsing log gate (header-only, so no extra sources) ---
+add_decenza_test(tst_logcollapse
+    tst_logcollapse.cpp
+)
+
 # --- tst_weightprocessor: WeightProcessor edge cases (LSLR, oscillation, per-frame) ---
 add_decenza_test(tst_weightprocessor
     tst_weightprocessor.cpp

--- a/tests/tst_logcollapse.cpp
+++ b/tests/tst_logcollapse.cpp
@@ -1,0 +1,95 @@
+#include <QtTest>
+
+#include "core/logcollapse.h"
+
+// LogCollapse decides whether a repeating log line is worth printing. Three periodic sources share
+// it (the MMR keepalive, the memory sampler, the ShotServer request log), which is exactly why the
+// rules are pinned here: a change that makes it slightly more eager to suppress would go unnoticed
+// in the app and quietly cost the next log reader the line they needed.
+//
+// The clock is a parameter, not a QElapsedTimer, so every case below is exact and instant.
+class tst_LogCollapse : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    // First sight of a key always speaks, with nothing attributed to it.
+    void firstCallAlwaysLogs()
+    {
+        LogCollapse c(60'000);
+        int suppressed = -1;
+        QVERIFY(c.shouldLog("k", "text", 0, &suppressed));
+        QCOMPARE(suppressed, 0);
+    }
+
+    // The whole point: identical repeats inside the window stay silent, and the count of what was
+    // swallowed rides along on the next line that does print.
+    void identicalRepeatsCollapseAndReportCount()
+    {
+        LogCollapse c(60'000);
+        int suppressed = -1;
+        QVERIFY(c.shouldLog("k", "same", 0, &suppressed));
+
+        for (int i = 1; i <= 5; ++i)
+            QVERIFY(!c.shouldLog("k", "same", i * 1'000, &suppressed));
+
+        // Window elapsed — speaks again, and accounts for the five it stood in for.
+        QVERIFY(c.shouldLog("k", "same", 60'000, &suppressed));
+        QCOMPARE(suppressed, 5);
+
+        // Count resets after being reported, so it is a per-window figure and never cumulative.
+        QVERIFY(!c.shouldLog("k", "same", 61'000, &suppressed));
+        QVERIFY(c.shouldLog("k", "same", 120'000, &suppressed));
+        QCOMPARE(suppressed, 1);
+    }
+
+    // A changed message is the interesting event. Holding it for the rest of the window is the one
+    // failure mode that would make this class harmful rather than merely noisy.
+    void changedTextLogsImmediately()
+    {
+        LogCollapse c(60'000);
+        int suppressed = -1;
+        QVERIFY(c.shouldLog("k", "before", 0, &suppressed));
+        QVERIFY(!c.shouldLog("k", "before", 1'000, &suppressed));
+        QVERIFY(c.shouldLog("k", "after", 2'000, &suppressed));
+        QCOMPARE(suppressed, 1);  // the one silent "before" is still accounted for
+    }
+
+    // Keys are independent: one chatty source must not silence another.
+    void keysAreIndependent()
+    {
+        LogCollapse c(60'000);
+        int suppressed = -1;
+        QVERIFY(c.shouldLog("a", "text", 0, &suppressed));
+        QVERIFY(c.shouldLog("b", "text", 0, &suppressed));
+        QCOMPARE(suppressed, 0);
+        QVERIFY(!c.shouldLog("a", "text", 1'000, &suppressed));
+        QVERIFY(!c.shouldLog("b", "text", 1'000, &suppressed));
+    }
+
+    // The window boundary is inclusive, so a source sampling on exactly the window period (the
+    // memory monitor at 60 s against a 60 s window would be the pathological case) is not held one
+    // extra tick every time.
+    void windowBoundaryIsInclusive()
+    {
+        LogCollapse c(10'000);
+        int suppressed = -1;
+        QVERIFY(c.shouldLog("k", "t", 0, &suppressed));
+        QVERIFY(!c.shouldLog("k", "t", 9'999, &suppressed));
+        QVERIFY(c.shouldLog("k", "t", 10'000, &suppressed));
+    }
+
+    // Suffix wording lives in one place so the callers cannot phrase it three ways.
+    void suffixIsEmptyWhenNothingWasSuppressed()
+    {
+        QCOMPARE(LogCollapse::suffix(0, 60'000), QString());
+        QCOMPARE(LogCollapse::suffix(-1, 60'000), QString());
+        QCOMPARE(LogCollapse::suffix(3, 60'000),
+                 QStringLiteral(" (+3 identical in the last 60 s)"));
+    }
+};
+
+QTEST_MAIN(tst_LogCollapse)
+#include "tst_logcollapse.moc"


### PR DESCRIPTION
Found by reading 48 hours of debug log off the tablet (2.0.1 build 3507, 20,569 lines, **0 ERROR/FATAL**).

> **Not built, not tested.** Qt Creator is pointed at another checkout, so nothing here has been compiled and `tst_logcollapse` has never run. Needs a build before merge.

Scale-subsystem logging is deliberately untouched — that is being handled separately.

## 1. `GHCSimulator is not defined` on every production Android/iOS launch

The guard covered *type registered, instance null*. Production tablets are the other case: registration is inside `#ifdef DECENZA_SIMULATOR`, so the **name** resolves to nothing and reading a member off it throws. Three warnings per launch on the tablet:

```
main.qml:867:5: QML Connections: Detected function "onRaiseMainWindow" in Connections element...
main.qml:860: ReferenceError: GHCSimulator is not defined
main.qml:868: ReferenceError: GHCSimulator is not defined
```

The `Connections` warning is the same defect one step removed: the throwing `target` binding never assigned, leaving `targetSet` false, and an unset target defaults to `parent()` — so it went looking for `onRaiseMainWindow` on the `Window`. With `target` evaluating to a clean `null`, `connectSignals()` returns early and says nothing (`qqmlconnections.cpp:342-344`, `target()` at `:~300`).

Both guards are required; both now live in one `readonly property` so the two call sites cannot drift apart again. `typeof` on an unresolvable name is safe — V4 clears the exception and answers `"undefined"` (`qtdeclarative/src/qml/jsruntime/qv4runtime.cpp:1746-1754`).

## 2. Spike filter froze its own comparison anchor

`ShotDataModel::addWeightSample()` compares against the last **accepted** point, which only works for an isolated glitch. A sustained move fails on its first sample and then keeps failing, because every later sample is still measured against the pre-move anchor. It recovers by accident, once `deltaTime` has grown enough to dilute the rate.

One shot in the log: **30 consecutive rejections over 2.0 s**, all against a frozen `39.94 g` while the scale climbed to `61.68 g` — a 2-second, 21-gram hole in the weight series, and 30 near-identical WARN lines.

Runs are now capped at three (a glitch does not persist across four samples), which re-anchors the filter on reality, and the run is reported once at the start and once at the end.

## 3. Log spam — four sources were 44% of the log

| Lines | Source | Change |
|---|---|---|
| 2,828 (14%) | `[WaterLevel] raw=…` | 2 mm logging hysteresis. The sensor dithers ±1 mm and each 1 mm is a 28 ml step in the CAD table, so "changed" was true twice a second forever. The **signal** still follows the sensor exactly as before — only the log line is gated. |
| 3,042 (15%) | `[MMR] keepalive:` | Collapsed to one line per 10 min with a count. The 60 s re-assert itself is load-bearing (the DE1 auto-disables the port after 10 min) and is untouched; `write` and `retry-write` still always print, since those are the lines a wedge investigation reads (#1309). |
| 3,107 (15%) | `[Memory] RSS:` | Collapsed while a plateau holds. Sampling stays at 60 s — the ring buffer is what makes a leak visible. Gated on a *quantized* text (5 MB RSS / 25 QObjects) because the line never repeats byte-for-byte; a new peak always prints. |
| 954 | `ShotServer: "GET" …` | `/api/power/status` joins the never-logged list (431 lines from a 5 s poll — the largest single entry, and the hand-maintained blocklist above it simply never mentioned it). Everything else collapses at 60 s, so the next polled endpoint costs one line a minute with no list to update. |

All three collapsing sources share one header, `src/core/logcollapse.h`, rather than growing three copies of "remember the last text, count repeats, print a summary" — the centralize rule in CLAUDE.md, which the `[USB Scale]` prefix (73 hand-written sites, 21 drifted) is the cautionary tale for. No timers: the window is checked against the message's own arrival, so there is nothing to own, stop, or leak.

`tests/tst_logcollapse.cpp` pins the rules that matter — repeats collapse and report a per-window count, a **changed** message always prints immediately, keys are independent, the boundary is inclusive.

## Not addressed here
- Scale-subsystem logging (3,418 lines, 1,147 of them the pre-#1700 duplicate mirror) — separate work.
- Low scale battery has no proactive surface at all — design notes below, to be built as its own change.
- RSS steps 130 MB → ~275 MB after a session of UI use and stays there for 16 h, peak 566 MB, with QObjects flat at 9,605 — native retention, not a QObject leak. Watch item, no change made.

## Scale battery: design notes for the follow-up change

Recorded here so the reasoning is not re-derived. **Nothing in this PR implements it.**

**What exists today.** `ScaleDevice.batteryLevel` (`-1` when the scale does not report one) is surfaced in exactly two places, both passive: the opt-in `scaleBattery` layout widget (`ScaleBatteryItem.qml`, tinted red at ≤20%) and a row in Settings → Connections that appears only while connected (`SettingsConnectionsTab.qml:1030`). There is no alert of any kind, and the value is **absent from the MCP tools and from the Home Screen widget snapshot** — a `grep` for `batteryLevel` under `src/mcp/` and `src/widget/` returns nothing.

**Agreed direction: warn in the start-espresso path.** A scale dying mid-shot is the failure that costs something — stop-at-weight stops working and the weight curve truncates. A warning timed to shot start can therefore be rare and still land, where an idle toast gets missed or dismissed.

**Two constraints the implementation has to respect, both real:**

1. **The number lies while charging.** The BT Decent Scale sends `0xFF` as a sentinel rather than a percent, which maps to 100; the 48-hour log shows `Battery byte d[4]=0xff (255)` at connect. `SettingsConnectionsTab.qml:1033` records that the WiFi percent is "similarly unreliable". So the gate cannot be a bare `level <= N` — it must exclude the charging path explicitly, or it will fire on a scale sitting at 100%.
2. **Freshness is conditional, not periodic.** The Decent Scale polls battery every ~4 min **and only while its own LCD is on** (`decentscale.cpp:503-506`) — 54 polls in 48 hours. A scale asleep in the corner reports a stale level. Shot start is roughly the best moment available to read it, but the value can be minutes old and the message should be able to say so.

**Shape that follows from those:** fire when a **non-charging, twice-confirmed** level is at or below threshold, suppressed once per connection and cleared by a charging-seen or disconnect **event** (not a timer — CLAUDE.md). Have the reading's age available to the wording.

**Still open:**
- Threshold. Suggest **15%** — enough headroom for several shots, low enough that the warning stays rare. 20% (matching the widget's existing red band) is the alternative.
- Whether the same gate is trusted for every scale type, or only for transports whose percent is known good.
- Needs translation keys and a wiki manual entry (user-visible feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
