### PR TITLE
Root the button family, ApplicationWindow and every dialog at QtQuick.Templates; fix the QML cache dependency gap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1858,10 +1858,11 @@ foreach(_qml_file IN LISTS QML_FILES)
 endforeach()
 message(STATUS "QML cross-file cache deps wired for ${_decenza_qml_units_wired} units")
 
-# The gate. `add_custom_command(APPEND)` against an OUTPUT that does not match an
-# existing command is a SILENT no-op, so a drift in Qt's path formula would leave
-# this whole block doing nothing while still printing a healthy-looking count
-# above. Verify by making the build system REFUSE, not by reading a number:
+# The gate. NOTE: `add_custom_command(APPEND)` against an OUTPUT that does not match an
+# existing command is a hard configure-time error, NOT a silent no-op — verified by
+# reproduction with this project's CMake 3.30.5. So path drift fails the build by itself,
+# and this target covers the other half: that the accepted dependencies actually reach the
+# generator and cause a rebuild. Exercise it rather than reading the count above:
 #
 #   cmake --build <builddir> --target qml_dep_wiring_check
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1362,6 +1362,7 @@ set(QML_FILES
     qml/components/UnsavedChangesDialog.qml
     qml/components/DatePickerDialog.qml
     qml/components/SwipeableArea.qml
+    qml/components/DecenzaDialog.qml
     qml/components/CrashReportDialog.qml
     qml/components/McpConfirmDialog.qml
     qml/components/De1CommunicationErrorDialog.qml
@@ -1806,6 +1807,74 @@ endif()
 
 # Also add QML files as sources so IDE can find them
 set_property(TARGET Decenza APPEND PROPERTY SOURCES ${QML_FILES})
+
+# ---------------------------------------------------------------------------
+# Cross-file QML cache dependencies
+#
+# qmlcachegen resolves QML-DECLARED types (singletons like Theme, and every
+# component used by name) by READING those files through `-I <builddir>`. It does
+# not declare them as inputs, and it has no --depfile, so it cannot report them
+# either: Qt's own add_custom_command (Qt6QmlMacros.cmake:3864) lists only the
+# file's own source, the .qrc files, Decenza.qmltypes and qmldir.
+#
+# The result is a build that is quietly WRONG rather than merely stale. Editing
+# Theme.qml changes how all ~214 other units should compile and rebuilds none of
+# them; the app then runs on a mixed cache, which is not cosmetic — it produced
+# `Unable to assign [undefined] to QString` at runtime, the exact failure that
+# once got type annotations banned from Theme's temperature wrappers for a
+# release. Until now the only defence was remembering to run
+# `find qml -name '*.qml' -exec touch {} +`, which is not a defence.
+#
+# So: every unit depends on every QML source. Coarse on purpose — the precise
+# graph would mean reimplementing QML type resolution, and getting THAT subtly
+# wrong reintroduces silent staleness, which is the thing being fixed.
+#
+# It is affordable because of `restat = 1` on the cachegen edges. Measured from
+# this project's .ninja_log: qmlcachegen is ~205 ms median per file, while
+# compiling the .cpp it emits is ~3387 ms — 16.5x more. A one-file QML edit now
+# re-runs cachegen on all of them (a few seconds wall, in parallel) and ninja
+# then prunes every unit whose generated .cpp came out byte-identical, so the
+# expensive compile still only happens where the output actually changed.
+#
+# The real fix is `qmlcachegen --depfile` upstream. This is the local stand-in.
+set(_decenza_qml_abs "")
+foreach(_qml_file IN LISTS QML_FILES)
+    get_filename_component(_abs "${_qml_file}" ABSOLUTE)
+    list(APPEND _decenza_qml_abs "${_abs}")
+endforeach()
+
+# Path formula copied from Qt6QmlMacros.cmake:3841-3847 — keep in step with it.
+# `${target}_${relative}` is why the directory is "Decenza_qml/": the "Decenza_"
+# prefix is glued straight onto the leading "qml/" of the relative path.
+set(_decenza_qml_units_wired 0)
+foreach(_qml_file IN LISTS QML_FILES)
+    get_filename_component(_abs "${_qml_file}" ABSOLUTE)
+    file(RELATIVE_PATH _rel "${CMAKE_CURRENT_SOURCE_DIR}" "${_abs}")
+    string(REGEX REPLACE "\\.(js|mjs|qml)$" "_\\1" _compiled "${_rel}")
+    string(REGEX REPLACE "[$#?]+" "_" _compiled "${_compiled}")
+    set(_compiled "${CMAKE_CURRENT_BINARY_DIR}/.rcc/qmlcache/Decenza_${_compiled}.cpp")
+    add_custom_command(OUTPUT "${_compiled}" APPEND DEPENDS ${_decenza_qml_abs})
+    math(EXPR _decenza_qml_units_wired "${_decenza_qml_units_wired} + 1")
+endforeach()
+message(STATUS "QML cross-file cache deps wired for ${_decenza_qml_units_wired} units")
+
+# The gate. `add_custom_command(APPEND)` against an OUTPUT that does not match an
+# existing command is a SILENT no-op, so a drift in Qt's path formula would leave
+# this whole block doing nothing while still printing a healthy-looking count
+# above. Verify by making the build system REFUSE, not by reading a number:
+#
+#   cmake --build <builddir> --target qml_dep_wiring_check
+#
+# It touches Theme.qml and asserts the generator re-runs cachegen on every unit.
+add_custom_target(qml_dep_wiring_check
+    COMMAND ${CMAKE_COMMAND}
+            -DQML_DIR=${CMAKE_CURRENT_SOURCE_DIR}/qml
+            -DBUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
+            -DEXPECTED_UNITS=${_decenza_qml_units_wired}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckQmlDepWiring.cmake
+    VERBATIM
+    USES_TERMINAL
+)
 
 # Android deployment
 if(ANDROID)

--- a/cmake/CheckQmlDepWiring.cmake
+++ b/cmake/CheckQmlDepWiring.cmake
@@ -1,18 +1,31 @@
 # Proves the cross-file QML cache dependency wiring in CMakeLists.txt is actually
 # attached, by making the build system refuse rather than by reading a count.
 #
-# WHY THIS EXISTS. The wiring uses `add_custom_command(OUTPUT ... APPEND DEPENDS ...)`
-# to add dependencies to custom commands that QT created. That only works if the
-# OUTPUT path matches Qt's byte for byte; against anything else CMake silently
-# ignores the APPEND. So a change to Qt's path formula (Qt6QmlMacros.cmake:3841-3847)
-# would disable the whole mechanism while CMake still cheerfully printed
-# "QML cross-file cache deps wired for 214 units" — a plausible number describing
-# nothing. That is precisely the failure mode this repo keeps re-learning: the real
-# defects all printed healthy numbers, and were caught only when a tool refused.
+# WHY THIS EXISTS — and NOT for the reason first claimed here.
 #
-# So this does not inspect the wiring. It exercises it: touch a file that every
-# other QML file resolves types through, ask the generator what is now dirty, and
-# require that to be all of them.
+# The wiring uses `add_custom_command(OUTPUT ... APPEND DEPENDS ...)` to add inputs to
+# custom commands that QT created. This file originally justified itself by asserting
+# that an APPEND against a non-matching OUTPUT is a SILENT no-op. **That is false.**
+# Reproduced with this project's own CMake 3.30.5 + Ninja:
+#
+#     CMake Error at CMakeLists.txt:12 (add_custom_command):
+#       Attempt to APPEND to custom command with output ... which is not already a
+#       custom command output.
+#     CMake Generate step failed.  Build files cannot be regenerated correctly.
+#
+# So a drift in Qt's path formula (Qt6QmlMacros.cmake:3841-3847) fails the build loudly
+# at configure time. It cannot silently detach. The original rationale was written from
+# belief rather than measurement, which is the very habit the rest of this file preaches
+# against; it is recorded here rather than quietly deleted.
+#
+# What is left for this check is the half CMake does NOT cover: that the dependencies,
+# having been accepted, actually reach the GENERATOR and make it rebuild. CMake accepting
+# an APPEND says the path matched; only asking ninja what it would rebuild says the edge
+# has effect. So this does not inspect the wiring, it exercises it — touch a file every
+# other QML file resolves types through, and require the whole set to go dirty.
+#
+# Side effect worth knowing: this leaves Theme.qml's mtime bumped, so the next real build
+# regenerates every QML unit. That is the cost of exercising rather than inspecting.
 #
 # Run:  cmake --build <builddir> --target qml_dep_wiring_check
 
@@ -54,7 +67,13 @@ if(NOT dry_run_rc EQUAL 0)
 endif()
 
 # Count the qmlcachegen edges ninja intends to re-run.
-string(REGEX MATCHALL "Generating \\.rcc/qmlcache/[^,\n]*_qml\\.cpp" hits "${dry_run}")
+#
+# BOTH suffixes. QML_FILES is 221 entries but only 214 are .qml — the other 7 are .js,
+# whose generated units end `_js.cpp`. Matching only `_qml.cpp` made hit_count top out at
+# 214 against an EXPECTED_UNITS of 221, so this check could never pass and had in fact
+# never been run green. A gate written to make the build refuse, that refused
+# unconditionally, is worse than no gate: it teaches people to skip it.
+string(REGEX MATCHALL "Generating \\.rcc/qmlcache/[^,\n]*_(qml|js)\\.cpp" hits "${dry_run}")
 list(LENGTH hits hit_count)
 
 if(hit_count LESS EXPECTED_UNITS)

--- a/cmake/CheckQmlDepWiring.cmake
+++ b/cmake/CheckQmlDepWiring.cmake
@@ -1,0 +1,75 @@
+# Proves the cross-file QML cache dependency wiring in CMakeLists.txt is actually
+# attached, by making the build system refuse rather than by reading a count.
+#
+# WHY THIS EXISTS. The wiring uses `add_custom_command(OUTPUT ... APPEND DEPENDS ...)`
+# to add dependencies to custom commands that QT created. That only works if the
+# OUTPUT path matches Qt's byte for byte; against anything else CMake silently
+# ignores the APPEND. So a change to Qt's path formula (Qt6QmlMacros.cmake:3841-3847)
+# would disable the whole mechanism while CMake still cheerfully printed
+# "QML cross-file cache deps wired for 214 units" — a plausible number describing
+# nothing. That is precisely the failure mode this repo keeps re-learning: the real
+# defects all printed healthy numbers, and were caught only when a tool refused.
+#
+# So this does not inspect the wiring. It exercises it: touch a file that every
+# other QML file resolves types through, ask the generator what is now dirty, and
+# require that to be all of them.
+#
+# Run:  cmake --build <builddir> --target qml_dep_wiring_check
+
+cmake_minimum_required(VERSION 3.16)
+
+foreach(var QML_DIR BUILD_DIR EXPECTED_UNITS)
+    if(NOT DEFINED ${var})
+        message(FATAL_ERROR "CheckQmlDepWiring: ${var} not set")
+    endif()
+endforeach()
+
+set(probe "${QML_DIR}/Theme.qml")
+if(NOT EXISTS "${probe}")
+    message(FATAL_ERROR
+        "CheckQmlDepWiring: probe file ${probe} is gone. Point this at another "
+        "singleton every other QML file reads, or the check proves nothing.")
+endif()
+
+find_program(NINJA_EXE NAMES ninja samu)
+if(NOT NINJA_EXE)
+    message(FATAL_ERROR
+        "CheckQmlDepWiring: needs ninja to ask what is dirty. This check only "
+        "supports the Ninja generator.")
+endif()
+
+# Touch the probe, then ask ninja what it WOULD build. -n does not run anything,
+# so this leaves the tree exactly as it found it apart from one mtime.
+file(TOUCH_NOCREATE "${probe}")
+
+execute_process(
+    COMMAND ${NINJA_EXE} -n
+    WORKING_DIRECTORY "${BUILD_DIR}"
+    OUTPUT_VARIABLE dry_run
+    ERROR_VARIABLE dry_run_err
+    RESULT_VARIABLE dry_run_rc
+)
+if(NOT dry_run_rc EQUAL 0)
+    message(FATAL_ERROR "CheckQmlDepWiring: ninja -n failed:\n${dry_run_err}")
+endif()
+
+# Count the qmlcachegen edges ninja intends to re-run.
+string(REGEX MATCHALL "Generating \\.rcc/qmlcache/[^,\n]*_qml\\.cpp" hits "${dry_run}")
+list(LENGTH hits hit_count)
+
+if(hit_count LESS EXPECTED_UNITS)
+    message(FATAL_ERROR
+        "CheckQmlDepWiring: FAILED.\n"
+        "  Touching ${probe} made ninja want to regenerate ${hit_count} QML units, "
+        "expected ${EXPECTED_UNITS}.\n"
+        "  The add_custom_command(APPEND DEPENDS) wiring in CMakeLists.txt is not "
+        "attached to Qt's cachegen commands — almost certainly because Qt's output "
+        "path formula changed. Re-read Qt6QmlMacros.cmake (search for "
+        "'INTEGRITY_SYMBOL_UNIQUENESS', the compiled_file is built just above it) "
+        "and update the formula in CMakeLists.txt to match.\n"
+        "  Until this passes, a cross-file QML edit produces a MIXED cache: the app "
+        "compiles and runs but binds against stale type information.")
+endif()
+
+message(STATUS
+    "QML dep wiring OK — touching Theme.qml dirties ${hit_count} of ${EXPECTED_UNITS} units.")

--- a/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
+++ b/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
@@ -166,13 +166,28 @@ cachegen on all 221 (seconds of wall time, in parallel), then ninja compares the
 regenerated `.cpp` against the old one and prunes every unit whose output came out
 byte-identical. The expensive half still only happens where the code really changed.
 
-**The failure mode to know about:** `add_custom_command(APPEND)` against an OUTPUT
-that does not match an existing command is a **silent no-op**. The path is
-reconstructed from Qt's own formula (`Qt6QmlMacros.cmake:3841-3847` — the reason
-the directory is `Decenza_qml/` is that the `Decenza_` target prefix is glued onto
-the leading `qml/` of the relative path). If Qt ever changes that formula, the
-wiring detaches, CMake still prints a healthy `wired for 221 units`, and the mixed
-cache comes back. Hence:
+The path is reconstructed from Qt's own formula (`Qt6QmlMacros.cmake:3841-3847` — the
+reason the directory is `Decenza_qml/` is that the `Decenza_` target prefix is glued
+onto the leading `qml/` of the relative path). **If Qt changes that formula the build
+fails loudly at configure time**, because `add_custom_command(APPEND)` against an
+OUTPUT with no existing command is a hard error:
+
+```
+CMake Error at CMakeLists.txt:12 (add_custom_command):
+  Attempt to APPEND to custom command with output ... which is not already a
+  custom command output.
+```
+
+This paragraph previously said the opposite — that a mismatch was a **silent no-op**
+which would leave CMake printing a healthy `wired for 221 units` while doing nothing.
+That was asserted without being tried, and a reproduction with this project's own
+CMake 3.30.5 disproved it. Recorded rather than quietly corrected, because the false
+version was the stated justification for the check below, and because writing a
+mechanism down from belief instead of measurement is the failure this whole document
+exists to push back on.
+
+What the check below is actually for is the half CMake does not cover: an accepted
+APPEND proves the path matched, not that the edge reaches the generator. Hence:
 
 ```bash
 cmake --build <builddir> --target qml_dep_wiring_check
@@ -182,6 +197,13 @@ cmake --build <builddir> --target qml_dep_wiring_check
 touches `Theme.qml`, asks ninja what is now dirty, and fails unless all 221 units
 are. Run it after any Qt upgrade. A count printed by the thing being tested is not
 evidence — the whole of this file's history says so.
+
+**221, not 214: 7 of those entries are `.js`, whose units end `_js.cpp`.** The check
+first shipped matching only `_qml.cpp`, so it could never reach 221 and refused
+unconditionally — and it went to review that way, never once run green. Which is the
+joke at this document's expense: a gate written to stop people trusting an unverified
+mechanism, itself never verified. If you add a check here, run it and watch it PASS,
+then break something on purpose and watch it FAIL. Neither half is optional.
 
 The real fix is `qmlcachegen --depfile` upstream. The tool has no such flag today
 (check `tools/qmlcachegen/qmlcachegen.cpp`; there is no dependency output of any

--- a/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
+++ b/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
@@ -148,15 +148,45 @@ updated, the suite passed, and of 217 `.aotstats` exactly **one** was newer than
 wrappers as `var`. Knowing about this section is not protection: an ordinary
 rebuild does not clear it, and nothing in the build output says so.
 
-Force a consistent cache before believing any cross-file result:
+### This is FIXED as of #1717 — but know what the fix is and how it can silently die
+
+`CMakeLists.txt` now makes every QML unit depend on every `.qml` source, using
+`add_custom_command(OUTPUT ... APPEND DEPENDS ...)` to add inputs to the commands
+**Qt** created. Editing `Theme.qml` rebuilds all 221. No `touch` step, and the
+mixed-cache failure above cannot happen.
+
+It is coarse on purpose. The precise graph would mean reimplementing QML type
+resolution, and getting *that* subtly wrong reintroduces silent staleness, which
+is the thing being fixed.
+
+It is affordable because of `restat = 1` on the cachegen edges. Measured from this
+project's `.ninja_log`: qmlcachegen is **205 ms** median per file, while compiling
+the `.cpp` it emits is **3387 ms** — 16.5x more. A one-file QML edit re-runs
+cachegen on all 221 (seconds of wall time, in parallel), then ninja compares the
+regenerated `.cpp` against the old one and prunes every unit whose output came out
+byte-identical. The expensive half still only happens where the code really changed.
+
+**The failure mode to know about:** `add_custom_command(APPEND)` against an OUTPUT
+that does not match an existing command is a **silent no-op**. The path is
+reconstructed from Qt's own formula (`Qt6QmlMacros.cmake:3841-3847` — the reason
+the directory is `Decenza_qml/` is that the `Decenza_` target prefix is glued onto
+the leading `qml/` of the relative path). If Qt ever changes that formula, the
+wiring detaches, CMake still prints a healthy `wired for 221 units`, and the mixed
+cache comes back. Hence:
 
 ```bash
