### PR TITLE
Enable Quick3D on Linux ARM64 (screensavers) and stop stripping it from the AppImage

### DIFF
--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -148,8 +148,6 @@ jobs:
           rm -f $QT_ROOT_DIR/plugins/position/libqtposition_nmea.so
           # Flite TTS plugin has missing libflite.so.1 dependency (we use speechd)
           rm -f $QT_ROOT_DIR/plugins/texttospeech/libqtexttospeech_flite.so
-          # Remove Quick3D QML modules (not built on ARM64, but Qt install includes them)
-          rm -rf $QT_ROOT_DIR/qml/QtQuick3D
 
       - name: Create AppImage
         env:

--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -104,7 +104,6 @@ jobs:
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DENABLE_QUICK3D=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 


### PR DESCRIPTION
## Summary
- `-DENABLE_QUICK3D=OFF` was forced on the Linux ARM64 build since #167 (Feb 2026), when that workflow's Qt install didn't carry `qtquick3d` at all. #1148 (May 2026) added `qtquick3d` to the module list — but only for `Qt6Graphs`' transitive dependency — and the flag was never revisited.
- Verified via two `workflow_dispatch` test builds (not tied to the release tag): [30502054635](https://github.com/Kulitorum/Decenza/actions/runs/30502054635) confirms Quick3D compiles clean on this platform with the flag removed.
- Also removed a stale `rm -rf $QT_ROOT_DIR/qml/QtQuick3D` packaging step that stripped the QML module from the AppImage post-build — leftover from when Quick3D was disabled; with it enabled, that would ship an AppImage missing the module the screensavers need at runtime.
- This also incidentally fixes the qmllint diagnostics gate failure blocking the current v2.0.1 pre-release: the gate expects `PipesScreensaver.qml`/`ShotMapGlobe.qml` in the module on every platform, which is now true again.

## Caveat
No physical ARM64/Raspberry Pi hardware available to verify screensaver rendering at runtime — only compile + packaging verified in CI. Worth a real-hardware smoke test on the next Pi build.

## Test plan
- [x] CI test build compiles with Quick3D enabled (see linked run)
- [ ] Runtime check of the 3D screensavers on real ARM64/Raspberry Pi hardware