### PR TITLE
Log weight-timed steaming's scale-vs-fallback decision at steam-start

### DIFF
--- a/openspec/changes/keep-milk-weight-across-shot/.openspec.yaml
+++ b/openspec/changes/keep-milk-weight-across-shot/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/keep-milk-weight-across-shot/design.md
+++ b/openspec/changes/keep-milk-weight-across-shot/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Weight-timed steaming decides between a scaled steam duration and the recipe/preset's fixed duration in `SettingsBrew::scaledSteamTime(index, milkG)` (`src/core/settings_brew.cpp:614-624`):
+
+```cpp
+int SettingsBrew::scaledSteamTime(int index, double milkG) const {
+    if (!milkAutoCaptureEnabled()) return 0;  // toggle gates ALL weight scaling, not just auto-capture
+    QVariantMap p = getSteamPitcherPreset(index);
+    if (p.isEmpty() || p.value("disabled").toBool()) return 0;
+    if (milkG <= 0.0) return 0;
+    double secPerGram = steamSecondsPerGram();
+    if (secPerGram <= 0.0) return 0;  // uncalibrated
+    return qBound(5, qRound(secPerGram * milkG), 120);
+}
+```
+
+Note this reads a single **global** `steamSecondsPerGram` rate, not a per-pitcher `calibMilkG`/`duration` pair — the comment at `settings_brew.cpp:619` says so explicitly ("No longer reads the per-preset calibMilkG/duration for scaling"). `openspec/specs/weight-timed-steaming/spec.md`'s "Per-pitcher calibration" requirement describes the old per-pitcher ratio math and is stale against the current implementation; reconciling that spec is a separate follow-up, noted here so it isn't mistaken for settled truth while investigating this bug.
+
+`SteamPage.qml` calls this via two thin wrappers (`scaledSteamTimeout()` at `SteamPage.qml:346-348`, `steamTimeForMilk()` at `SteamPage.qml:351-353`), consumed at the steam-start decision point (`onIsSteamingChanged`, `SteamPage.qml:152-176`) and the page-activation sync (`syncSteamTimeout()`, `SteamPage.qml:434-448`). Both already fire for a machine-driven (GHC) entry into Steam exactly as they would for a user-tapped one — confirmed by two rounds of static investigation that found no code path clearing `AppShell.sessionMeasuredMilkG` during an espresso shot, in `PostShotReviewPage.qml`, or (for this user's confirmed "straight through, no reselection" workflow) via recipe-driven pitcher reassignment.
+
+That leaves a fourth, unconfirmed gate any of which returns `0` and forces the fixed-duration fallback, silently, with no distinguishing signal in the current debug output:
+1. `milkAutoCaptureEnabled()` false (master toggle off).
+2. Selected pitcher preset missing/disabled.
+3. `milkG <= 0` — no milk actually reached the scaling call (this is where a capture lost somewhere upstream would show up).
+4. `steamSecondsPerGram() <= 0` — global rate never calibrated.
+
+None of `SteamPage.qml`'s existing debug lines (`SteamPage.qml:119-132`, phase/state/isSteaming changes) log which of these four gates fired, or the actual milk/rate values at decision time. The live settings surface exposed over MCP (`steam_pitcher_list`, `settings_get category=steam`) does not expose `milkAutoCaptureEnabled` or `steamSecondsPerGram` either, so the cause can't be confirmed retroactively from outside the app.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the fixed-vs-scaled decision fully diagnosable from the debug log: which of the four gates (if any) blocked scaling, and what the actual captured-milk/rate/pitcher values were at that instant.
+- Cover both call sites that can apply the fallback (steam-start in `onIsSteamingChanged`, and `syncSteamTimeout()` on page activation/pitcher-lift), since either could be the one that ran for this user's GHC-from-Shot-Review sequence.
+- Keep it QML-side `console.log`, matching `SteamPage.qml`'s existing debug-logging style (`SteamPage.qml:119-132`) — this is UI/session logic, not a device/radio/transport subsystem, so it is out of scope for the C++ marker-macro gate in `docs/CLAUDE_MD/LOGGING.md` (that document's scope is explicitly "device, radio or transport subsystem").
+
+**Non-Goals:**
+- No behavior change. Nothing about which duration gets applied changes in this pass — only what gets logged.
+- Not fixing `openspec/specs/weight-timed-steaming/spec.md`'s stale per-pitcher-calibration description — flagged above, deferred.
+- Not adding new persisted settings, new MCP surface, or new Settings properties.
+
+## Decisions
+
+**Decision: log the four gate values and the outcome at both call sites, once per steam-start/activation, not per-frame.**
+
+At `SteamPage.qml:152-176` (`onIsSteamingChanged`, when `isSteaming` becomes true) and `SteamPage.qml:434-448` (`syncSteamTimeout()`), add one `console.log` each, right where the scaled-vs-fallback decision is made, reporting:
+- `AppShell.sessionMeasuredMilkG` and `steamPage.lastOnScaleMilk` (the two candidate milk sources `capturedMilkForScaling()` chooses between).
+- `Settings.brew.milkAutoCaptureEnabled`, `Settings.brew.steamSecondsPerGram`, and the selected pitcher's name/disabled state.
+- The `scaledSteamTimeout()`/`steamTimeForMilk()` result and, if it's `0`, which of the four `scaledSteamTime()` gates is the likely cause (inferred client-side from the same values being logged — no new C++ accessor needed since every value read by `scaledSteamTime()` already has a QML-visible property).
+- The final duration actually applied (`Settings.brew.steamTimeout`) and its source (`"scaled"` vs `"fixed-fallback"` vs `"user-adjusted, unchanged"`).
+
+Log once per `isSteaming` transition to `true` and once per `syncSteamTimeout()` call (already only called from `StackView.onActivated` and a couple of explicit triggers per the existing code, not per-frame) — no new throttling/collapsing needed, this isn't a periodic source.
+
+Alternatives considered:
+- *Add a C++ accessor that returns which gate failed, instead of inferring it in QML.* Slightly cleaner, but every value `scaledSteamTime()` reads is already a plain `Q_PROPERTY` (`milkAutoCaptureEnabled`, `steamSecondsPerGram`, `getSteamPitcherPreset`), so a QML-side log line can reconstruct the same answer without a new C++ surface. Revisit if the C++ logic grows more branches.
+- *Wait for a repro with `qWarning` set to trace level instead of adding permanent log lines.* Rejected — this is a one-time GHC-driven repro the user can't easily force on demand; a standing, always-on debug line (matching the page's existing style) is what actually catches it the next time it happens organically.
+- *Fix the openspec spec drift (per-pitcher calibration text) in this same change.* Rejected — unrelated to the reported bug and would blur what this change is actually verifying; tracked as a follow-up instead.
+
+## Risks / Trade-offs
+
+- **[Risk]** Logging every steam-start doesn't help if the real cause is something upstream of `scaledSteamTime()` entirely (e.g. `capturedMilkForScaling()` never seeing a value that was in fact captured, for a reason neither investigation round found). **Mitigation**: logging both `AppShell.sessionMeasuredMilkG` directly and the four gate values together will still show "milk was there, everything was enabled/calibrated, yet result was fixed" versus "milk was already 0 by steam-start" — either outcome narrows the next investigation immediately instead of requiring a third blind round.
+- **[Risk]** `console.log` output on a real device may not always be captured unless the user is on a debug build or has debug logging enabled. **Mitigation**: this matches the existing convention already in the file (`SteamPage.qml:119-132`), which the user must already be relying on for other diagnostics; no new capture mechanism needed.
+
+## Migration Plan
+
+None — logging only, no schema/data changes, no rollback concerns beyond reverting the diff.