-find qml -name '*.qml' -exec touch {} +
+cmake --build <builddir> --target qml_dep_wiring_check
 ```
 
-Then build. Cost is the full QML regen (~80 s here), against ~16 s for one unit.
-The same caution applies to `.aotstats`: coverage numbers read after a two-file
-build describe those two files plus whatever the last full build left behind.
+`cmake/CheckQmlDepWiring.cmake` does not inspect the wiring; it exercises it. It
+touches `Theme.qml`, asks ninja what is now dirty, and fails unless all 221 units
+are. Run it after any Qt upgrade. A count printed by the thing being tested is not
+evidence — the whole of this file's history says so.
+
+The real fix is `qmlcachegen --depfile` upstream. The tool has no such flag today
+(check `tools/qmlcachegen/qmlcachegen.cpp`; there is no dependency output of any
+kind), and Qt's own `add_custom_command` has no `DEPFILE`, so the information does
+not exist to be used. This is the local stand-in until it does.
 
 ## Where the time goes
 
@@ -178,12 +208,15 @@ again after #1698 (`FINAL` on the settings/controller accessors, type annotation
 in `Theme.qml` and `IdlePage.qml`).
 
 ```
-                          post-cleanup      post-#1698      post-#1715     post-#1717
-total bindings/functions       29097           29097           29087           29088
-  AOT compiled            13017 (44.7%)   17631 (60.6%)   18168 (62.5%)   18853 (64.8%)
-  skipped -> interpreter  14665 (50.4%)   10051 (34.5%)    9504 (32.7%)    8820 (30.3%)
+                          post-cleanup      post-#1698      post-#1715      post-#1717
+total bindings/functions       29097           29097           29087           29097
+  AOT compiled            13017 (44.7%)   17631 (60.6%)   18168 (62.5%)   20459 (70.3%)
+  skipped -> interpreter  14665 (50.4%)   10051 (34.5%)    9504 (32.7%)    7223 (24.8%)
   partial                  1415 ( 4.9%)    1415 ( 4.9%)    1415 ( 4.9%)    1415 ( 4.9%)
 ```
+
+The post-#1717 column is the whole of that PR: the button family, `main.qml`'s
+`ApplicationWindow`, and the dialogs. Its three parts are described below in that order.
 
 #1715 rooted 31 pages at `QtQuick.Templates.Page`; **id skips went 1,464 -> 510**.
 
@@ -202,6 +235,31 @@ qmllint effect in `QML_GOTCHAS.md` ("a count going UP after a fix is usually the
 working") showing up in the AOT stats. **Diff per-cause, never on the total** — judged on
 the total alone this migration looks half as effective as it is, and the +335 looks like a
 regression it introduced.
+
+#1717 then did `main.qml`'s `ApplicationWindow` and the dialogs, which were the two classes
+left. The window was a one-line change worth 583 skips: Material's `ApplicationWindow.qml`
+is **three lines** whose only content is `color: Material.backgroundColor`, and `main.qml`
+already set its own `color`.
+
+The dialogs were 131 sites — 27 file roots and 104 inline `Dialog {}` blocks across 39 more
+files — and they are the case where re-rooting each one directly would have been WRONG.
+Unlike the buttons, the style's `Dialog.qml` contributed things that were genuinely on
+screen and that no dialog in the app overrode: the grow-fade `enter`/`exit` transitions and
+the modal dim. Not one of the 131 declared `enter` or `exit`. Re-rooting each at `T.Dialog`
+would have meant 131 copies of both. `DecenzaDialog.qml` carries them once.
+
+Two facts made that safe, and both were checked rather than assumed:
+
+- **All 104 inline blocks override `background`** — established by walking each block's
+  braces, not by grepping the file, because a file can contain a `background:` belonging to
+  something else entirely. Had any block relied on the style's background, re-rooting would
+  have rendered it invisible: the base supplies none.
+- **The only `Dialog`-specific API in the whole tree is `BrewDialog`'s `onRejected`**, which
+  `T.Dialog` has. That is what made one base sufficient where two looked necessary.
+
+Three inline `Popup {}` blocks were deliberately left alone: Material's `Popup` is non-modal
+with `padding: 12`, while the base carries `Dialog`'s `modal: true` and `padding: 24`, so
+re-rooting them would start dimming the screen and blocking input behind them.
 
 The post-#1715 column is measured on a **consistent** cache — all 213 units regenerated
 together, after #1714's `Theme.qml` annotations. #1715's own commit message reports
@@ -280,37 +338,43 @@ described below, paying off in the direction the ratio predicted. The `FINAL`
 work, by contrast, was worth 429 skips: real, but an order of magnitude smaller.
 
 Grouped by root cause. Re-derived post-#1717 on a consistent cache, by exact
-`message` string out of the `.aotstats` (8,820 hard skips; shares are of that):
+`message` string out of the `.aotstats` (7,223 hard skips; shares are of that):
 
 | Skips | Share | `message` |
 |---|---|---|
-| 2168 | 24.6 % | `Type TranslationManager does not have a property translate for calling` |
-| 1107 | 12.6 % | `Could not find property "X".` |
-| 593 | 6.7 % | `Cannot generate efficient code for call to untyped JavaScript function` |
-| 524 | 5.9 % | `Functions without type annotations won't be compiled` |
-| 434 | 4.9 % | `Cannot access value for name root` |
-| 180 | 2.0 % | `Could not find signal "X".` |
-| 149 | 1.7 % | `Cannot retrieve a non-object type by ID: root` |
-| 144 | 1.6 % | `Cannot generate efficient code for storing an array in a non-sequence type` |
-| 87 | 1.0 % | `Cannot access value for name popup` |
-| 76 | 0.9 % | `Cannot retrieve a non-object type by ID: popup` |
+| 2253 | 31.2 % | `Type TranslationManager does not have a property translate for calling` |
+| 754 | 10.4 % | `Cannot generate efficient code for call to untyped JavaScript function` |
+| 598 | 8.3 % | `Could not find property "X".` |
+| 524 | 7.3 % | `Functions without type annotations won't be compiled` |
+| 157 | 2.2 % | `Cannot generate efficient code for storing an array in a non-sequence type` |
+| 131 | 1.8 % | `...incompatible or ambiguous types: conversion to QVariant` |
+| 83 | 1.1 % | `Cannot access value for name Overlay` |
+| 78 | 1.1 % | `Could not find signal "X".` |
+| 73 | 1.0 % | `Cannot access value for name Dialog` |
 | **0** | — | **context property** (was 3351 / 19.0 %) |
+| **0** | — | **`root`** (was 583 across two rows) |
 
 What is left, in the order worth taking:
 
-- **`TranslationManager.translate` is now the single largest class at 2,168.** It grew as
-  the Controls-composite work shrank the classes in front of it (see above). Do not touch
-  it without reading `tst_translationreactivity.cpp` first — `translate` is a `Q_PROPERTY`
-  holding a callable precisely so a binding records a dependency on it, and that
-  reactivity is worth more than the skips.
-- **`Could not find property` + `signal` is down to 1,287 from 2,669**, and what remains
-  is the same defect in the next tier of types: **`Dialog` 572**, `Label` 204,
-  `StyledComboBox` 69, `ColoredIcon` 38. `Dialog` is the big one and the risky one — a
-  Material `Dialog` supplies header, footer, dim and an elevated background, so it is
-  nothing like the drop-in the buttons were.
-- **The `root` id is 583 across its two rows**, essentially all `main.qml`'s
-  `ApplicationWindow` — Controls-rooted for exactly the reason the pages were. One file,
-  same migration, but it is the shell, so the visual risk is concentrated.
+- **`TranslationManager.translate` is the single largest class at 2,253, now 31 % of all
+  that remains.** It has GROWN at every step, because each Controls-composite fix lets
+  qmlcachegen reach further into bindings and land on this instead. Do not touch it
+  without reading `tst_translationreactivity.cpp` first — `translate` is a `Q_PROPERTY`
+  holding a callable precisely so that a binding records a dependency on it, and that
+  reactivity is worth more than the skips. 3,248 call sites depend on it. Treat this
+  number as the floor of the program, not the next target.
+- **The untyped-JS classes together are 1,278** (754 calls + 524 definitions) and are now
+  the largest *actionable* group. This is annotation work with no UI surface — the same
+  lever that took `Theme.qml` from 4,681 skips to 499. It is the obvious next move.
+- **`Could not find property` + `signal` is down to 676 from 2,669.** What is left is the
+  long tail of the same defect: `Label`, `StyledComboBox`, `ColoredIcon`, `TextArea`,
+  `ScrollView`. Individually small, and `ColoredIcon` in particular must NOT be migrated
+  (see "What the style's QML supplies that Templates does not").
+- **`Overlay` 83 and `Dialog` 73 are new, and are the dialog migration's own residue** —
+  files that still import `QtQuick.Controls` only to name `Overlay.overlay` or a
+  `Dialog.CloseOnEscape` enum. Cheap to clear, but check each one: three files' imports
+  became genuinely unused in #1717 and the qmllint gate caught them, which is what a
+  mechanical re-rooting always leaves behind.
 - To attribute a `Could not find property/signal` skip to the type that caused it, walk
   back from the reported line to the enclosing `Type {` and count by that. The message
   names the member, never the type — counting by message alone tells you `text` is a
@@ -318,6 +382,37 @@ What is left, in the order worth taking:
 
 Re-derive rather than hand-adjusting these rows, and only from a cache you have just
 forced consistent — see the staleness section above for why that is not optional.
+
+### AOT buys speed with binary size, and macOS has a shelf at 16 MiB
+
+#1717 crossed it. The Debug link now prints:
+
+```
+ld: warning: __eh_frame section too large (max 16MB) to encode dwarf unwind offsets
+    in compact unwind table, performance of exception handling might be affected
+```
+
+Measured on that binary — `size -m` — `__eh_frame` is **16,859,952 bytes** against a
+16,777,216-byte cap: over by 82 KB, 0.5 %. AOT-compiled functions went 18,168 -> 20,459
+(+12.6 %) in the same change, and every one of them is real generated C++ carrying unwind
+data, so back-computing puts the previous build around 15 MB — under. This change tipped it.
+
+**What it costs is small and specific.** macOS's compact-unwind table stores offsets INTO
+`__eh_frame`; past 16 MiB the offset no longer fits, so affected functions fall back to the
+unwinder parsing DWARF. That is slower only while an exception is being thrown and unwound.
+Not correctness, not normal execution, and Decenza does not throw on any hot path.
+
+**What matters is the direction.** "0 hard skips" means strictly more generated C++, so this
+number only rises, and we hit a hard platform limit at 70.3 % coverage with a quarter of the
+tree still interpreted. Two things worth knowing before anyone panics or acts:
+
+- This is the **Debug** build, with ASan *and* UBSan — `__text` alone is 213 MB. Release has
+  neither and is far smaller, so it very likely sits under the cap. That is expectation, not
+  measurement: **nobody has checked a Release link.** Do that before treating it as a
+  release-affecting problem.
+- If Release ever does cross it, the lever is `-fno-asynchronous-unwind-tables` scoped to the
+  generated QML units. That is a real tradeoff, not a free win, and needs its own
+  justification — do not reach for it on the strength of a warning that costs nothing today.
 
 **Untyped JS functions — was 32 %, now 5 %, and still the best lever.** Of 1,107
 `function` declarations under `qml/`, **54** now carry a return-type annotation and

--- a/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
+++ b/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
@@ -178,14 +178,30 @@ again after #1698 (`FINAL` on the settings/controller accessors, type annotation
 in `Theme.qml` and `IdlePage.qml`).
 
 ```
-                          post-cleanup      post-#1698      post-#1715
-total bindings/functions       29097           29097           29087
-  AOT compiled            13017 (44.7%)   17631 (60.6%)   18168 (62.5%)
-  skipped -> interpreter  14665 (50.4%)   10051 (34.5%)    9504 (32.7%)
-  partial                  1415 ( 4.9%)    1415 ( 4.9%)    1415 ( 4.9%)
+                          post-cleanup      post-#1698      post-#1715     post-#PRNUM
+total bindings/functions       29097           29097           29087           29088
+  AOT compiled            13017 (44.7%)   17631 (60.6%)   18168 (62.5%)   18853 (64.8%)
+  skipped -> interpreter  14665 (50.4%)   10051 (34.5%)    9504 (32.7%)    8820 (30.3%)
+  partial                  1415 ( 4.9%)    1415 ( 4.9%)    1415 ( 4.9%)    1415 ( 4.9%)
 ```
 
 #1715 rooted 31 pages at `QtQuick.Templates.Page`; **id skips went 1,464 -> 510**.
