### PR TITLE
Fix Android build: variable shadowed info() log helper

### DIFF
--- a/src/usb/usbscalemanager.cpp
+++ b/src/usb/usbscalemanager.cpp
@@ -311,8 +311,8 @@ void UsbScaleManager::onPollTimerTickAndroid()
     // Log when a scale first appears
     if (!m_hasLoggedInitialPorts && devicePresent) {
         m_hasLoggedInitialPorts = true;
-        QString info = AndroidUsbScaleHelper::deviceInfo();
-        info(QStringLiteral("Device found: %1").arg(info));
+        QString deviceInfo = AndroidUsbScaleHelper::deviceInfo();
+        info(QStringLiteral("Device found: %1").arg(deviceInfo));
     }
 
     // Check if connected scale disappeared


### PR DESCRIPTION
## Summary
- Android release build (run 30501079325, v2.0.1 tag push) failed with `error: type 'QString' does not provide a call operator` at `usbscalemanager.cpp:315`.
- Root cause: `QString info = AndroidUsbScaleHelper::deviceInfo();` shadowed the `info()` logging function on the very next line, so `info(...)` resolved to the QString variable instead of the log call.
- Only the Android-guarded path (`#ifdef Q_OS_ANDROID`) hits this, so macOS/desktop builds compiled clean and never caught it.
- Fix: renamed the local variable to `deviceInfo`.

## Test plan
- [x] macOS build compiles clean (unaffected path, verified pre-existing)
- [ ] Android CI build (triggered on merge via tag rebuild)