--- a/openspec/changes/keep-milk-weight-across-shot/proposal.md
+++ b/openspec/changes/keep-milk-weight-across-shot/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+A user captures milk weight on the idle screen, brews an espresso shot via the DE1's own GHC buttons (no app interaction), lands on the Shot Review page, then presses the GHC's physical Steam button — and weight-timed steaming does not scale to the milk they captured; it falls back to the recipe's fixed duration.
+
+Investigation so far (two rounds, both purely static) ruled out the two most obvious theories: `AppShell.sessionMeasuredMilkG` is not cleared during an espresso shot or by anything in `PostShotReviewPage.qml`, and the machine-driven navigation into `SteamPage` (`main.qml:600-625`, `main.qml:3438-3442`) reads it through the same code path (`SteamPage.qml`'s `onIsSteamingChanged`/`StackView.onActivated`) regardless of which page the machine-driven `pageStack.replace` came from. The user confirmed they use a saved Drink Recipe with its own steam/pitcher block, and that nothing else (recipe or pitcher reselection) happens between capturing the milk and pressing GHC Steam — which also rules out the recipe-reactivation-reassigns-pitcher theory (`maincontroller.cpp:1663`, `brew->setSelectedSteamCup()`), since that only resets the capture when the pitcher index actually changes.
+
+The remaining, unconfirmed candidate: weight-timed steaming's per-pitcher **calibration** (`calibMilkG` + reference `duration`) may be missing for the recipe's pitcher ("Small," per the user's live settings) — the spec's own "Uncalibrated pitcher" fallback would then silently use the recipe's fixed duration no matter how correctly the milk weight was captured and carried through. This can't be confirmed from static code or from the currently-exposed MCP settings surface (no `calibMilkG` field is exposed by `steam_pitcher_list`), so rather than ship a fix for a guessed cause, this change adds targeted diagnostic logging at the exact scaling decision point, so the next real occurrence pins the cause definitively before any behavioral fix is written.
+
+## What Changes
+
+- Add debug logging at the point weight-timed steaming decides between a scaled duration and the fixed fallback (`SteamPage.qml`'s `onIsSteamingChanged` and `syncSteamTimeout()`), recording: the session-captured milk weight, the selected pitcher's name and calibration (`calibMilkG`/reference `duration`, or "uncalibrated"), the computed scaled duration (or 0), and which value was actually applied and why.
+- No behavior change. This is diagnostics-only — the actual fix (once the log identifies the real cause) is out of scope here and will be proposed separately.
+- Follow `docs/CLAUDE_MD/LOGGING.md`'s scope note: this is QML UI/session logic, not a device/radio/transport subsystem, so it uses plain `console.log` consistent with `SteamPage.qml`'s existing debug lines (`SteamPage.qml:119-132`) rather than the C++ marker-macro system, which only gates device/radio subsystems.
+
+## Capabilities
+
+### Modified Capabilities
+- `weight-timed-steaming`: adds a diagnosability requirement — when the system falls back to the fixed duration instead of scaling, it SHALL be possible to determine why from the debug log (captured milk present but no calibration, vs. no milk captured, vs. scaling disabled). No scaling behavior itself changes.
+
+## Impact
+
+- `qml/pages/SteamPage.qml` — `onIsSteamingChanged`, `syncSteamTimeout()`, `capturedMilkForScaling()`: add decision-point logging only.
+- No BLE, database, settings-schema, or behavior changes.

--- a/openspec/changes/keep-milk-weight-across-shot/specs/weight-timed-steaming/spec.md
+++ b/openspec/changes/keep-milk-weight-across-shot/specs/weight-timed-steaming/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Fallback-to-fixed-duration is diagnosable from the debug log
+
+When weight-timed steaming applies the recipe/preset's fixed duration instead of a weight-scaled one, the system SHALL log enough information to determine why: the session-captured milk weight and last on-scale milk reading, whether the master toggle (`milkAutoCaptureEnabled`) is on, the global steam-seconds-per-gram calibration value, the selected pitcher's name and enabled/disabled state, the computed scaled duration (or its absence), and which duration was actually applied. This SHALL cover both the steam-start decision point and the page-activation/pitcher-lift sync point, regardless of whether the steam session was reached by a user tap or a machine-driven (GHC) transition.
+
+#### Scenario: Fallback due to missing calibration is visible in the log
+- **WHEN** steaming starts with milk captured but the global steam-seconds-per-gram rate is uncalibrated
+- **THEN** the debug log shows the captured milk value, the toggle as enabled, the calibration value as unset/zero, and the applied duration as the fixed fallback
+
+#### Scenario: Fallback due to no captured milk is distinguishable from a calibration gap
+- **WHEN** steaming starts with no milk captured (session value and last on-scale value both zero)
+- **THEN** the debug log shows both milk sources as zero, distinguishing this case from an uncalibrated-but-milk-present fallback
+
+#### Scenario: Successful scaling is also logged
+- **WHEN** steaming starts with milk captured, the toggle enabled, a valid calibration, and an enabled pitcher
+- **THEN** the debug log shows the computed scaled duration and records it as the applied source, not the fallback

--- a/openspec/changes/keep-milk-weight-across-shot/tasks.md
+++ b/openspec/changes/keep-milk-weight-across-shot/tasks.md
@@ -1,0 +1,20 @@
+## 1. Steam-start decision logging
+
+- [x] 1.1 In `SteamPage.qml`'s `onIsSteamingChanged` (~line 152-176), right where `_scaledNow` is computed and before it's applied, add a `console.log` reporting: `AppShell.sessionMeasuredMilkG`, `steamPage.lastOnScaleMilk`, `Settings.brew.milkAutoCaptureEnabled`, `Settings.brew.steamSecondsPerGram`, the selected pitcher's name and `disabled` flag (via `Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)`), and the `_scaledNow` result.
+- [x] 1.2 Right after the existing `if (_scaledNow > 0) { ... }` block, log the value actually written to `Settings.brew.steamTimeout` and tag it `"scaled"` or `"fixed-fallback"` (i.e. `_scaledNow > 0` vs not) — or `"user-adjusted, unchanged"` when `steamTimeoutUserAdjusted` short-circuited the calculation.
+
+## 2. Page-activation / pitcher-lift sync logging
+
+- [x] 2.1 In `syncSteamTimeout()` (~line 434-448), add the same set of values (milk sources, toggle, calibration rate, pitcher name/disabled, computed `scaled` result) as one `console.log` at the top of the function, before the early-return for a disabled pitcher.
+- [x] 2.2 Log the final `scaled` value and whether it was applied, at the point the function currently sets/skips the timeout.
+
+## 3. Verify
+
+- [x] 3.1 Build via Qt Creator MCP (`mcp__qtcreator__build`), confirm no warnings introduced.
+- [ ] 3.2 Manually exercise weight-timed steaming from the idle screen (existing working path) and confirm the new log lines show milk/calibration/outcome as expected — this validates the logging itself before waiting on the harder-to-reproduce GHC/Shot-Review path.
+- [ ] 3.3 Ask the user to reproduce the original GHC-from-Shot-Review sequence once, capture the resulting debug log (`debug_get_log` or on-device), and confirm which of the four gates (or none) explains the fallback.
+
+## 4. Follow-up (not part of this change)
+
+- [ ] 4.1 Once the log confirms the actual cause, file the real fix as a separate change.
+- [ ] 4.2 Separately reconcile `openspec/specs/weight-timed-steaming/spec.md`'s "Per-pitcher calibration" requirement, which still describes the old per-preset `calibMilkG`/`duration` ratio math — the current implementation (`SettingsBrew::scaledSteamTime`) uses a single global `steamSecondsPerGram` rate instead (`settings_brew.cpp:614-624`).

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -169,10 +169,23 @@ Page {
                 var _cm = steamPage.capturedMilkForScaling()
                 if (_cm > 0) _scaledNow = steamPage.steamTimeForMilk(_cm)
             }
+            var _pitcherAtStart = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+            console.log("SteamPage: steam-start scaling decision — sessionMeasuredMilkG=", AppShell.sessionMeasuredMilkG,
+                        "lastOnScaleMilk=", steamPage.lastOnScaleMilk,
+                        "milkAutoCaptureEnabled=", Settings.brew.milkAutoCaptureEnabled,
+                        "steamSecondsPerGram=", Settings.brew.steamSecondsPerGram,
+                        "pitcher=", _pitcherAtStart ? _pitcherAtStart.name : "<none>",
+                        "pitcherDisabled=", _pitcherAtStart ? _pitcherAtStart.disabled === true : true,
+                        "steamTimeoutUserAdjusted=", steamPage.steamTimeoutUserAdjusted,
+                        "scaledResult=", _scaledNow)
             if (_scaledNow > 0) {
                 Settings.brew.steamTimeout = _scaledNow
                 steamPage.steamTimeoutScaled = true
                 MainController.setSteamTimeoutImmediate(_scaledNow)
+                console.log("SteamPage: steam-start applied duration=", _scaledNow, "source=scaled")
+            } else {
+                console.log("SteamPage: steam-start applied duration=", Settings.brew.steamTimeout,
+                            "source=", steamPage.steamTimeoutUserAdjusted ? "user-adjusted, unchanged" : "fixed-fallback")
             }
             // Drop any banner left over from a prior session so it doesn't
             // carry into the new one. SteamHealthTracker re-arms its per-session
@@ -432,7 +445,17 @@ Page {
     // or weight-timing toggled off while the scaled flag is still latched) — writing
     // the base duration then would discard the measured-milk scaling.
     function syncSteamTimeout() {
-        if (isCurrentPitcherDisabled()) return   // heater is off — keep whatever's set
+        var _pitcherAtSync = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        console.log("SteamPage: syncSteamTimeout decision — sessionMeasuredMilkG=", AppShell.sessionMeasuredMilkG,
+                    "lastOnScaleMilk=", steamPage.lastOnScaleMilk,
+                    "milkAutoCaptureEnabled=", Settings.brew.milkAutoCaptureEnabled,
+                    "steamSecondsPerGram=", Settings.brew.steamSecondsPerGram,
+                    "pitcher=", _pitcherAtSync ? _pitcherAtSync.name : "<none>",
+                    "pitcherDisabled=", _pitcherAtSync ? _pitcherAtSync.disabled === true : true)
+        if (isCurrentPitcherDisabled()) {
+            console.log("SteamPage: syncSteamTimeout skipped — pitcher disabled")
+            return   // heater is off — keep whatever's set
+        }
         var milk = currentMeasuredMilk()
         if (milk <= 0) milk = capturedMilkForScaling()   // pitcher lifted: use the captured milk
         var scaled = steamTimeForMilk(milk)
@@ -444,6 +467,10 @@ Page {
         if (scaled > 0 || Settings.brew.steamSecondsPerGram <= 0 || !steamPage.steamTimeoutScaled) {
             Settings.brew.steamTimeout = Settings.brew.effectiveSteamDurationSec(
                 Settings.brew.selectedSteamPitcher, milk)
+            console.log("SteamPage: syncSteamTimeout applied duration=", Settings.brew.steamTimeout,
+                        "source=", scaled > 0 ? "scaled" : "fixed-fallback")
+        } else {
+            console.log("SteamPage: syncSteamTimeout kept existing scaled duration=", Settings.brew.steamTimeout)
         }
     }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -156,36 +156,27 @@ Page {
             steamSoftStopped = false
             _lastAnnouncedSteamWeight = 0
             // Apply the weight-scaled steam time NOW, at steam-start, using the same direct
-            // calc as the "Expected steam time" readout (falling back to the last on-scale
-            // reading once the pitcher is lifted). The auto-capture can't be relied on here,
-            // so this is what actually makes the steam scale. setSteamTimeoutImmediate pushes
-            // it to the DE1 and takes effect even mid-steam.
+            // calc as the "Expected steam time" readout. The auto-capture can't be relied on
+            // here, so this is what actually makes the steam scale. setSteamTimeoutImmediate
+            // pushes it to the DE1 and takes effect even mid-steam.
             // Respect a manual ±5 override: if the user dialed the time by hand, don't
             // overwrite it with the weight-scaled value at steam-start. Otherwise use the
-            // live scaled time, falling back to the milk captured this session once the
-            // pitcher is lifted to the wand.
+            // live scaled time, falling back to capturedMilkForScaling()'s two sources in
+            // priority order (this session's capture, then the last on-scale reading) once
+            // the pitcher is lifted to the wand.
             var _scaledNow = steamPage.steamTimeoutUserAdjusted ? 0 : steamPage.scaledSteamTimeout()
             if (_scaledNow <= 0 && !steamPage.steamTimeoutUserAdjusted) {
                 var _cm = steamPage.capturedMilkForScaling()
                 if (_cm > 0) _scaledNow = steamPage.steamTimeForMilk(_cm)
             }
-            var _pitcherAtStart = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
-            console.log("SteamPage: steam-start scaling decision — sessionMeasuredMilkG=", AppShell.sessionMeasuredMilkG,
-                        "lastOnScaleMilk=", steamPage.lastOnScaleMilk,
-                        "milkAutoCaptureEnabled=", Settings.brew.milkAutoCaptureEnabled,
-                        "steamSecondsPerGram=", Settings.brew.steamSecondsPerGram,
-                        "pitcher=", _pitcherAtStart ? _pitcherAtStart.name : "<none>",
-                        "pitcherDisabled=", _pitcherAtStart ? _pitcherAtStart.disabled === true : true,
-                        "steamTimeoutUserAdjusted=", steamPage.steamTimeoutUserAdjusted,
-                        "scaledResult=", _scaledNow)
             if (_scaledNow > 0) {
                 Settings.brew.steamTimeout = _scaledNow
                 steamPage.steamTimeoutScaled = true
                 MainController.setSteamTimeoutImmediate(_scaledNow)
-                console.log("SteamPage: steam-start applied duration=", _scaledNow, "source=scaled")
+                steamPage.logSteamScalingDecision("steam-start", _scaledNow, _scaledNow, "scaled")
             } else {
-                console.log("SteamPage: steam-start applied duration=", Settings.brew.steamTimeout,
-                            "source=", steamPage.steamTimeoutUserAdjusted ? "user-adjusted, unchanged" : "fixed-fallback")
+                steamPage.logSteamScalingDecision("steam-start", _scaledNow, Settings.brew.steamTimeout,
+                    steamPage.steamTimeoutUserAdjusted ? "user-adjusted, unchanged" : "fixed-fallback")
             }
             // Drop any banner left over from a prior session so it doesn't
             // carry into the new one. SteamHealthTracker re-arms its per-session
@@ -436,24 +427,44 @@ Page {
         return steamPage.lastOnScaleMilk
     }
 
-    // Sync steamTimeout to the selected preset WITHOUT clobbering a weight-scaled
-    // value. Milk to scale against = the scale reading now, else the milk captured
-    // this session (or the last reading seen on this page — lastOnScaleMilk survives
-    // session end); the scaled-or-base resolution itself is the shared SettingsBrew
-    // helper. Kept-current cases: a calibrated preset already scaled for this
-    // selection with nothing to scale against right now (pitcher lifted to the wand,
-    // or weight-timing toggled off while the scaled flag is still latched) — writing
-    // the base duration then would discard the measured-milk scaling.
-    function syncSteamTimeout() {
-        var _pitcherAtSync = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
-        console.log("SteamPage: syncSteamTimeout decision — sessionMeasuredMilkG=", AppShell.sessionMeasuredMilkG,
+    // Shared diagnostic for weight-timed steaming's scale-vs-fallback decision, called from
+    // both call sites that can apply it (steam-start in onIsSteamingChanged, and here) so
+    // they can't drift on which fields they report (see CLAUDE.md's centralization rule —
+    // the [USB Scale] prefix drifted at 21 of 73 hand-copied sites for exactly this reason).
+    // Includes the raw inputs behind currentMeasuredMilk()'s own silent zero-outs
+    // (SettingsBrew::netMilkForPitcher: no saved pitcherWeightG, or reading outside
+    // [50, 1500] g) — without rawScaleWeight/pitcherWeightG, a milk value of 0 in the log
+    // can't be told apart from "no pitcher on the scale" versus "pitcher on the scale but
+    // untared or out of range".
+    function logSteamScalingDecision(tag, scaledResult, appliedDuration, appliedSource) {
+        var pitcher = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        console.log("SteamPage:", tag, "scaling decision —",
+                    "sessionMeasuredMilkG=", AppShell.sessionMeasuredMilkG,
                     "lastOnScaleMilk=", steamPage.lastOnScaleMilk,
+                    "rawScaleWeight=", MachineState.scaleWeight,
+                    "scaleConnected=", ScaleDevice.connected,
+                    "pitcher=", pitcher ? pitcher.name : "<none>",
+                    "pitcherWeightG=", pitcher ? pitcher.pitcherWeightG : 0,
+                    "pitcherDisabled=", pitcher ? pitcher.disabled === true : false,
                     "milkAutoCaptureEnabled=", Settings.brew.milkAutoCaptureEnabled,
                     "steamSecondsPerGram=", Settings.brew.steamSecondsPerGram,
-                    "pitcher=", _pitcherAtSync ? _pitcherAtSync.name : "<none>",
-                    "pitcherDisabled=", _pitcherAtSync ? _pitcherAtSync.disabled === true : true)
+                    "scaledResult=", scaledResult,
+                    "appliedDuration=", appliedDuration,
+                    "appliedSource=", appliedSource)
+    }
+
+    // Sync steamTimeout to the selected preset WITHOUT clobbering a weight-scaled
+    // value. Milk to scale against = the scale reading now, else capturedMilkForScaling()'s
+    // two sources in priority order (this session's capture, then the last reading seen on
+    // this page — lastOnScaleMilk survives session end); the scaled-or-base resolution
+    // itself is the shared SettingsBrew helper. Kept-current cases: a calibrated preset
+    // already scaled for this selection with nothing to scale against right now (pitcher
+    // lifted to the wand, or weight-timing toggled off while the scaled flag is still
+    // latched) — writing the base duration then would discard the measured-milk scaling.
+    function syncSteamTimeout() {
         if (isCurrentPitcherDisabled()) {
-            console.log("SteamPage: syncSteamTimeout skipped — pitcher disabled")
+            steamPage.logSteamScalingDecision("syncSteamTimeout", 0, Settings.brew.steamTimeout,
+                "skipped-pitcher-disabled")
             return   // heater is off — keep whatever's set
         }
         var milk = currentMeasuredMilk()
@@ -467,10 +478,11 @@ Page {
         if (scaled > 0 || Settings.brew.steamSecondsPerGram <= 0 || !steamPage.steamTimeoutScaled) {
             Settings.brew.steamTimeout = Settings.brew.effectiveSteamDurationSec(
                 Settings.brew.selectedSteamPitcher, milk)
-            console.log("SteamPage: syncSteamTimeout applied duration=", Settings.brew.steamTimeout,
-                        "source=", scaled > 0 ? "scaled" : "fixed-fallback")
+            steamPage.logSteamScalingDecision("syncSteamTimeout", scaled, Settings.brew.steamTimeout,
+                scaled > 0 ? "scaled" : "fixed-fallback")
         } else {
-            console.log("SteamPage: syncSteamTimeout kept existing scaled duration=", Settings.brew.steamTimeout)
+            steamPage.logSteamScalingDecision("syncSteamTimeout", scaled, Settings.brew.steamTimeout,
+                "kept-existing-scaled")
         }
     }
 


### PR DESCRIPTION
## Summary
- Diagnostics-only: adds debug logging at both weight-timed-steaming scaling decision points (`SteamPage.qml`'s `onIsSteamingChanged` and `syncSteamTimeout()`) — captured milk, master toggle, `steamSecondsPerGram` calibration, selected pitcher, and which duration was applied and why.
- Fixes nothing yet. Reported bug: capture milk on idle → brew via GHC → Shot Review → press GHC Steam → steaming falls back to fixed duration instead of scaling. Two rounds of static investigation ruled out the capture being cleared during the shot or by Shot Review's lifecycle, and recipe-driven pitcher reassignment (user confirmed no recipe/pitcher reselection happens in between). Remaining candidate — missing/zero global calibration, or milk not reaching the scaling call for an unconfirmed reason — needs a real reproduction's log to confirm.
- Full investigation trail and follow-up tasks in `openspec/changes/keep-milk-weight-across-shot/`.

## Test plan
- [x] Built clean via Qt Creator MCP — 223/223 qmllint, no new warnings
- [ ] Reproduce the GHC-from-Shot-Review sequence on beta, pull the debug log, confirm which gate fired
- [ ] Follow-up PR with the actual fix once confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)