+
+#PRNUM did the same for the button family — `AccessibleButton`, `StyledIconButton`,
+`ActionButton`, `StyledSwitch`. Attributing every `Could not find property/signal` skip to
+the element it was written on (walk back from the reported line to the enclosing `Type {`)
+showed that class was not spread thin: **`AccessibleButton` alone owned 1,049 of 2,653**,
+almost all of it `text:` and `onClicked:` on instances in other files. Re-rooting the four
+took the whole class 2,653 -> 1,271 and cleared all four types to zero.
+
+**But the total only moved 9,504 -> 8,820, not by the 1,353 those four accounted for.**
+Both numbers are right. Resolving a type lets qmlcachegen reach *further* into bindings it
+used to abandon at the first unresolvable member, where it then hits the next blocker:
+`TranslationManager.translate` went **1,833 -> 2,168** in the same sweep. This is the
+qmllint effect in `QML_GOTCHAS.md` ("a count going UP after a fix is usually the fix
+working") showing up in the AOT stats. **Diff per-cause, never on the total** — judged on
+the total alone this migration looks half as effective as it is, and the +335 looks like a
+regression it introduced.
 
 The post-#1715 column is measured on a **consistent** cache — all 213 units regenerated
 together, after #1714's `Theme.qml` annotations. #1715's own commit message reports
@@ -219,6 +235,28 @@ property typed Page or casts to it"; the cast was there, one grep away.
 the Templates type.** `as T.Page` is strictly more general: it is the C++ `QQuickPage`, so
 it matches Templates-rooted and Controls-rooted instances alike.
 
+### What the style's QML supplies that Templates does not
+
+`Page` was nearly free because a Material `Page` is nearly empty. Most controls are not.
+Open the style file — `qtdeclarative/src/quickcontrols/material/<Type>.qml` — and carry
+over anything the migrated file does not already replace. Three things bite:
+
+- **`implicitWidth` / `implicitHeight`.** The `Math.max(implicitBackground… , implicitContent…)`
+  formula lives ONLY in the style QML. C++ computes the `implicitContentWidth` and
+  `implicitBackgroundWidth` inputs but leaves the result to the style
+  (`qquickcontrol.cpp:1749-1757`), so a Templates root that does not declare it is **0 wide**.
+- **Insets.** Material inset buttons by 6 (all four sides for `RoundButton`, top/bottom for
+  `Button`), so the background paints smaller than the control. Dropping them silently
+  fattens every instance. They are **unscaled literals** in Material — keep them unscaled,
+  or the look changes at every `Theme.scaled` factor except 1.
+- **`contentItem`.** Only safe to omit if the file already replaces it. `ColoredIcon.qml` is
+  the counter-example and is deliberately still Controls-rooted: its whole mechanism is
+  Material's internal `IconLabel` doing `icon.color` tinting, and a Templates root would
+  render nothing. 38 skips is not worth a blank icon.
+
+Palette and default font are NOT in this list — those come from `QQuickTheme`, which the
+style plugin registers against the C++ class, so a Templates-rooted control still gets them.
+
 **Read the measurement warning below before trusting any number you take
 yourself.** #1698 reported +1.7 points for days because every intermediate
 measurement was taken against a build that had recompiled only the two edited
@@ -241,33 +279,42 @@ file unblocked roughly 4,200 call sites elsewhere. This is the 8:1 ratio
 described below, paying off in the direction the ratio predicted. The `FINAL`
 work, by contrast, was worth 429 skips: real, but an order of magnitude smaller.
 
-Grouped by root cause. Re-derived post-#1715 on a consistent cache, by exact
-`message` string out of the `.aotstats` (9,504 hard skips; shares are of that):
+Grouped by root cause. Re-derived post-#PRNUM on a consistent cache, by exact
+`message` string out of the `.aotstats` (8,820 hard skips; shares are of that):
 
 | Skips | Share | `message` |
 |---|---|---|
-| 1997 | 21.0 % | `Could not find property "X".` |
-| 1833 | 19.3 % | `Type TranslationManager does not have a property translate for calling` |
-| 672 | 7.1 % | `Could not find signal "X".` |
-| 570 | 6.0 % | `Cannot generate efficient code for call to untyped JavaScript function` |
-| 524 | 5.5 % | `Functions without type annotations won't be compiled` |
-| 399 | 4.2 % | `Cannot access value for name root` |
-| 164 | 1.7 % | `Cannot retrieve a non-object type by ID: root` |
-| 144 | 1.5 % | `Cannot generate efficient code for storing an array in a non-sequence type` |
-| 126 | 1.3 % | `Cannot load property length from <T> with type QVariant.` |
-| 79 | 0.8 % | `Cannot access value for name popup` |
+| 2168 | 24.6 % | `Type TranslationManager does not have a property translate for calling` |
+| 1107 | 12.6 % | `Could not find property "X".` |
+| 593 | 6.7 % | `Cannot generate efficient code for call to untyped JavaScript function` |
+| 524 | 5.9 % | `Functions without type annotations won't be compiled` |
+| 434 | 4.9 % | `Cannot access value for name root` |
+| 180 | 2.0 % | `Could not find signal "X".` |
+| 149 | 1.7 % | `Cannot retrieve a non-object type by ID: root` |
+| 144 | 1.6 % | `Cannot generate efficient code for storing an array in a non-sequence type` |
+| 87 | 1.0 % | `Cannot access value for name popup` |
+| 76 | 0.9 % | `Cannot retrieve a non-object type by ID: popup` |
 | **0** | — | **context property** (was 3351 / 19.0 %) |
 
-Two things this table says that the previous, coarser one hid:
+What is left, in the order worth taking:
 
-- **The `root` id is now the whole of the id problem**, at 563 skips across the two
-  `root` rows. #1715 took the page ids out; what is left is `main.qml`'s
-  `ApplicationWindow`, which is Controls-rooted for the same reason the pages were.
-- **`Could not find property` + `Could not find signal` is the largest class at 2,669
-  combined**, and it is mostly *downstream* of the same defect: those members read as
-  missing because the type declaring them is a Controls-rooted composite whose base
-  chain qmlcachegen cannot resolve (`AccessibleButton` and friends). It is one cause
-  wearing two message strings, not two independent buckets.
+- **`TranslationManager.translate` is now the single largest class at 2,168.** It grew as
+  the Controls-composite work shrank the classes in front of it (see above). Do not touch
+  it without reading `tst_translationreactivity.cpp` first — `translate` is a `Q_PROPERTY`
+  holding a callable precisely so a binding records a dependency on it, and that
+  reactivity is worth more than the skips.
+- **`Could not find property` + `signal` is down to 1,287 from 2,669**, and what remains
+  is the same defect in the next tier of types: **`Dialog` 572**, `Label` 204,
+  `StyledComboBox` 69, `ColoredIcon` 38. `Dialog` is the big one and the risky one — a
+  Material `Dialog` supplies header, footer, dim and an elevated background, so it is
+  nothing like the drop-in the buttons were.
+- **The `root` id is 583 across its two rows**, essentially all `main.qml`'s
+  `ApplicationWindow` — Controls-rooted for exactly the reason the pages were. One file,
+  same migration, but it is the shell, so the visual risk is concentrated.
+- To attribute a `Could not find property/signal` skip to the type that caused it, walk
+  back from the reported line to the enclosing `Type {` and count by that. The message
+  names the member, never the type — counting by message alone tells you `text` is a
+  problem, not that `AccessibleButton` is.
 
 Re-derive rather than hand-adjusting these rows, and only from a cache you have just
 forced consistent — see the staleness section above for why that is not optional.

--- a/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
+++ b/docs/CLAUDE_MD/BUILD_PERFORMANCE.md
@@ -178,7 +178,7 @@ again after #1698 (`FINAL` on the settings/controller accessors, type annotation
 in `Theme.qml` and `IdlePage.qml`).
 
 ```
-                          post-cleanup      post-#1698      post-#1715     post-#PRNUM
+                          post-cleanup      post-#1698      post-#1715     post-#1717
 total bindings/functions       29097           29097           29087           29088
   AOT compiled            13017 (44.7%)   17631 (60.6%)   18168 (62.5%)   18853 (64.8%)
   skipped -> interpreter  14665 (50.4%)   10051 (34.5%)    9504 (32.7%)    8820 (30.3%)
@@ -187,7 +187,7 @@ total bindings/functions       29097           29097           29087           2
 
 #1715 rooted 31 pages at `QtQuick.Templates.Page`; **id skips went 1,464 -> 510**.
 
-#PRNUM did the same for the button family — `AccessibleButton`, `StyledIconButton`,
+#1717 did the same for the button family — `AccessibleButton`, `StyledIconButton`,
 `ActionButton`, `StyledSwitch`. Attributing every `Could not find property/signal` skip to
 the element it was written on (walk back from the reported line to the enclosing `Type {`)
 showed that class was not spread thin: **`AccessibleButton` alone owned 1,049 of 2,653**,
@@ -279,7 +279,7 @@ file unblocked roughly 4,200 call sites elsewhere. This is the 8:1 ratio
 described below, paying off in the direction the ratio predicted. The `FINAL`
 work, by contrast, was worth 429 skips: real, but an order of magnitude smaller.
 
-Grouped by root cause. Re-derived post-#PRNUM on a consistent cache, by exact
+Grouped by root cause. Re-derived post-#1717 on a consistent cache, by exact
 `message` string out of the `.aotstats` (8,820 hard skips; shares are of that):
 
 | Skips | Share | `message` |

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -606,6 +606,18 @@ QtObject {
     // this one state instead of just fixing the underlying contrast problem.
     readonly property real backgroundScrimAlpha: 0.4
 
+    // The dimmer drawn behind a modal dialog. Distinct from backgroundScrimAlpha above,
+    // which is the light "tinted glass" wash over chrome — this one IS a heavy dimmer,
+    // and it is what pushes the page back when a dialog is open.
+    //
+    // The value is Material's, carried over verbatim rather than re-invented, because
+    // that is what every dialog in the app has always drawn: QQuickMaterialStyle::
+    // backgroundDimColor() returns 0x99303030 for the LIGHT theme, and Material's theme
+    // is Light here (nothing sets Material.theme; only main.cpp's QQuickStyle::setStyle
+    // picks the style). Material's Dialog.qml and Popup.qml each declared it as an
+    // Overlay.modal component; DecenzaDialog now declares it once for the whole app.
+    readonly property color dialogDimColor: Qt.rgba(0x30 / 255, 0x30 / 255, 0x30 / 255, 0x99 / 255)
+
     // True when there is a PICTURE behind the chrome — a photo, or the last shot's chart —
     // which is the only case where translucency has anything to show through. The name
     // predates the shot chart and is kept because ~70 call sites read it; what it means is

--- a/qml/components/AccessibleButton.qml
+++ b/qml/components/AccessibleButton.qml
@@ -4,12 +4,23 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Templates as T
 import QtQuick.Effects
 import Decenza
 
 // Button with required accessibility - enforces accessibleName at compile time
-Button {
+//
+// Rooted at QtQuick.Templates.Button, NOT QtQuick.Controls.Button. Under a style,
+// `Controls.Button` resolves to that style's Button.qml — a COMPOSITE type whose base
+// chain qmlcachegen cannot walk at build time, so every `root.<prop>` here and every
+// `text:`/`onClicked:` on an AccessibleButton ANYWHERE in the app fell back to the
+// interpreter: 1,085 skipped bindings, the single largest AOT loss in the tree.
+// Templates.Button is the plain C++ QQuickButton, so the chain resolves.
+//
+// This is only safe because the file already replaces `contentItem` and `background`
+// outright and uses no Material attached property — nothing of the style's Button.qml
+// was reaching the screen. What DID come from it is re-declared below.
+T.Button {
     id: root
 
     // Required property - will cause compile error if not provided
@@ -57,6 +68,22 @@ Button {
     // Optional font overrides (0/-1 = use defaults)
     property int _customFontSize: 0
     property int _customFontWeight: -1
+
+    // Carried over verbatim from qtdeclarative/src/quickcontrols/material/Button.qml,
+    // which supplied them and which we no longer inherit. Templates types declare no
+    // geometry at all — QQuickControl computes implicitContentWidth/implicitBackgroundWidth
+    // in C++ but leaves implicitWidth itself to the style
+    // (qquickcontrol.cpp:1749-1757), so without this every button would be 0 wide.
+    //
+    // The insets are the load-bearing ones: Material draws a button's background 6px
+    // short at top and bottom, so the fill under a 44px AccessibleButton is 32px tall.
+    // They are deliberately unscaled, exactly as Material has them — scaling them would
+    // change the look at any Theme scale other than 1.
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            implicitContentWidth + leftPadding + rightPadding)
+    topInset: 6
+    bottomInset: 6
+    verticalPadding: 14   // Material.buttonVerticalPadding, non-Dense variant
 
     implicitHeight: Theme.scaled(44)
     leftPadding: Theme.scaled(20)

--- a/qml/components/AccessibleButton.qml
+++ b/qml/components/AccessibleButton.qml
@@ -14,7 +14,11 @@ import Decenza
 // `Controls.Button` resolves to that style's Button.qml — a COMPOSITE type whose base
 // chain qmlcachegen cannot walk at build time, so every `root.<prop>` here and every
 // `text:`/`onClicked:` on an AccessibleButton ANYWHERE in the app fell back to the
-// interpreter: 1,085 skipped bindings, the single largest AOT loss in the tree.
+// interpreter — the single largest AOT loss in the tree. 1,049 of those were members read
+// on AccessibleButton INSTANCES in other files (the figure BUILD_PERFORMANCE.md quotes,
+// since that table counts by the element a skip was written on); 36 more were inside this
+// file. Two numbers for one fact is how drift starts, so: 1,049 is the attributed count
+// and the one to cite.
 // Templates.Button is the plain C++ QQuickButton, so the chain resolves.
 //
 // This is only safe because the file already replaces `contentItem` and `background`

--- a/qml/components/ActionButton.qml
+++ b/qml/components/ActionButton.qml
@@ -57,9 +57,17 @@ T.Button {
     implicitHeight: Theme.scaled(120)
 
     // From qtdeclarative/src/quickcontrols/material/Button.qml — see AccessibleButton.qml.
-    // Both implicit sizes are set explicitly above, so only the insets carry over.
+    // Both implicit sizes are set explicitly above, so the formulas do not carry over, but
+    // the insets and padding do. The padding is inert here as it happens (the contentItem
+    // is anchored with centerIn, which overrides the geometry the control would assign it)
+    // — restated anyway rather than reasoned away. leftPadding/rightPadding are what
+    // Material.buttonLeftPadding/RightPadding resolve to for this button: not flat, no
+    // icon.source, non-empty text.
     topInset: 6
     bottomInset: 6
+    verticalPadding: 14
+    leftPadding: 24
+    rightPadding: 24
 
     contentItem: Column {
         spacing: Theme.scaled(10)

--- a/qml/components/ActionButton.qml
+++ b/qml/components/ActionButton.qml
@@ -4,11 +4,13 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Templates as T
 import QtQuick.Effects
 import Decenza
 
-Button {
+// Templates.Button, not Controls.Button — see the note in AccessibleButton.qml for why a
+// style-composite root costs every binding on this type its AOT compilation.
+T.Button {
     id: control
 
     property string iconSource: ""
@@ -28,15 +30,11 @@ Button {
 
     // Auto-compute text from translation if translationKey is set (reactive to translation changes)
     text: translationKey !== "" ? _computedText : ""
-    readonly property string _computedText: {
-        var _ = TranslationManager.translationVersion  // Trigger re-evaluation
-        return TranslationManager.translate(translationKey, translationFallback)
-    }
+    // No `var _ = TranslationManager.translationVersion` line: `translate` is a Q_PROPERTY
+    // holding a callable, so reading it is itself the binding dependency. See CLAUDE.md.
+    readonly property string _computedText: TranslationManager.translate(control.translationKey, control.translationFallback)
 
-    readonly property string _computedAccessibleDescription: {
-        var _ = TranslationManager.translationVersion
-        return TranslationManager.translate(accessibleDescriptionKey, accessibleDescriptionFallback)
-    }
+    readonly property string _computedAccessibleDescription: TranslationManager.translate(control.accessibleDescriptionKey, control.accessibleDescriptionFallback)
 
     // Track pressed state for visual feedback
     property bool _isPressed: false
@@ -57,6 +55,11 @@ Button {
 
     implicitWidth: Theme.scaled(150)
     implicitHeight: Theme.scaled(120)
+
+    // From qtdeclarative/src/quickcontrols/material/Button.qml — see AccessibleButton.qml.
+    // Both implicit sizes are set explicitly above, so only the insets carry over.
+    topInset: 6
+    bottomInset: 6
 
     contentItem: Column {
         spacing: Theme.scaled(10)

--- a/qml/components/BackgroundPickerDialog.qml
+++ b/qml/components/BackgroundPickerDialog.qml
@@ -22,7 +22,7 @@ import Decenza
 // One selection covers both sections — a preset and an image are mutually exclusive, and
 // the highlighted candidate only updates the live preview. Nothing is saved until
 // "Apply". Modal shell modeled on CustomEditorPopup.qml.
-Dialog {
+DecenzaDialog {
     id: popup
 
     // Currently highlighted candidate — previewed live but not yet saved. Exactly one of

--- a/qml/components/BeanBaseDetailsPopup.qml
+++ b/qml/components/BeanBaseDetailsPopup.qml
@@ -11,7 +11,7 @@ import Decenza
 // beanBaseJson blob. Shared by BeanInfoPage (live DYE state), the post-shot
 // review page, and the shot detail page (per-shot snapshots), so a historical
 // shot always shows the bean it was actually pulled with.
-Popup {
+DecenzaDialog {
     id: root
 
     // Compact-JSON blob; parse failures render as an empty popup body, never throw.

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 import QtQuick.Effects
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -23,7 +23,7 @@ import "DateUtils.js" as DateUtils
 //
 // Extra entry point (bag inventory page): openForEdit(bag) updates the same
 // bag row in place.
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent
@@ -658,7 +658,7 @@ Dialog {
 
     // Revert confirmation: local edits (including a user-added URL the
     // canonical entry lacked) are discarded and the bag saved immediately.
-    Dialog {
+    DecenzaDialog {
         id: revertConfirmDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -906,7 +906,7 @@ Rectangle {
 
     // Fullscreen input dialog for mobile — avoids keyboard thrashing the conversation layout.
     // Opens above the keyboard with a large text area; Send dismisses and returns to conversation.
-    Dialog {
+    DecenzaDialog {
         id: inputDialog
         parent: Overlay.overlay
         modal: true
@@ -1099,7 +1099,7 @@ Rectangle {
     }
 
     // Report bad advice — directs to web interface
-    Dialog {
+    DecenzaDialog {
         id: reportWebDialog
         anchors.centerIn: parent
         width: Theme.scaled(380)
@@ -1220,7 +1220,7 @@ Rectangle {
     }
 
     // Unsupported beverage type dialog (used by openWithShot)
-    Dialog {
+    DecenzaDialog {
         id: unsupportedBeverageDialog
         property string beverageType: ""
         title: TranslationManager.translate("shotdetail.unsupportedbeverage.title", "AI Not Available")

--- a/qml/components/CrashReportDialog.qml
+++ b/qml/components/CrashReportDialog.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: root
     anchors.centerIn: parent
     width: Theme.scaled(450)

--- a/qml/components/DatePickerDialog.qml
+++ b/qml/components/DatePickerDialog.qml
@@ -10,7 +10,7 @@ import QtQuick.Layouts
 import Decenza
 import "DateUtils.js" as DateUtils
 
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/components/De1CommunicationErrorDialog.qml
+++ b/qml/components/De1CommunicationErrorDialog.qml
@@ -10,7 +10,7 @@ import Decenza
 //
 // Bound to ProfileManager.de1CommunicationFailure. The single OK button
 // calls acknowledgeDe1CommunicationFailure() to clear the flag.
-Dialog {
+DecenzaDialog {
     id: root
     anchors.centerIn: parent
     width: Theme.dialogWidth + 2 * padding

--- a/qml/components/DecenzaDialog.qml
+++ b/qml/components/DecenzaDialog.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import QtQuick.Templates as T
+import Decenza
+
+// The base every dialog and popup in the app roots at.
+//
+// WHY IT EXISTS — AOT. A `Dialog {}` from QtQuick.Controls resolves to the active style's
+// Dialog.qml, a composite whose base chain qmlcachegen cannot walk at build time, so every
+// `root.<prop>` in a dialog and every property set on a dialog instance elsewhere lost AOT
+// compilation. Same defect #1715 fixed for pages and #1717 fixed for the button family;
+// dialogs were the largest class left.
+//
+// WHY A SHARED BASE RATHER THAN 27 RE-ROOTINGS. Unlike the buttons, the style's Dialog.qml
+// contributed things that were genuinely ON SCREEN and that no dialog in this app overrode:
+// the grow-fade enter/exit transitions, and the modal dim behind the dialog. Re-rooting each
+// file at T.Dialog directly would have meant 27 copies of both — the drift opportunity
+// CLAUDE.md's "centralize anything produced at more than one site" rule exists to prevent.
+// Declared once here, they cannot disagree.
+//
+// WHAT IT DELIBERATELY DOES NOT CARRY. `Material.elevation`, `Material.roundedScale` and the
+// style's `background` only ever fed the style's own background Rectangle, and all 27 files
+// already replace `background:` outright — none of it reached the screen. Likewise the
+// `header: Label` and `footer: DialogButtonBox`: the four files that show a header or footer
+// declare their own, and no file in the tree uses `standardButtons`.
+//
+// One base covers both shapes: 26 of the 27 were `Dialog {}` and the last was `Popup {}`, and
+// T.Dialog IS a QQuickPopup in C++, so a popup loses nothing by rooting here. The only
+// Dialog-specific API in use anywhere is BrewDialog's `onRejected`, which T.Dialog has.
+T.Dialog {
+    id: control
+
+    // From qtdeclarative/src/quickcontrols/material/Dialog.qml. The implicit-size formulas
+    // live only in style QML — QQuickControl computes the inputs in C++ but leaves the
+    // result to the style (qquickcontrol.cpp:1749-1757) — so without them a dialog that
+    // does not set an explicit width is zero-sized. Most of ours do set one; the ones that
+    // don't relied entirely on this.
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            implicitContentWidth + leftPadding + rightPadding,
+                            implicitHeaderWidth,
+                            implicitFooterWidth)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             implicitContentHeight + topPadding + bottomPadding
+                             + (implicitHeaderHeight > 0 ? implicitHeaderHeight + spacing : 0)
+                             + (implicitFooterHeight > 0 ? implicitFooterHeight + spacing : 0))
+
+    // Also Material's. Roughly half the dialogs set `padding: 0` and override this; the
+    // other half never set padding at all and have been laid out against these numbers
+    // since they were written, so dropping them would reflow every one of those.
+    padding: 24
+    topPadding: 16
+
+    modal: true
+
+    // grow_fade_in / shrink_fade_out, copied exactly from Material's Dialog.qml. Not one
+    // dialog in the app declares `enter`/`exit`, so all 27 have always animated with these
+    // — losing them would make every dialog in the app pop in and out instantly.
+    enter: Transition {
+        NumberAnimation { property: "scale"; from: 0.9; to: 1.0; easing.type: Easing.OutQuint; duration: 220 }
+        NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; easing.type: Easing.OutCubic; duration: 150 }
+    }
+
+    exit: Transition {
+        NumberAnimation { property: "scale"; from: 1.0; to: 0.9; easing.type: Easing.OutQuint; duration: 220 }
+        NumberAnimation { property: "opacity"; from: 1.0; to: 0.0; easing.type: Easing.OutCubic; duration: 150 }
+    }
+
+    // The dimmer behind the dialog. A popup's own attached Overlay.modal wins over the
+    // window-wide default (qquickpopup.cpp:1274-1279), so declaring it here covers every
+    // dialog that roots at this file, and a dialog that wants something else can still
+    // override it. ProfilePreviewPopup already does.
+    T.Overlay.modal: Rectangle {
+        color: Theme.dialogDimColor
+        Behavior on opacity { NumberAnimation { duration: 150 } }
+    }
+
+    T.Overlay.modeless: Rectangle {
+        color: Theme.dialogDimColor
+        Behavior on opacity { NumberAnimation { duration: 150 } }
+    }
+}

--- a/qml/components/DecenzaDialog.qml
+++ b/qml/components/DecenzaDialog.qml
@@ -54,6 +54,13 @@ T.Dialog {
     // grow_fade_in / shrink_fade_out, copied exactly from Material's Dialog.qml. Not one
     // dialog in the app declares `enter`/`exit`, so all 27 have always animated with these
     // — losing them would make every dialog in the app pop in and out instantly.
+    // VERIFIED RUNNING, not just assigned. Temporary instrumentation on this Transition
+    // (`onRunningChanged` logging, since removed) measured the exit at 220-224 ms across
+    // repeated opens of GrindPickerDialog — an inline site, i.e. one of the 104 rewritten
+    // mechanically — which is exactly the `duration: 220` below. `Overlay.modal` resolved
+    // SET on the same instances. Worth recording because a screenshot cannot tell a
+    // running transition from a dialog that pops, and a non-null `enter` does not prove
+    // Qt honours it; those are different failures with different fixes.
     enter: Transition {
         NumberAnimation { property: "scale"; from: 0.9; to: 1.0; easing.type: Easing.OutQuint; duration: 220 }
         NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; easing.type: Easing.OutCubic; duration: 150 }

--- a/qml/components/DecenzaDialog.qml
+++ b/qml/components/DecenzaDialog.qml
@@ -18,14 +18,20 @@ import Decenza
 // Declared once here, they cannot disagree.
 //
 // WHAT IT DELIBERATELY DOES NOT CARRY. `Material.elevation`, `Material.roundedScale` and the
-// style's `background` only ever fed the style's own background Rectangle, and all 27 files
-// already replace `background:` outright — none of it reached the screen. Likewise the
-// `header: Label` and `footer: DialogButtonBox`: the four files that show a header or footer
-// declare their own, and no file in the tree uses `standardButtons`.
+// style's `background` only ever fed the style's own background Rectangle, and all 131 sites
+// already replace `background:` outright — none of it reached the screen. Same for
+// `footer: DialogButtonBox`: no DecenzaDialog-rooted file sets `standardButtons`, so it never
+// rendered. (`SettingsConnectionsTab.qml` does set it, on a `ComboBox.popup: Dialog` that is
+// deliberately NOT migrated — so the scope of that statement is this base's users, not the
+// tree. An earlier version of this comment said "no file in the tree", which is false.)
 //
-// One base covers both shapes: 26 of the 27 were `Dialog {}` and the last was `Popup {}`, and
-// T.Dialog IS a QQuickPopup in C++, so a popup loses nothing by rooting here. The only
-// Dialog-specific API in use anywhere is BrewDialog's `onRejected`, which T.Dialog has.
+// The `header` IS carried, below — see the note there. Getting that wrong is the one defect
+// this migration actually shipped into review.
+//
+// One base covers both shapes: 26 of the 27 file roots were `Dialog {}` and the last was
+// `Popup {}`, and T.Dialog IS a QQuickPopup in C++, so a popup loses nothing by rooting here.
+// Dialog-specific API is in use at exactly two sites — `onRejected` in BrewDialog.qml and
+// SettingsScreensaverTab.qml — and T.Dialog has it.
 T.Dialog {
     id: control
 
@@ -69,6 +75,44 @@ T.Dialog {
     exit: Transition {
         NumberAnimation { property: "scale"; from: 1.0; to: 0.9; easing.type: Easing.OutQuint; duration: 220 }
         NumberAnimation { property: "opacity"; from: 1.0; to: 0.0; easing.type: Easing.OutCubic; duration: 150 }
+    }
+
+    // THE TITLE. Material's Dialog.qml renders `title` through a header Label and nothing
+    // else (qquickdialog.cpp:42: "Dialog's title is displayed by a style-specific title bar
+    // that is assigned to header"). T.Dialog supplies no header at all, so omitting this
+    // made three dialogs that set `title:` — SteamPage's steamWarningDialog,
+    // ConversationOverlay's unsupportedBeverageDialog and ProfileImportPage's
+    // duplicateDialog — open with no visible heading. Body and buttons still drew, so
+    // nothing looked broken; the heading was simply gone.
+    //
+    // It is declared HERE rather than patched into those three because Material attached its
+    // header to all 131 sites, gated on `title` being non-empty. Reproducing that gate
+    // reproduces the previous behaviour everywhere at once: dialogs with no title get
+    // nothing (as before), and the files that declare their own `header:` override this one
+    // exactly as they overrode Material's.
+    //
+    // The visible condition is Material's own — a dialog reparented away from the overlay
+    // (an inline/embedded one) does not draw a title bar. Styling is Theme's rather than
+    // Material's dialogColor, since every dialog here paints its own background.
+    //
+    // VERIFIED RENDERING, by temporarily setting a `title:` on an untitled dialog that uses
+    // this header (SteamPage's editPitcherPopup) and opening it: the heading drew above the
+    // content, correctly padded, no overlap. That check was worth its two rebuilds — the
+    // app log alone could not distinguish "the binding evaluates" from "the binding is
+    // TRUE", because an untitled dialog short-circuits before the overlay comparison
+    // decides anything. All three real cases are behind conditions too awkward to trigger
+    // on demand, and one of them sits behind a button that would start a paid AI request.
+    header: Text {
+        text: control.title
+        visible: parent?.parent === T.Overlay.overlay && control.title !== ""
+        elide: Text.ElideRight
+        color: Theme.textColor
+        font.family: Theme.subtitleFont.family
+        font.pixelSize: Theme.scaled(20)
+        font.weight: Font.Medium
+        padding: Theme.scaled(24)
+        bottomPadding: 0
+        Accessible.ignored: true   // T.Dialog announces `title` itself
     }
 
     // The dimmer behind the dialog. A popup's own attached Overlay.modal wins over the

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -7,7 +7,7 @@ import Decenza
 // Opened from the info button on any equipment line (Brew Settings, Shot Review,
 // Edit Bag). Call openFor(packageId) — it resolves the package async and shows
 // its name, grinder identity, RPM capability, and last dial.
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/components/ExpandableTextArea.qml
+++ b/qml/components/ExpandableTextArea.qml
@@ -238,7 +238,7 @@ Rectangle {
     }
 
     // Expanded editor dialog
-    Dialog {
+    DecenzaDialog {
         id: expandDialog
         parent: Overlay.overlay
         modal: true

--- a/qml/components/ExtractionViewSelector.qml
+++ b/qml/components/ExtractionViewSelector.qml
@@ -6,13 +6,12 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
 import Decenza
 
 // Dialog for selecting espresso extraction view mode: Shot Chart or Cup Fill.
-Dialog {
+DecenzaDialog {
     id: selectorDialog
 
     property string currentMode: "chart"

--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -33,7 +33,7 @@ import Decenza
 // (NoAutoClose) so a stray tap can't drop a half-made change. In text mode an
 // empty grind or RPM at Done is an EXPLICIT clear — grindPicked("") /
 // rpmPicked("") — and every host applies it, with no exceptions.
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     // Explicit x/y instead of anchors.centerIn: a Popup's anchors group has

--- a/qml/components/LinkBeanBaseDialog.qml
+++ b/qml/components/LinkBeanBaseDialog.qml
@@ -10,7 +10,7 @@ import Decenza
 // metadata-enrichment path for a (historical) shot whose bean simply isn't
 // linked to Bean Base yet. The heavyweight Change Beans dialog remains the
 // path for actually creating or re-pointing a bag.
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/components/McpConfirmDialog.qml
+++ b/qml/components/McpConfirmDialog.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: root
     anchors.centerIn: parent
     width: Theme.dialogWidth + 2 * padding

--- a/qml/components/ProfileKnowledgeDialog.qml
+++ b/qml/components/ProfileKnowledgeDialog.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Effects
 import Decenza
 
@@ -8,7 +7,7 @@ import Decenza
 // grind guidance). ONE implementation shared by the profile selector, the
 // shot detail / post-shot review pages, and the recipe wizard's profile
 // tiles — call openFor(title), or set profileTitle/content and open().
-Dialog {
+DecenzaDialog {
     id: knowledgeDialog
     anchors.centerIn: parent
     width: Math.min(Theme.scaled(500), parent.width - Theme.scaled(40))

--- a/qml/components/ProfilePreviewPopup.qml
+++ b/qml/components/ProfilePreviewPopup.qml
@@ -8,7 +8,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     x: (parent.width - width) / 2

--- a/qml/components/ProfileRefusedDialog.qml
+++ b/qml/components/ProfileRefusedDialog.qml
@@ -17,7 +17,7 @@ import Decenza
 // Driven by ProfileManager.profileRefusedUnreadable. Either key list may be
 // empty (a profile can also be refused for having no steps, or too many), so the
 // detail block hides rather than showing an empty parenthesis.
-Dialog {
+DecenzaDialog {
     id: root
 
     property string profileTitle: ""

--- a/qml/components/RatioPresetDialog.qml
+++ b/qml/components/RatioPresetDialog.qml
@@ -19,7 +19,7 @@ import Decenza
 // Descriptions are original but the ratio styles/learning are adapted from
 // La Marzocco Home's article "Brew Ratios Around the World" (credited in the
 // footer).
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/components/SelectionDialog.qml
+++ b/qml/components/SelectionDialog.qml
@@ -23,7 +23,7 @@ import Decenza
 //       currentValue: root.text     // highlights matching item
 //       onSelected: function(index, value) { root.selectSuggestion(value) }
 //   }
-Dialog {
+DecenzaDialog {
     id: root
 
     property var options: []        // Array of display strings

--- a/qml/components/ShotAnalysisDialog.qml
+++ b/qml/components/ShotAnalysisDialog.qml
@@ -10,7 +10,7 @@ import Decenza
 // Brief shot quality summary dialog — no AI, computed from curve data.
 // Shows only noteworthy observations + a verdict.
 // Analysis logic lives in C++ (ShotAnalysis) — this is a thin display layer.
-Dialog {
+DecenzaDialog {
     id: analysisDialog
 
     property var shotData: ({})

--- a/qml/components/StyledIconButton.qml
+++ b/qml/components/StyledIconButton.qml
@@ -4,13 +4,16 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Templates as T
 import QtQuick.Effects
 import Decenza
 
 // Round icon button with consistent styling
 // Use text property for text/emoji icons, or icon.source for image icons
-RoundButton {
+//
+// Templates.RoundButton, not Controls.RoundButton — see the note in AccessibleButton.qml
+// for why a style-composite root costs every binding on this type its AOT compilation.
+T.RoundButton {
     id: root
 
     // For toggle states (starred, selected, etc.)
@@ -30,6 +33,15 @@ RoundButton {
     implicitWidth: Theme.scaled(40)
     implicitHeight: Theme.scaled(40)
     flat: true
+
+    // From qtdeclarative/src/quickcontrols/material/RoundButton.qml, which supplied these
+    // before this file was re-rooted. RoundButton insets on all four sides, so the round
+    // background under a 40px button is a 28px circle; dropping them would fatten every
+    // icon button in the app. Unscaled, as Material has them.
+    topInset: 6
+    bottomInset: 6
+    leftInset: 6
+    rightInset: 6
 
     // Default icon styling - override with icon.width/height/color as needed
     icon.width: Theme.scaled(18)

--- a/qml/components/StyledIconButton.qml
+++ b/qml/components/StyledIconButton.qml
@@ -42,6 +42,10 @@ T.RoundButton {
     bottomInset: 6
     leftInset: 6
     rightInset: 6
+    // Also Material's (RoundButton.qml:23). Inert here as it happens — the contentItem
+    // sizes itself from the root and centers its children — but restated rather than
+    // reasoned away, because "it should not matter" is not a verification.
+    padding: 12
 
     // Default icon styling - override with icon.width/height/color as needed
     icon.width: Theme.scaled(18)

--- a/qml/components/StyledSwitch.qml
+++ b/qml/components/StyledSwitch.qml
@@ -3,11 +3,23 @@ import QtQuick.Templates as T
 import Decenza
 
 // Templates.Switch, not Controls.Switch — see the note in AccessibleButton.qml for why a
-// style-composite root costs every binding on this type its AOT compilation. Nothing
-// carries over here: this file already replaces `indicator`, `contentItem` and both
-// implicit sizes, and Material's Switch.qml declares no insets and no padding.
+// style-composite root costs every binding on this type its AOT compilation. This file
+// already replaces `indicator`, `contentItem` and both implicit sizes, and Material's
+// Switch.qml declares no insets — but it DOES declare padding, which is carried over below.
 T.Switch {
     id: control
+
+    // qtdeclarative/src/quickcontrols/material/Switch.qml:19. Load-bearing, not cosmetic:
+    // the implicit sizes below are written in terms of this padding, so dropping it takes
+    // implicitHeight from max(28, 8+24+8)=40 down to max(28,24)=28 and cuts 16 from
+    // implicitWidth — shrinking every switch in the app and, per the comment below, undoing
+    // the touch-target enlargement that width was widened to provide.
+    //
+    // An earlier version of this file's header claimed Material's Switch declared no
+    // padding. It does. The claim came from a grep whose pattern matched leftPadding /
+    // topPadding / verticalPadding but not a bare `padding:` — the same miss that briefly
+    // dropped RoundButton's `padding: 12` in StyledIconButton.qml.
+    padding: 8
 
     // Optional accessibility label for context when text is empty
     property string accessibleName: ""

--- a/qml/components/StyledSwitch.qml
+++ b/qml/components/StyledSwitch.qml
@@ -1,8 +1,12 @@
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Templates as T
 import Decenza
 
-Switch {
+// Templates.Switch, not Controls.Switch — see the note in AccessibleButton.qml for why a
+// style-composite root costs every binding on this type its AOT compilation. Nothing
+// carries over here: this file already replaces `indicator`, `contentItem` and both
+// implicit sizes, and Material's Switch.qml declares no insets and no padding.
+T.Switch {
     id: control
 
     // Optional accessibility label for context when text is empty

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -17,7 +17,7 @@ import Decenza
 //             registry-backed suggestions; rpmCapable is derived in storage)
 // Opening with open() shows the picker; openForCreate()/openForEdit() jump
 // straight to the form.
-Dialog {
+DecenzaDialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/components/UnsavedChangesDialog.qml
+++ b/qml/components/UnsavedChangesDialog.qml
@@ -1,9 +1,8 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: root
     anchors.centerIn: parent
     width: Theme.scaled(400)

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -531,7 +531,7 @@ Item {
     }
 
     // Full-width dialog with blur - same as compact but bigger
-    Dialog {
+    DecenzaDialog {
         id: scrubberPopup
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/components/layout/CustomEditorPopup.qml
+++ b/qml/components/layout/CustomEditorPopup.qml
@@ -10,7 +10,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: popup
 
     property string itemId: ""
@@ -1056,7 +1056,7 @@ Dialog {
     }
 
     // === Color picker popup (deferred via Loader) ===
-    Dialog {
+    DecenzaDialog {
         id: colorPickerPopup
         property string mode: "text"  // "text" or "bg"
         property color initialColor: "#ffffff"

--- a/qml/components/layout/ReadoutOptionsPopup.qml
+++ b/qml/components/layout/ReadoutOptionsPopup.qml
@@ -12,7 +12,7 @@ import Decenza
 // exactly the option keys the widget type declares in the readout capability
 // schema (Settings.network.optionKeysForType): dataMode, displayMode,
 // showRatio, color. Persists via Settings.network.setItemProperty.
-Dialog {
+DecenzaDialog {
     id: popup
 
     property string itemId: ""

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -11,7 +11,7 @@ import QtQml.Models
 import Decenza
 import "ShotPlanConfig.js" as ShotPlanConfig
 
-Dialog {
+DecenzaDialog {
     id: popup
 
     property string itemId: ""

--- a/qml/components/layout/SleepEditorPopup.qml
+++ b/qml/components/layout/SleepEditorPopup.qml
@@ -5,7 +5,7 @@ import Decenza
 
 // Per-instance editor for the Sleep widget (composable-status-bar): toggle
 // whether long-press quits the app. Persists via Settings.network.setItemProperty.
-Dialog {
+DecenzaDialog {
     id: popup
 
     property string itemId: ""

--- a/qml/components/layout/ZoneOptionsPopup.qml
+++ b/qml/components/layout/ZoneOptionsPopup.qml
@@ -12,7 +12,7 @@ import Decenza
 // and a one-tap "populate from preset". Opened from the layout editor by the
 // zone options button / long-press. Writes via Settings.network.setZoneOption,
 // so the live layout re-renders immediately.
-Dialog {
+DecenzaDialog {
     id: popup
 
     property string zoneName: ""

--- a/qml/components/layout/items/BeansItem.qml
+++ b/qml/components/layout/items/BeansItem.qml
@@ -188,7 +188,7 @@ LayoutWidgetItem {
     // Popup leaks focus and the pills are unreachable by swipe. modal traps
     // focus; dim:false keeps it looking like a dropdown, header/footer:null
     // strip the Dialog chrome so it renders like the old bare popup.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/layout/items/EquipmentItem.qml
+++ b/qml/components/layout/items/EquipmentItem.qml
@@ -179,7 +179,7 @@ LayoutWidgetItem {
     // Dialog (not Popup) so TalkBack can trap focus inside the pill list, mirroring
     // BeansItem. modal traps focus; dim:false keeps the dropdown look; header/footer
     // null strip the Dialog chrome.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/layout/items/EspressoItem.qml
+++ b/qml/components/layout/items/EspressoItem.qml
@@ -174,7 +174,7 @@ LayoutWidgetItem {
     // dialog role that screen readers use to trap focus, which `Popup { modal }`
     // alone (already set below) does not provide. header/footer null strip the
     // Dialog chrome so it still renders as the same bare dropdown.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/layout/items/FlushItem.qml
+++ b/qml/components/layout/items/FlushItem.qml
@@ -149,7 +149,7 @@ LayoutWidgetItem {
     // dialog role that screen readers use to trap focus, which `Popup { modal }`
     // alone (already set below) does not provide. header/footer null strip the
     // Dialog chrome so it still renders as the same bare dropdown.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/layout/items/HotWaterItem.qml
+++ b/qml/components/layout/items/HotWaterItem.qml
@@ -149,7 +149,7 @@ LayoutWidgetItem {
     // dialog role that screen readers use to trap focus, which `Popup { modal }`
     // alone (already set below) does not provide. header/footer null strip the
     // Dialog chrome so it still renders as the same bare dropdown.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/layout/items/RecipesItem.qml
+++ b/qml/components/layout/items/RecipesItem.qml
@@ -217,7 +217,7 @@ LayoutWidgetItem {
     // --- RECIPE PILL POPUP ---
     // Dialog (not Popup) so TalkBack can trap focus inside the pill list —
     // same reasoning as BeansItem's bag pill popup.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -113,7 +113,7 @@ LayoutWidgetItem {
     // dialog role that screen readers use to trap focus, which `Popup { modal }`
     // alone (already set below) does not provide. header/footer null strip the
     // Dialog chrome so it still renders as the same bare dropdown.
-    Dialog {
+    DecenzaDialog {
         id: presetPopup
         modal: true
         dim: false

--- a/qml/components/library/LibraryPanel.qml
+++ b/qml/components/library/LibraryPanel.qml
@@ -227,7 +227,7 @@ Rectangle {
                     onClicked: addMenu.open()
                 }
 
-                Dialog {
+                DecenzaDialog {
                     id: addMenu
                     modal: true
                     parent: Overlay.overlay
@@ -799,7 +799,7 @@ Rectangle {
     }
 
     // Delete confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: deleteConfirm
         anchors.centerIn: parent
         modal: true

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -5,7 +5,18 @@ import QtQuick.Templates as T
 import QtQuick.Window
 import Decenza
 
-ApplicationWindow {
+// Rooted at QtQuick.Templates.ApplicationWindow for the same reason the pages and the
+// button family are: a Controls root resolves to the style's composite, whose base chain
+// qmlcachegen cannot walk, so every `root.<prop>` in this file lost AOT compilation --
+// 583 skips, the whole of the remaining id class.
+//
+// Nothing is lost. Material's ApplicationWindow.qml is three lines and its only content is
+// `color: Material.backgroundColor`, which the `color:` below already overrode. The Qt 6.9+
+// safe-area padding the `topPadding` block fights is C++ (QQuickApplicationWindow), not the
+// style, so those four lines are still doing their job.
+//
+// `import QtQuick.Controls` stays -- this file has 16 inline Dialogs and a StackView.
+T.ApplicationWindow {
     id: root
     visible: true
     visibility: Qt.platform.os === "android" ? Window.FullScreen : Window.AutomaticVisibility
@@ -154,7 +165,7 @@ ApplicationWindow {
         scaleSleepTimer.start()
     }
 
-    Dialog {
+    DecenzaDialog {
         id: firmwareFlashExitDialog
         modal: true
         dim: true
@@ -260,7 +271,7 @@ ApplicationWindow {
         }
     }
 
-    Dialog {
+    DecenzaDialog {
         id: firmwareRebootRequiredDialog
         modal: true
         dim: true
@@ -1464,7 +1475,7 @@ ApplicationWindow {
     }
 
     // Global error dialog for BLE issues
-    Dialog {
+    DecenzaDialog {
         id: bleErrorDialog
         modal: true
         dim: true
@@ -1633,7 +1644,7 @@ ApplicationWindow {
     }
 
     // FlowScale fallback dialog (no scale found at startup)
-    Dialog {
+    DecenzaDialog {
         id: flowScaleDialog
         modal: true
         dim: true
@@ -1687,7 +1698,7 @@ ApplicationWindow {
     }
 
     // Scale disconnected dialog
-    Dialog {
+    DecenzaDialog {
         id: scaleDisconnectedDialog
         modal: true
         dim: true
@@ -1748,7 +1759,7 @@ ApplicationWindow {
         }
     }
 
-    Dialog {
+    DecenzaDialog {
         id: noScaleAbortDialog
         modal: true
         dim: true
@@ -1804,7 +1815,7 @@ ApplicationWindow {
     // Charging mismatch warning dialog
     // Shown when smart charging commands the DE1 USB port ON but Android still reports
     // DISCHARGING — the port is not delivering power (DE1 asleep, BLE command failed, cable issue).
-    Dialog {
+    DecenzaDialog {
         id: chargingMismatchDialog
         modal: true
         dim: true
@@ -1877,7 +1888,7 @@ ApplicationWindow {
     }
 
     // Water tank refill dialog
-    Dialog {
+    DecenzaDialog {
         id: refillDialog
         modal: true
         dim: true
@@ -1946,7 +1957,7 @@ ApplicationWindow {
 
 
     // Update notification dialog
-    Dialog {
+    DecenzaDialog {
         id: updateDialog
         modal: true
         dim: true
@@ -2505,7 +2516,7 @@ ApplicationWindow {
     // is random or public and rejects connections to the DE1 (which uses a
     // random static address) with UnknownRemoteDeviceError. The capability
     // is granted via `sudo setcap` and is frequently cleared by OS updates.
-    Dialog {
+    DecenzaDialog {
         id: linuxBleCapabilityDialog
         modal: true
         dim: true
@@ -2609,7 +2620,7 @@ ApplicationWindow {
         }
     }
 
-    Dialog {
+    DecenzaDialog {
         id: linuxBleBluezCacheDialog
         modal: true
         dim: true
@@ -2702,7 +2713,7 @@ ApplicationWindow {
     }
 
     // First-run welcome dialog
-    Dialog {
+    DecenzaDialog {
         id: firstRunDialog
         modal: true
         dim: true
@@ -2758,7 +2769,7 @@ ApplicationWindow {
     }
 
     // Storage setup dialog (Android 11+ - request MANAGE_EXTERNAL_STORAGE permission)
-    Dialog {
+    DecenzaDialog {
         id: storageSetupDialog
         modal: true
         dim: true
@@ -2860,7 +2871,7 @@ ApplicationWindow {
     // so next week's update reopens automatically. Same pattern as the GPS /
     // storage permission prompts: surfaced at the teachable moment, no
     // permanent in-app UI. Dismissed permanently after either button.
-    Dialog {
+    DecenzaDialog {
         id: autoRelaunchPromptDialog
         modal: true
         dim: true
@@ -2951,7 +2962,7 @@ ApplicationWindow {
     // via MainController; decline/dismiss just records that the offer was
     // answered. Dismiss (escape) counts as decline (recipes-idle-layout-upgrade
     // design.md decision 8) — it must be dismissible, per ACCESSIBILITY.md.
-    Dialog {
+    DecenzaDialog {
         id: recipesUpgradeDialog
         modal: true
         dim: true
@@ -4954,7 +4965,7 @@ ApplicationWindow {
     }
 
     // Empty database + backups exist: ask user if they want to restore
-    Dialog {
+    DecenzaDialog {
         id: emptyDatabaseDialog
         modal: true
         dim: true

--- a/qml/pages/AutoFavoritesPage.qml
+++ b/qml/pages/AutoFavoritesPage.qml
@@ -533,7 +533,7 @@ T.Page {
     }
 
     // Settings dialog
-    Dialog {
+    DecenzaDialog {
         id: settingsPopup
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -665,7 +665,7 @@ T.Page {
 
 
     // Edit preset popup
-    Dialog {
+    DecenzaDialog {
         id: editPresetPopup
         x: (parent.width - width) / 2
         y: editPresetPopupAtTop ? Theme.scaled(40) : (parent.height - height) / 2
@@ -790,7 +790,7 @@ T.Page {
     }
 
     // Add preset dialog
-    Dialog {
+    DecenzaDialog {
         id: addPresetDialog
         x: (parent.width - width) / 2
         y: addPresetDialogAtTop ? Theme.scaled(40) : (parent.height - height) / 2

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -863,7 +863,7 @@ T.Page {
 
 
     // Edit vessel preset popup
-    Dialog {
+    DecenzaDialog {
         id: editVesselPopup
         x: (parent.width - width) / 2
         y: editVesselPopup.editVesselPopupAtTop ? Theme.scaled(40) : (parent.height - height) / 2
@@ -1000,7 +1000,7 @@ T.Page {
     }
 
     // Add vessel dialog
-    Dialog {
+    DecenzaDialog {
         id: addVesselDialog
         x: (parent.width - width) / 2
         y: addVesselDialog.addVesselDialogAtTop ? Theme.scaled(40) : (parent.height - height) / 2

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -417,7 +417,7 @@ T.Page {
     }
 
     // Profile Settings Popup
-    Dialog {
+    DecenzaDialog {
         id: profileSettingsPopup
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -570,7 +570,7 @@ T.Page {
     }
 
     // Limits Popup
-    Dialog {
+    DecenzaDialog {
         id: limitsPopup
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -822,7 +822,7 @@ T.Page {
     } // KeyboardAwareContainer
 
     // Save As dialog - just title input, filename derived automatically
-    Dialog {
+    DecenzaDialog {
         id: saveAsDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -944,7 +944,7 @@ T.Page {
     }
 
     // Overwrite confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: overwriteDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -1020,7 +1020,7 @@ T.Page {
     }
 
     // Built-in profile name collision dialog
-    Dialog {
+    DecenzaDialog {
         id: builtInNameDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -1079,7 +1079,7 @@ T.Page {
     }
 
     // Save error dialog
-    Dialog {
+    DecenzaDialog {
         id: saveErrorDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -1469,7 +1469,7 @@ T.Page {
     }
 
     // Profile name edit dialog
-    Dialog {
+    DecenzaDialog {
         id: profileNameDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/ProfileImportPage.qml
+++ b/qml/pages/ProfileImportPage.qml
@@ -385,7 +385,7 @@ T.Page {
     }
 
     // Duplicate dialog
-    Dialog {
+    DecenzaDialog {
         id: duplicateDialog
         anchors.centerIn: parent
         width: Theme.scaled(400)

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -847,7 +847,7 @@ T.Page {
     // proper modal Dialog. Menus don't surface role/focus to screen readers
     // reliably; Dialog does. Follows the same shape as the bean-info preset
     // dialogs: centered, modal, AccessibleButton stack.
-    Dialog {
+    DecenzaDialog {
         id: profileActionsDialog
         x: (parent.width - width) / 2
         y: (parent.height - height) / 2
@@ -994,7 +994,7 @@ T.Page {
     }
 
     // Delete confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: deleteDialog
         anchors.centerIn: parent
         width: Theme.scaled(350)
@@ -1083,7 +1083,7 @@ T.Page {
     }
 
     // New profile type picker dialog
-    Dialog {
+    DecenzaDialog {
         id: newProfileDialog
         anchors.centerIn: parent
         width: Theme.scaled(350)
@@ -1188,7 +1188,7 @@ T.Page {
     }
 
     // Copy profile dialog
-    Dialog {
+    DecenzaDialog {
         id: copyProfileDialog
         anchors.centerIn: parent
         width: Theme.scaled(400)
@@ -1321,7 +1321,7 @@ T.Page {
     }
 
     // Rename profile dialog
-    Dialog {
+    DecenzaDialog {
         id: renameProfileDialog
         anchors.centerIn: parent
         width: Theme.scaled(400)

--- a/qml/pages/RecipeEditorPage.qml
+++ b/qml/pages/RecipeEditorPage.qml
@@ -636,7 +636,7 @@ T.Page {
     } // KeyboardAwareContainer
 
     // Save error dialog
-    Dialog {
+    DecenzaDialog {
         id: saveErrorDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -736,7 +736,7 @@ T.Page {
     }
 
     // Save As dialog
-    Dialog {
+    DecenzaDialog {
         id: saveAsDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -873,7 +873,7 @@ T.Page {
     }
 
     // Overwrite confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: overwriteDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2
@@ -950,7 +950,7 @@ T.Page {
     }
 
     // Built-in profile name collision dialog
-    Dialog {
+    DecenzaDialog {
         id: builtInNameDialog
         parent: Overlay.overlay
         x: (parent.width - width) / 2

--- a/qml/pages/RecipesPage.qml
+++ b/qml/pages/RecipesPage.qml
@@ -327,7 +327,7 @@ T.Page {
     // recipe (recipe-bag-lifecycle "manual re-point"). Selecting a bag only
     // moves the bag link (the recipe's own grind is untouched by construction).
     property var _repointRecipe: null
-    Dialog {
+    DecenzaDialog {
         id: repointPicker
         modal: true
         anchors.centerIn: parent

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -289,7 +289,7 @@ T.Page {
     }
 
     // Save Theme Dialog
-    Dialog {
+    DecenzaDialog {
         id: saveThemeDialog
         modal: true
         x: (parent.width - width) / 2

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1427,7 +1427,7 @@ T.Page {
     }
 
     // Debug log dialog
-    Dialog {
+    DecenzaDialog {
         id: debugLogDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1493,7 +1493,7 @@ T.Page {
     }
 
     // Delete confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: deleteConfirmDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -1021,7 +1021,7 @@ T.Page {
         onBackClicked: AppShell.backRequested()
     }
 
-    Dialog {
+    DecenzaDialog {
         id: bulkDeleteConfirmDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1106,7 +1106,7 @@ T.Page {
     }
 
     // Saved searches dialog
-    Dialog {
+    DecenzaDialog {
         id: savedSearchesDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1272,7 +1272,7 @@ T.Page {
     }
 
     // Search syntax help dialog
-    Dialog {
+    DecenzaDialog {
         id: searchHelpDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/SimpleProfileEditorPage.qml
+++ b/qml/pages/SimpleProfileEditorPage.qml
@@ -693,7 +693,7 @@ T.Page {
     } // KeyboardAwareContainer
 
     // === Temperature Steps Dialog ===
-    Dialog {
+    DecenzaDialog {
         id: tempStepsDialog
         anchors.centerIn: parent
         width: Math.min(parent.width - Theme.scaled(40), Theme.scaled(400))
@@ -844,7 +844,7 @@ T.Page {
     }
 
     // Save error dialog
-    Dialog {
+    DecenzaDialog {
         id: saveErrorDialog
         anchors.centerIn: parent
         width: Theme.scaled(350)
@@ -947,7 +947,7 @@ T.Page {
     }
 
     // Save As dialog
-    Dialog {
+    DecenzaDialog {
         id: saveAsDialog
         anchors.centerIn: parent
         width: Math.min(parent.width - Theme.scaled(40), Theme.scaled(400))
@@ -1101,7 +1101,7 @@ T.Page {
     }
 
     // Overwrite confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: overwriteDialog
         anchors.centerIn: parent
         width: Math.min(parent.width - Theme.scaled(40), Theme.scaled(400))
@@ -1210,7 +1210,7 @@ T.Page {
     }
 
     // Built-in profile name collision dialog
-    Dialog {
+    DecenzaDialog {
         id: builtInNameDialog
         anchors.centerIn: parent
         width: Math.min(parent.width - Theme.scaled(40), Theme.scaled(400))

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -556,7 +556,7 @@ T.Page {
     }
 
     // Post-session warning dialog
-    Dialog {
+    DecenzaDialog {
         id: steamWarningDialog
         property string warningMessage: ""
         title: TranslationManager.translate("steam.warning.title", "Steam Warning")
@@ -2448,7 +2448,7 @@ T.Page {
 
 
     // Edit Pitcher Popup (rename/delete)
-    Dialog {
+    DecenzaDialog {
         id: editPitcherPopup
         x: (parent.width - width) / 2
         y: editPitcherPopupAtTop ? Theme.scaled(40) : (parent.height - height) / 2
@@ -2587,7 +2587,7 @@ T.Page {
     }
 
     // Add Pitcher Dialog
-    Dialog {
+    DecenzaDialog {
         id: addPitcherDialog
         x: (parent.width - width) / 2
         y: addPitcherDialogAtTop ? Theme.scaled(40) : (parent.height - height) / 2

--- a/qml/pages/settings/DeviceMigrationDialog.qml
+++ b/qml/pages/settings/DeviceMigrationDialog.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-Dialog {
+DecenzaDialog {
     id: migrationDialog
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/pages/settings/LayoutEditorZone.qml
+++ b/qml/pages/settings/LayoutEditorZone.qml
@@ -429,7 +429,7 @@ Rectangle {
                 accessibleName: TranslationManager.translate("layoutEditor.addWidgetTo", "Add widget to %1").arg(root.zoneLabel)
                 onClicked: addPopup.open()
 
-                Dialog {
+                DecenzaDialog {
                     id: addPopup
                     modal: true
                     parent: Overlay.overlay

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1395,7 +1395,7 @@ KeyboardAwareContainer {
 
     // Discuss Shot app selector
     // Advanced endpoint dialog (OpenAI / Anthropic custom endpoint)
-    Dialog {
+    DecenzaDialog {
         id: advancedEndpointDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1470,7 +1470,7 @@ KeyboardAwareContainer {
 
     // MCP Help Dialog
     // Confirm rotating the remote-access token (revokes the current URL).
-    Dialog {
+    DecenzaDialog {
         id: rotateTokenDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1531,7 +1531,7 @@ KeyboardAwareContainer {
     }
 
     // Confirm signing out of Tailscale (wipes the embedded node's identity).
-    Dialog {
+    DecenzaDialog {
         id: tailscaleSignoutDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1594,7 +1594,7 @@ KeyboardAwareContainer {
     }
 
     // Step-by-step Tailscale Funnel setup instructions.
-    Dialog {
+    DecenzaDialog {
         id: tailscaleSetupDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1752,7 +1752,7 @@ KeyboardAwareContainer {
         }
     }
 
-    Dialog {
+    DecenzaDialog {
         id: mcpHelpDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -659,7 +659,7 @@ Item {
     }
 
     // Heater Calibration Warning Dialog
-    Dialog {
+    DecenzaDialog {
         id: calibrationWarningDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -720,7 +720,7 @@ Item {
     }
 
     // Heater Calibration Popup
-    Dialog {
+    DecenzaDialog {
         id: calibrationPopup
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -18,7 +18,7 @@ Item {
     readonly property bool usbAvailable: Qt.platform.os !== "ios"
 
     // Share Log Dialog
-    Dialog {
+    DecenzaDialog {
         id: shareLogDialog
         modal: true
         anchors.centerIn: parent
@@ -214,7 +214,7 @@ Item {
 
     // Add WiFi Scale Dialog — enter an IP address or mDNS name to connect a
     // WiFi scale that isn't being advertised/discovered right now.
-    Dialog {
+    DecenzaDialog {
         id: addWifiScaleDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -437,7 +437,7 @@ Item {
     // the user would silently end up with a poisoned saved primary that the
     // app keeps redialing on every reconnect cycle (see #1281).
     property string lastManualWifiHost: ""
-    Dialog {
+    DecenzaDialog {
         id: manualWifiFailedDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/settings/SettingsDebugTab.qml
+++ b/qml/pages/settings/SettingsDebugTab.qml
@@ -347,7 +347,7 @@ Item {
             }
 
             // Profile conversion result dialog
-            Dialog {
+            DecenzaDialog {
                 id: profileConvertResultDialog
                 modal: true
                 dim: true
@@ -499,7 +499,7 @@ Item {
             }
 
             // Import result feedback dialog
-            Dialog {
+            DecenzaDialog {
                 id: importResultDialog
                 modal: true
                 dim: true

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -817,7 +817,7 @@ KeyboardAwareContainer {
         }
 
         // Extracting popup - shows during ZIP extraction
-        Dialog {
+        DecenzaDialog {
             id: extractingPopup
             modal: true
             dim: true
@@ -879,7 +879,7 @@ KeyboardAwareContainer {
         }
 
         // Import result feedback dialog
-        Dialog {
+        DecenzaDialog {
             id: importResultDialog
             modal: true
             dim: true
@@ -997,7 +997,7 @@ KeyboardAwareContainer {
     }
 
     // Import complete popup
-    Dialog {
+    DecenzaDialog {
         id: importCompletePopup
         parent: Overlay.overlay
         // qmllint disable Quick.layout-positioning
@@ -1223,7 +1223,7 @@ KeyboardAwareContainer {
     }
 
     // Restore confirmation dialog
-    Dialog {
+    DecenzaDialog {
         id: restoreConfirmDialog
         parent: Overlay.overlay
         // qmllint disable Quick.layout-positioning
@@ -1552,7 +1552,7 @@ KeyboardAwareContainer {
     }
 
     // TOTP Setup Dialog
-    Dialog {
+    DecenzaDialog {
         id: totpSetupDialog
         parent: Overlay.overlay
         // qmllint disable Quick.layout-positioning
@@ -1811,7 +1811,7 @@ KeyboardAwareContainer {
     }
 
     // TOTP Reset Confirmation Dialog
-    Dialog {
+    DecenzaDialog {
         id: totpResetDialog
         parent: Overlay.overlay
         // qmllint disable Quick.layout-positioning
@@ -1902,7 +1902,7 @@ KeyboardAwareContainer {
     }
 
     // Factory Reset - Confirmation Dialog 1
-    Dialog {
+    DecenzaDialog {
         id: factoryResetDialog1
         parent: Overlay.overlay
         // qmllint disable Quick.layout-positioning
@@ -1993,7 +1993,7 @@ KeyboardAwareContainer {
     }
 
     // Factory Reset - Confirmation Dialog 2 (the fun one)
-    Dialog {
+    DecenzaDialog {
         id: factoryResetDialog2
         parent: Overlay.overlay
         // qmllint disable Quick.layout-positioning

--- a/qml/pages/settings/SettingsLanguageTab.qml
+++ b/qml/pages/settings/SettingsLanguageTab.qml
@@ -694,7 +694,7 @@ Item {
         }
 
     // Delete confirmation popup
-    Dialog {
+    DecenzaDialog {
         id: deleteConfirmPopup
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -789,7 +789,7 @@ Item {
     }
 
     // Submission result popup
-    Dialog {
+    DecenzaDialog {
         id: submitResultPopup
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -948,7 +948,7 @@ Item {
         }
     }
 
-    Dialog {
+    DecenzaDialog {
         id: aiTranslateOfferPopup
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/settings/SettingsLayoutTab.qml
+++ b/qml/pages/settings/SettingsLayoutTab.qml
@@ -172,7 +172,7 @@ Item {
 
     // Confirm wiping the whole custom layout — a single tap is otherwise
     // irreversible.
-    Dialog {
+    DecenzaDialog {
         id: resetConfirm
         anchors.centerIn: Overlay.overlay
         modal: true
@@ -224,7 +224,7 @@ Item {
 
     // Confirm removing a configured widget so a set-up widget isn't lost by an
     // accidental tap.
-    Dialog {
+    DecenzaDialog {
         id: removeConfirm
         anchors.centerIn: Overlay.overlay
         modal: true

--- a/qml/pages/settings/SettingsMachineTab.qml
+++ b/qml/pages/settings/SettingsMachineTab.qml
@@ -1768,7 +1768,7 @@ KeyboardAwareContainer {
     }
 
     // Map Test Popup
-    Dialog {
+    DecenzaDialog {
         id: mapTestPopup
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/settings/SettingsScreensaverTab.qml
+++ b/qml/pages/settings/SettingsScreensaverTab.qml
@@ -18,7 +18,7 @@ Item {
     property int autoSleepMinutes: Settings.value("autoSleepMinutes", 60)
 
     // Dialog to offer clearing video cache when switching away from videos
-    Dialog {
+    DecenzaDialog {
         id: clearCacheDialog
         modal: true
         anchors.centerIn: parent
@@ -125,7 +125,7 @@ Item {
     }
 
     // Dialog to confirm clearing personal media
-    Dialog {
+    DecenzaDialog {
         id: clearPersonalMediaDialog
         modal: true
         anchors.centerIn: parent

--- a/qml/pages/settings/SettingsSearchDialog.qml
+++ b/qml/pages/settings/SettingsSearchDialog.qml
@@ -10,7 +10,7 @@ import QtQuick.Layouts
 import Decenza
 import "../../components/SettingsSearchIndex.js" as SearchIndex
 
-Dialog {
+DecenzaDialog {
     id: searchDialog
     parent: Overlay.overlay
     anchors.centerIn: parent

--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -664,7 +664,7 @@ Item {
     }
 
     // Firmware update dialog (full-screen) — hosts the SettingsFirmwareTab panel
-    Dialog {
+    DecenzaDialog {
         id: firmwareDialog
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -753,7 +753,7 @@ Item {
     }
 
     // Release notes popup
-    Dialog {
+    DecenzaDialog {
         id: releaseNotesPopup
         modal: true
         dim: true
@@ -946,7 +946,7 @@ Item {
     }
 
     // Donate dialog
-    Dialog {
+    DecenzaDialog {
         id: donateDialog
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/qml/pages/settings/StringBrowserPage.qml
+++ b/qml/pages/settings/StringBrowserPage.qml
@@ -948,7 +948,7 @@ T.Page {
     }
 
     // API Key missing popup
-    Dialog {
+    DecenzaDialog {
         id: apiKeyPopup
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1051,7 +1051,7 @@ T.Page {
     }
 
     // All translated popup
-    Dialog {
+    DecenzaDialog {
         id: allTranslatedPopup
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -1117,7 +1117,7 @@ T.Page {
     }
 
     // Clear AI translations confirmation popup
-    Dialog {
+    DecenzaDialog {
         id: clearAiPopup
         parent: Overlay.overlay
         anchors.centerIn: parent

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -75,11 +75,38 @@ void ShotHistoryStorage::runOnDbThread(std::function<void()> task)
     m_dbWorker->post(std::move(task));
 }
 
+void ShotHistoryStorage::runDetachedDbThread(std::function<void()> body)
+{
+    // Counted, so isDbWorkIdle() can see it. The counter is a shared_ptr for the
+    // same reason m_destroyed is: the thread may outlive `this`, and it must still
+    // be able to decrement without touching a destroyed object.
+    auto inFlight = m_detachedDbThreads;
+    inFlight->fetch_add(1, std::memory_order_relaxed);
+    QThread* thread = QThread::create([body = std::move(body), inFlight]() {
+        body();
+        // Release, paired with the acquire in isDbWorkIdle(): a reader that sees
+        // zero must also see everything the thread did to the DB file before it.
+        inFlight->fetch_sub(1, std::memory_order_release);
+    });
+    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+    thread->start();
+}
+
 bool ShotHistoryStorage::isDbWorkIdle() const
 {
     // No worker means nothing was ever posted, which is idle by definition — the
     // worker is created lazily on first use (runOnDbThread).
-    return !m_dbWorker || m_dbWorker->isIdle();
+    //
+    // The detached count is the other half, and it used to be missing: the eleven
+    // read queries spawn one-shot threads that never go through m_dbWorker, so a
+    // caller that waited on this was told "idle" while a thread was mid-SELECT.
+    // initialize() itself starts one (the distinct-cache pre-warm), so EVERY user
+    // of this class had one running. It surfaced as tst_mcptools_write failing
+    // with `disk I/O error Unable to execute statement` — a test's QTemporaryDir
+    // deleting the .db out from under the previous test's still-running pre-warm,
+    // with the warning landing in whichever test happened to be running next.
+    return (!m_dbWorker || m_dbWorker->isIdle())
+        && m_detachedDbThreads->load(std::memory_order_acquire) == 0;
 }
 
 void ShotHistoryStorage::close()
@@ -3313,7 +3340,7 @@ void ShotHistoryStorage::requestCreateBackup(const QString& destPath)
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([this, dbPath, destPath, destroyed]() {
+    runDetachedDbThread([this, dbPath, destPath, destroyed]() {
         QString resultPath = createBackupStatic(dbPath, destPath);
 
         if (*destroyed) return;
@@ -3327,8 +3354,6 @@ void ShotHistoryStorage::requestCreateBackup(const QString& destPath)
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 void ShotHistoryStorage::checkpoint()
@@ -3419,7 +3444,7 @@ void ShotHistoryStorage::requestImportDatabase(const QString& filePath, bool mer
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([this, dbPath, cleanPath, merge, destroyed]() {
+    runDetachedDbThread([this, dbPath, cleanPath, merge, destroyed]() {
         bool success = importDatabaseStatic(dbPath, cleanPath, merge);
 
         if (*destroyed) return;
@@ -3439,8 +3464,6 @@ void ShotHistoryStorage::requestImportDatabase(const QString& filePath, bool mer
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 // ============================================================================

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -80,14 +80,39 @@ void ShotHistoryStorage::runDetachedDbThread(std::function<void()> body)
     // Counted, so isDbWorkIdle() can see it. The counter is a shared_ptr for the
     // same reason m_destroyed is: the thread may outlive `this`, and it must still
     // be able to decrement without touching a destroyed object.
-    auto inFlight = m_detachedDbThreads;
-    inFlight->fetch_add(1, std::memory_order_relaxed);
-    QThread* thread = QThread::create([body = std::move(body), inFlight]() {
-        body();
-        // Release, paired with the acquire in isDbWorkIdle(): a reader that sees
-        // zero must also see everything the thread did to the DB file before it.
-        inFlight->fetch_sub(1, std::memory_order_release);
-    });
+    // The decrement is RAII rather than a trailing statement, so an exception escaping
+    // body() cannot latch the counter above zero for the rest of the process. That matters
+    // because a stuck counter makes isDbWorkIdle() permanently false, turning any future
+    // wait on it — a factory reset about to delete the file, a shutdown drain — from a wait
+    // into a hang.
+    //
+    // NOT covered: thread->start() failing. Qt only warns there, run() never executes, and
+    // `finished` never fires, so the QThread is never deleteLater'd and the lambda holding
+    // this guard is never destroyed either. Accepted rather than worked around: it means
+    // the OS refused a thread, the process has bigger problems, and the tests' failOnWarning
+    // would surface Qt's warning immediately. Stated because the first draft of this comment
+    // claimed the guard handled it, which is wrong in a way that reads as reassuring.
+    struct InFlightGuard {
+        std::shared_ptr<std::atomic<int>> counter;
+        explicit InFlightGuard(std::shared_ptr<std::atomic<int>> c) : counter(std::move(c)) {
+            counter->fetch_add(1, std::memory_order_relaxed);
+        }
+        InFlightGuard(InFlightGuard&& other) noexcept : counter(std::move(other.counter)) {}
+        InFlightGuard(const InFlightGuard&) = delete;
+        InFlightGuard& operator=(const InFlightGuard&) = delete;
+        ~InFlightGuard() {
+            // Release, paired with the acquire in isDbWorkIdle(): a reader that sees zero
+            // must also see everything the thread did to the DB file before it. Guarded
+            // because a moved-from copy holds nothing.
+            if (counter)
+                counter->fetch_sub(1, std::memory_order_release);
+        }
+    };
+
+    QThread* thread = QThread::create(
+        [body = std::move(body), guard = InFlightGuard(m_detachedDbThreads)]() mutable {
+            body();
+        });
     connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
 }

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -358,8 +358,14 @@ public:
     // Close the database (for factory reset before file deletion)
     void close();
 
-    // True when no background CRUD work is queued, running, or waiting to deliver
-    // its result. False only while something is in flight.
+    // True when no background DB work is queued, running, or waiting to deliver
+    // its result — covering BOTH the FIFO CRUD worker and the one-shot read
+    // threads from runDetachedDbThread(). False only while something is in flight.
+    //
+    // "Waiting to deliver its result" is exact for the CRUD worker. For a detached
+    // read thread it means the thread has finished touching the DB FILE; its
+    // result callback is already posted and m_destroyed guards it. That is the
+    // granularity callers actually need — it is what makes deleting the file safe.
     //
     // For callers that must not continue until the DB work has really finished —
     // a test tearing this object down, a factory reset about to delete the file —
@@ -422,6 +428,16 @@ private:
     // marshals results back to the main thread itself. Heavy one-shot ops
     // (backup/import) deliberately stay on their own threads.
     void runOnDbThread(std::function<void()> task);
+
+    // Run `body` on a one-shot background thread for a read query that does NOT
+    // need the FIFO ordering runOnDbThread() provides (and for the two heavy
+    // one-shot ops, backup and import). The thread deletes itself when it
+    // finishes and is counted, so isDbWorkIdle() covers it.
+    //
+    // ALWAYS spawn through this, never a bare QThread::create — that boilerplate
+    // was hand-copied at eleven sites, none of which was counted, and one of which
+    // had already drifted to calling start() before the deleteLater connect.
+    void runDetachedDbThread(std::function<void()> body);
 
     bool createTables();
     bool runMigrations();
@@ -503,6 +519,11 @@ private:
     // Atomic because the flag is written on the main thread (destructor) and
     // read on background threads (before QMetaObject::invokeMethod).
     std::shared_ptr<std::atomic<bool>> m_destroyed = std::make_shared<std::atomic<bool>>(false);
+
+    // Number of runDetachedDbThread() threads currently touching the DB file.
+    // shared_ptr for the same reason as m_destroyed — a thread may outlive `this`
+    // and still has to decrement. Read by isDbWorkIdle().
+    std::shared_ptr<std::atomic<int>> m_detachedDbThreads = std::make_shared<std::atomic<int>>(0);
 
     // Serializes shot-CRUD background work onto one FIFO worker thread so
     // successive writes to the same shot row apply in submission order

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -49,7 +49,7 @@ void ShotHistoryStorage::requestDistinctCache()
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, destroyed]() {
+    runDetachedDbThread([this, dbPath, destroyed]() {
         QHash<QString, QStringList> results;
         bool opened = withTempDb(dbPath, "shs_distinct", [&](QSqlDatabase& db) {
             static const QStringList columns = {
@@ -94,8 +94,6 @@ void ShotHistoryStorage::requestDistinctCache()
             }
         }, Qt::QueuedConnection);
     });
-    thread->start();
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 }
 
 void ShotHistoryStorage::requestDistinctValueAsync(const QString& cacheKey, const QString& sql,
@@ -108,7 +106,7 @@ void ShotHistoryStorage::requestDistinctValueAsync(const QString& cacheKey, cons
     auto destroyed = m_destroyed;
     bool needsGrinderSort = cacheKey.startsWith("grinder_setting");
 
-    QThread* thread = QThread::create([this, dbPath, cacheKey, sql, bindValues, needsGrinderSort, destroyed]() {
+    runDetachedDbThread([this, dbPath, cacheKey, sql, bindValues, needsGrinderSort, destroyed]() {
         QStringList values;
         bool opened = withTempDb(dbPath, "shs_dv", [&](QSqlDatabase& db) {
             QSqlQuery query(db);
@@ -146,8 +144,6 @@ void ShotHistoryStorage::requestDistinctValueAsync(const QString& cacheKey, cons
             emit distinctCacheReady();
         }, Qt::QueuedConnection);
     });
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 ShotFilter ShotHistoryStorage::parseFilterMap(const QVariantMap& filterMap)
@@ -440,7 +436,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
     }
 
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create(
+    runDetachedDbThread(
         [this, dbPath, sql, countSql, bindValues, countBindValues, serial, isAppend, destroyed]() {
             QVariantList results;
             int totalCount = 0;
@@ -513,8 +509,6 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                 Qt::QueuedConnection);
         });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 
@@ -527,7 +521,7 @@ void ShotHistoryStorage::requestRecentShotsByKbId(const QString& kbId, int limit
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, kbId, limit, destroyed]() {
+    runDetachedDbThread([this, dbPath, kbId, limit, destroyed]() {
         QVariantList results;
         withTempDb(dbPath, "shs_kbid", [&](QSqlDatabase& db) {
             results = loadRecentShotsByKbIdStatic(db, kbId, limit);
@@ -543,8 +537,6 @@ void ShotHistoryStorage::requestRecentShotsByKbId(const QString& kbId, int limit
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, const QString& kbId, int limit, qint64 excludeShotId)
@@ -660,7 +652,7 @@ void ShotHistoryStorage::requestRankedProfilesForBean(const QString& beanBrand,
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, beanBrand, beanType, roastLevel, teaType, destroyed]() {
+    runDetachedDbThread([this, dbPath, beanBrand, beanType, roastLevel, teaType, destroyed]() {
         QVariantMap result;
         withTempDb(dbPath, "shs_rankedprof", [&](QSqlDatabase& db) {
             result = loadRankedProfilesForBeanStatic(db, beanBrand, beanType, roastLevel, teaType);
@@ -677,8 +669,6 @@ void ShotHistoryStorage::requestRankedProfilesForBean(const QString& beanBrand,
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 QVariantMap ShotHistoryStorage::loadRankedProfilesForBeanStatic(QSqlDatabase& db,
@@ -776,7 +766,7 @@ void ShotHistoryStorage::requestLatestShotForBeanProfile(const QString& beanBran
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, beanBrand, beanType, profileName, destroyed]() {
+    runDetachedDbThread([this, dbPath, beanBrand, beanType, profileName, destroyed]() {
         QVariantMap shot;
         withTempDb(dbPath, "shs_beanprof", [&](QSqlDatabase& db) {
             shot = loadLatestShotForBeanProfileStatic(db, beanBrand, beanType, profileName);
@@ -789,8 +779,6 @@ void ShotHistoryStorage::requestLatestShotForBeanProfile(const QString& beanBran
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 QVariantMap ShotHistoryStorage::loadLatestShotForBeanProfileStatic(QSqlDatabase& db,
@@ -860,7 +848,7 @@ void ShotHistoryStorage::requestLatestGrindForBean(const QString& beanBrand,
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, beanBrand, beanType, roastLevel, destroyed]() {
+    runDetachedDbThread([this, dbPath, beanBrand, beanType, roastLevel, destroyed]() {
         QVariantMap grind;
         withTempDb(dbPath, "shs_beangrind", [&](QSqlDatabase& db) {
             grind = loadLatestGrindForBeanStatic(db, beanBrand, beanType, roastLevel);
@@ -879,8 +867,6 @@ void ShotHistoryStorage::requestLatestGrindForBean(const QString& beanBrand,
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 QVariantMap ShotHistoryStorage::loadLatestGrindForBeanStatic(QSqlDatabase& db,
@@ -1352,7 +1338,7 @@ void ShotHistoryStorage::requestAutoFavorites(const QString& groupBy, int maxIte
         "LIMIT %4"
     ).arg(selectColumns, groupColumns, joinConditions).arg(maxItems).arg(yieldCol, bucketCol);
 
-    QThread* thread = QThread::create([this, dbPath, sql, destroyed]() {
+    runDetachedDbThread([this, dbPath, sql, destroyed]() {
         QVariantList results;
         if (!withTempDb(dbPath, "shs_raf", [&](QSqlDatabase& db) {
             QSqlQuery query(db);
@@ -1397,8 +1383,6 @@ void ShotHistoryStorage::requestAutoFavorites(const QString& groupBy, int maxIte
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 void ShotHistoryStorage::requestAutoFavoriteGroupDetails(const QString& groupBy,
@@ -1484,7 +1468,7 @@ void ShotHistoryStorage::requestAutoFavoriteGroupDetails(const QString& groupBy,
         " AND espresso_notes IS NOT NULL AND espresso_notes != '' "
         "ORDER BY timestamp DESC";
 
-    QThread* thread = QThread::create([this, dbPath, statsSql, notesSql, bindValues, destroyed]() {
+    runDetachedDbThread([this, dbPath, statsSql, notesSql, bindValues, destroyed]() {
         QVariantMap result;
         if (!withTempDb(dbPath, "shs_ragd", [&](QSqlDatabase& db) {
             // Stats query
@@ -1538,8 +1522,6 @@ void ShotHistoryStorage::requestAutoFavoriteGroupDetails(const QString& groupBy,
         }, Qt::QueuedConnection);
     });
 
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 

--- a/tests/tst_mcptools_write.cpp
+++ b/tests/tst_mcptools_write.cpp
@@ -688,6 +688,8 @@ private slots:
         QCOMPARE(result["recipeId"].toInteger(), recipeId);
         QCOMPARE(result["name"].toString(), QString("Morning Latte"));
         QCOMPARE(result["revertMinutes"].toInt(), 15);
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeGetAutoLoadStaleIdReturnsNullNotError()
@@ -705,6 +707,8 @@ private slots:
         QJsonObject result = f.callAsyncTool("recipe_get_auto_load", {});
         QVERIFY(result["recipeId"].isNull());
         QVERIFY(!result.contains("error"));
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeGetAutoLoadConfiguredButStorageUnavailableIsError()
@@ -747,6 +751,8 @@ private slots:
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), static_cast<int>(recipeId));
         // Mutual exclusion: setting a recipe auto-load clears the profile side.
         QCOMPARE(f.settings.app()->autoLoadProfileFilename(), QString());
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeSetAutoLoadMissingRecipeIdIsError()
@@ -809,6 +815,8 @@ private slots:
         QJsonObject result = f.callAsyncTool("recipe_set_auto_load", args);
         QCOMPARE(result["error"].toString(), QString("Recipe not found: 99999"));
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), before);
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeSetAutoLoadArchivedIsError()
@@ -828,6 +836,8 @@ private slots:
         QJsonObject result = f.callAsyncTool("recipe_set_auto_load", args);
         QCOMPARE(result["error"].toString(), QString("Recipe is archived"));
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), before);
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeSetAutoLoadOverwritesExistingPin()
@@ -857,6 +867,8 @@ private slots:
         QVERIFY2(resultSecond["success"].toBool(), qPrintable(QJsonDocument(resultSecond).toJson()));
         QCOMPARE(resultSecond["recipeId"].toInteger(), second);
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), static_cast<int>(second));
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeSetAutoLoadOptionalRevertMinutesUpdatesSharedSetting()
@@ -878,6 +890,8 @@ private slots:
         QCOMPARE(result["revertMinutes"].toInt(), 33);
         // Shared with the profile side.
         QCOMPARE(f.settings.app()->autoLoadRevertMinutes(), 33);
+        drainDbWork(storage);
+        storage.close();
     }
 
     void recipeClearAutoLoadSuccessPreservesRevertMinutes()

--- a/tests/tst_mcptools_write.cpp
+++ b/tests/tst_mcptools_write.cpp
@@ -75,10 +75,21 @@ private:
     // timing. QTRY_VERIFY spins the event loop (which is what delivers the result
     // callbacks) and fails loudly if the work never completes, instead of
     // continuing regardless the way the sleep did.
-    static void drainDbWork(ShotHistoryStorage& storage) {
+    // Drain, THEN close -- in that order, and only if the drain succeeded.
+    //
+    // The two were previously written as a `drainDbWork(storage); storage.close();` pair at
+    // all 12 call sites. That is a drift opportunity (nothing enforces the order, or that
+    // both are present), and it also mishandles failure: QTRY_VERIFY inside a non-slot
+    // helper returns from the HELPER, so a timed-out drain fell straight through to the
+    // close() it exists to protect, whose warning then became a second, louder failure that
+    // buried the first. Returning early here instead leaves the close to
+    // ~ShotHistoryStorage, which resets the worker (and WAITS) before closing -- so the
+    // teardown is safe even on the failure path.
+    static void drainDbWorkAndClose(ShotHistoryStorage& storage) {
         QTRY_VERIFY(storage.isDbWorkIdle());
         // One more pass for anything the final callback itself posted.
         QCoreApplication::processEvents();
+        storage.close();
     }
 
     // Load a minimal D-Flow profile
@@ -422,8 +433,7 @@ private slots:
         // qWarns "connection is still in use" if background work still holds one —
         // and failOnWarning makes that a failure. Closing first was the original
         // order, with the sleep afterwards hoping the work had already finished.
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     // equipment_update: a name-only rename must be REPORTED as a success, not
@@ -475,8 +485,7 @@ private slots:
         // qWarns "connection is still in use" if background work still holds one —
         // and failOnWarning makes that a failure. Closing first was the original
         // order, with the sleep afterwards hoping the work had already finished.
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     // bag_create (add-recipe-wizard-tea): kind stamped at creation, gated in
@@ -531,8 +540,7 @@ private slots:
         // qWarns "connection is still in use" if background work still holds one —
         // and failOnWarning makes that a failure. Closing first was the original
         // order, with the sleep afterwards hoping the work had already finished.
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     // bag_update kind gate runs on the static path (nullptr bagStorage): tea
@@ -575,8 +583,7 @@ private slots:
         // qWarns "connection is still in use" if background work still holds one —
         // and failOnWarning makes that a failure. Closing first was the original
         // order, with the sleep afterwards hoping the work had already finished.
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     // The linked-bag case is where the MCP wiring does real work: the tool
@@ -636,8 +643,7 @@ private slots:
         // qWarns "connection is still in use" if background work still holds one —
         // and failOnWarning makes that a failure. Closing first was the original
         // order, with the sleep afterwards hoping the work had already finished.
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     // ===== recipe_get/set/clear_auto_load (recipe-auto-load) =====
@@ -688,8 +694,7 @@ private slots:
         QCOMPARE(result["recipeId"].toInteger(), recipeId);
         QCOMPARE(result["name"].toString(), QString("Morning Latte"));
         QCOMPARE(result["revertMinutes"].toInt(), 15);
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeGetAutoLoadStaleIdReturnsNullNotError()
@@ -707,8 +712,7 @@ private slots:
         QJsonObject result = f.callAsyncTool("recipe_get_auto_load", {});
         QVERIFY(result["recipeId"].isNull());
         QVERIFY(!result.contains("error"));
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeGetAutoLoadConfiguredButStorageUnavailableIsError()
@@ -751,8 +755,7 @@ private slots:
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), static_cast<int>(recipeId));
         // Mutual exclusion: setting a recipe auto-load clears the profile side.
         QCOMPARE(f.settings.app()->autoLoadProfileFilename(), QString());
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeSetAutoLoadMissingRecipeIdIsError()
@@ -815,8 +818,7 @@ private slots:
         QJsonObject result = f.callAsyncTool("recipe_set_auto_load", args);
         QCOMPARE(result["error"].toString(), QString("Recipe not found: 99999"));
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), before);
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeSetAutoLoadArchivedIsError()
@@ -836,8 +838,7 @@ private slots:
         QJsonObject result = f.callAsyncTool("recipe_set_auto_load", args);
         QCOMPARE(result["error"].toString(), QString("Recipe is archived"));
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), before);
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeSetAutoLoadOverwritesExistingPin()
@@ -867,8 +868,7 @@ private slots:
         QVERIFY2(resultSecond["success"].toBool(), qPrintable(QJsonDocument(resultSecond).toJson()));
         QCOMPARE(resultSecond["recipeId"].toInteger(), second);
         QCOMPARE(f.settings.dye()->autoLoadRecipeId(), static_cast<int>(second));
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeSetAutoLoadOptionalRevertMinutesUpdatesSharedSetting()
@@ -890,8 +890,7 @@ private slots:
         QCOMPARE(result["revertMinutes"].toInt(), 33);
         // Shared with the profile side.
         QCOMPARE(f.settings.app()->autoLoadRevertMinutes(), 33);
-        drainDbWork(storage);
-        storage.close();
+        drainDbWorkAndClose(storage);
     }
 
     void recipeClearAutoLoadSuccessPreservesRevertMinutes()

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -31,6 +31,36 @@ private:
         }
     }
 
+    // Feed a stable plateau until the clean-avg capture gate fires, then stop.
+    //
+    // The gate needs SETTLING_CLEAN_CAPTURE_MS (250 ms) of continuous stability,
+    // but the WHOLE loop has to finish inside SETTLING_STABLE_MS (1000 ms) — or the
+    // stability timer completes settling on its own and the post-settling path the
+    // caller exists to test never runs at all.
+    //
+    // Three tests each hand-rolled `for (i < 14 or 15) { sample; qWait(50) }` and
+    // budgeted it in a comment as 700-750 ms against that 1000 ms ceiling. But
+    // QTest::qWait waits AT LEAST its argument: in the parallel ASan/UBSan suite the
+    // 15-iteration one measured **1015 ms**, settling completed by timer, and the test
+    // failed on an unrelated final-weight assertion that said nothing about why. That
+    // is the "timers as guards" anti-pattern CLAUDE.md names by name, living in a test.
+    //
+    // Looping on the CONDITION instead spends the minimum wall time — the gate fires
+    // around sample 7, ~350 ms — so it cannot overshoot. The isSawSettling() check is
+    // the point of the helper: if the ceiling is ever hit anyway, the failure says so.
+    void feedPlateauUntilCaptured(ShotTimingController& tc, double grams, double flow) {
+        for (int i = 0; i < 20 && tc.m_lastCleanSettlingAvg <= 0.0; ++i) {
+            tc.onWeightSample(grams, flow);
+            QTest::qWait(50);
+        }
+        QVERIFY2(tc.m_lastCleanSettlingAvg > 0.0,
+                 "Capture gate never fired on the plateau");
+        QVERIFY2(tc.isSawSettling(),
+                 "Settling completed on the stability timer before the plateau loop "
+                 "finished, so the path under test never ran. The machine was too "
+                 "loaded for the loop to stay inside SETTLING_STABLE_MS.");
+    }
+
 private slots:
     void init() { QTest::failOnWarning(); }
 
@@ -354,21 +384,12 @@ private slots:
         QTest::ignoreMessage(QtWarningMsg,
             QRegularExpression("rejected as scale fault"));
 
-        // Simulate a frozen-scale fault: a long run of identical samples
-        // at 74.8 g (35+ g above stop weight). The gate fires once the
-        // rolling window fills (SETTLING_WINDOW_SIZE = 6) and then
-        // consecutively. We need the post-window-fill cumulative qWait
-        // to exceed SETTLING_CLEAN_CAPTURE_MS (250 ms): 15 samples × 50 ms
-        // = 750 ms total wall time; subtracting the first 6 samples that
-        // fill the window leaves 9 post-fill intervals × 50 ms = 450 ms,
-        // comfortably above the 250 ms capture threshold.
-        for (int i = 0; i < 15; ++i) {
-            tc.onWeightSample(74.8, 0.0);
-            QTest::qWait(50);
-        }
-        // Confirm the capture did happen (we DON'T want to silently rely
-        // on the capture gate having filtered it — the plausibility cap
-        // is the layer being tested).
+        // Simulate a frozen-scale fault: a run of identical samples at 74.8 g
+        // (35+ g above stop weight), held until the capture gate fires.
+        feedPlateauUntilCaptured(tc, 74.8, 0.0);
+        // Confirm the capture landed on the GLITCH value (we DON'T want to
+        // silently rely on the capture gate having filtered it — the
+        // plausibility cap is the layer being tested).
         QVERIFY2(tc.m_lastCleanSettlingAvg > 70.0,
                  "Capture gate should have fired on the frozen plateau");
 
@@ -436,17 +457,12 @@ private slots:
         DE1Device device;
         ShotTimingController tc(&device);
 
-        // Shot N: capture a clean avg via the same QTest::qWait pattern
-        // the _1280 plateau test uses.
+        // Shot N: capture a clean avg via the same plateau helper the _1280
+        // test uses.
         tc.startShot();
         tc.onSawTriggered(35.0, 2.5, 36.0);
         tc.endShot();
-        for (int i = 0; i < 14; ++i) {
-            tc.onWeightSample(36.0, 0.5);
-            QTest::qWait(50);
-        }
-        QVERIFY2(tc.m_lastCleanSettlingAvg > 0.0,
-                 "Capture gate should have fired on the plateau");
+        feedPlateauUntilCaptured(tc, 36.0, 0.5);
 
         // Starting shot N+1 while shot N is still settling warns that it's
         // cancelling the settling timer and saving the previous shot — exactly
@@ -485,10 +501,7 @@ private slots:
             QRegularExpression("Cup removed during settling"));
 
         // Establish the captured value with a stable plateau.
-        for (int i = 0; i < 14; ++i) {
-            tc.onWeightSample(42.3, 0.5);
-            QTest::qWait(50);
-        }
+        feedPlateauUntilCaptured(tc, 42.3, 0.5);
         const double capturedAvg = tc.m_lastCleanSettlingAvg;
         QVERIFY2(capturedAvg > 41.0 && capturedAvg < 43.0,
                  "Plateau should produce a clean avg near 42.3 g");

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -45,11 +45,24 @@ private:
     // failed on an unrelated final-weight assertion that said nothing about why. That
     // is the "timers as guards" anti-pattern CLAUDE.md names by name, living in a test.
     //
-    // Looping on the CONDITION instead spends the minimum wall time — the gate fires
-    // around sample 7, ~350 ms — so it cannot overshoot. The isSawSettling() check is
-    // the point of the helper: if the ceiling is ever hit anyway, the failure says so.
+    // Looping on the CONDITION instead spends the minimum wall time, so it cannot
+    // overshoot by feeding samples nobody needs. The isSawSettling() check is the point of
+    // the helper: if the ceiling is hit anyway, the failure says so instead of surfacing
+    // as a wrong final weight three assertions later.
+    //
+    // TIMING, derived from the constants rather than guessed. The window fills on the 6th
+    // sample (SETTLING_WINDOW_SIZE = 6), which is when the stability clock STARTS; the gate
+    // then needs SETTLING_CLEAN_CAPTURE_MS (250 ms) more, i.e. 5 further samples at 50 ms.
+    // So capture lands on roughly the 11th sample, ~500 ms — against a 1000 ms ceiling.
+    // An earlier version of this comment said "around sample 7, ~350 ms", which was wrong
+    // in the direction that matters: it made the margin look twice as large as it is.
+    //
+    // Hence the cap of 16 rather than 20. Twenty iterations is 1000 ms, exactly
+    // SETTLING_STABLE_MS — a bound sitting precisely on the threshold it exists to stay
+    // under, which is no bound at all. Sixteen leaves ~300 ms of headroom past the ~500 ms
+    // the gate actually needs, and still stops short of the ceiling.
     void feedPlateauUntilCaptured(ShotTimingController& tc, double grams, double flow) {
-        for (int i = 0; i < 20 && tc.m_lastCleanSettlingAvg <= 0.0; ++i) {
+        for (int i = 0; i < 16 && tc.m_lastCleanSettlingAvg <= 0.0; ++i) {
             tc.onWeightSample(grams, flow);
             QTest::qWait(50);
         }
@@ -387,6 +400,11 @@ private slots:
         // Simulate a frozen-scale fault: a run of identical samples at 74.8 g
         // (35+ g above stop weight), held until the capture gate fires.
         feedPlateauUntilCaptured(tc, 74.8, 0.0);
+        // QVERIFY2 inside a non-slot helper returns from the HELPER, not the test, so
+        // without this the test would keep asserting against state the helper just
+        // reported as bad -- and the failure it printed would be buried under the
+        // downstream one. That is the same diagnosis problem the helper exists to fix.
+        QVERIFY(!QTest::currentTestFailed());
         // Confirm the capture landed on the GLITCH value (we DON'T want to
         // silently rely on the capture gate having filtered it — the
         // plausibility cap is the layer being tested).
@@ -463,6 +481,11 @@ private slots:
         tc.onSawTriggered(35.0, 2.5, 36.0);
         tc.endShot();
         feedPlateauUntilCaptured(tc, 36.0, 0.5);
+        // QVERIFY2 inside a non-slot helper returns from the HELPER, not the test, so
+        // without this the test would keep asserting against state the helper just
+        // reported as bad -- and the failure it printed would be buried under the
+        // downstream one. That is the same diagnosis problem the helper exists to fix.
+        QVERIFY(!QTest::currentTestFailed());
 
         // Starting shot N+1 while shot N is still settling warns that it's
         // cancelling the settling timer and saving the previous shot — exactly
@@ -502,6 +525,11 @@ private slots:
 
         // Establish the captured value with a stable plateau.
         feedPlateauUntilCaptured(tc, 42.3, 0.5);
+        // QVERIFY2 inside a non-slot helper returns from the HELPER, not the test, so
+        // without this the test would keep asserting against state the helper just
+        // reported as bad -- and the failure it printed would be buried under the
+        // downstream one. That is the same diagnosis problem the helper exists to fix.
+        QVERIFY(!QTest::currentTestFailed());
         const double capturedAvg = tc.m_lastCleanSettlingAvg;
         QVERIFY2(capturedAvg > 41.0 && capturedAvg < 43.0,
                  "Plateau should produce a clean avg near 42.3 g");


### PR DESCRIPTION
Referencing a member on an object whose type comes from **QtQuick.Controls** fails AOT compilation: `QtQuick/Controls/qmldir` declares no types, every concrete type arrives from a style module chosen at run time, and qmlcachegen cannot walk that base chain at build time. #1715 fixed it for pages; this does the button family, `main.qml`'s `ApplicationWindow`, and every dialog.

## Measured

On a cache forced consistent:

```
                        post-#1715      this PR
AOT compiled          18168 (62.5%)   20459 (70.3%)
skipped                9504 (32.7%)    7223 (24.8%)
partial                1415 ( 4.9%)    1415 ( 4.9%)
```

`root` and `popup` id skips are gone; the missing-member class fell 2,653 → 676.

**The total moved by less than the parts, and both numbers are right.** Resolving a type lets qmlcachegen reach further into bindings it used to abandon at the first unresolvable member, where it hits the next blocker. `TranslationManager.translate` went 1,833 → 2,253 and is now 31% of everything left — it has grown at every step, and it is the program's floor, not its next target. **Diff per-cause, never on the total.**

## What each part needed

**Buttons** (`AccessibleButton`, `StyledIconButton`, `ActionButton`, `StyledSwitch`) were near-drop-ins: all four already replaced `contentItem`/`background`/`indicator` and use no Material attached property, so nothing of the style's QML reached the screen. What did — the `implicitWidth` formula (`qquickcontrol.cpp:1749-1757`: it lives only in style QML, so a Templates root without it is 0 wide), the insets, and the padding — is re-declared with its Qt source cited.

**`ApplicationWindow`** was one line for 583 skips: Material's `ApplicationWindow.qml` is three lines whose only content is `color: Material.backgroundColor`, already overridden.

**Dialogs were the case where per-file re-rooting would have been wrong.** Unlike the buttons, the style's `Dialog.qml` contributed things genuinely on screen that no dialog overrode — the grow-fade transitions, the modal dim, and the header that renders `title`. Not one of the 131 sites declared `enter`/`exit`. `DecenzaDialog.qml` carries them once. Two facts made a single base sufficient, both checked rather than assumed: all 104 inline blocks override `background` (established by walking each block's braces), and the tree's only `Dialog`-specific API is `onRejected`, which `T.Dialog` has.

`ColoredIcon` is deliberately **not** migrated — its mechanism is Material's internal `IconLabel` doing `icon.color` tinting. Three inline `Popup {}` blocks are left alone too: the base carries `Dialog`'s `modal: true`, which would start dimming the screen behind them.

## Also fixed

**The cross-file QML cache staleness this repo has documented for months.** qmlcachegen resolves QML-declared types by *reading* other files through `-I`, does not declare them as inputs, and has no `--depfile`. Editing `Theme.qml` changed how ~214 units should compile and rebuilt none of them — a build that was quietly wrong, not merely stale. `CMakeLists.txt` now makes every unit depend on every `.qml`. Affordable because of `restat`: qmlcachegen is 205 ms median per file against 3387 ms to compile what it emits, so ninja prunes every unit whose output is byte-identical.

**A real threading defect.** `isDbWorkIdle()` claimed to cover all background DB work but only saw the FIFO worker; eleven read queries spawn detached threads that bypass it, and `initialize()` starts one — so every user of `ShotHistoryStorage` had an uncounted thread running against the DB file. Now centralized behind `runDetachedDbThread()`, counted, with an RAII decrement.

**A latent test flake.** Three `tst_settling` tests budgeted `qWait(50)` loops at 700-750 ms against a 1000 ms ceiling; under the parallel ASan suite one measured 1015 ms, settling completed on the timer, and the path under test never ran.

## Review

Five defects found and fixed, two of which would have shipped: `StyledSwitch` had lost Material's `padding: 8` (switches 12 px shorter, undoing a deliberate touch-target fix), and three dialogs with `title:` rendered no heading. Both traced to the same habit — verifying the 104 inline blocks for one property and then writing conclusions about all 131 into comments as fact. The dependency-wiring gate was also found to be incapable of passing (221 expected vs 214 matchable) and its stated rationale false: `add_custom_command(APPEND)` against a non-matching OUTPUT is a hard configure error, not a silent no-op, established by reproduction.

## Verification

Full suite 110/110. qmllint 221/221. Visual pass over idle, settings, shot history, shot detail and dialogs; transitions measured running at 220-224 ms; the dialog header confirmed rendering by temporarily setting a title, because the log could only show the binding evaluated, not that it was true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
