### PR TITLE
Count the Home Assistant discovery entities instead of naming each one

### DIFF
--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -1138,12 +1138,31 @@ void MqttClient::publishDiscoveryConfig(const QString& component, const QString&
     QString payload = QJsonDocument(config).toJson(QJsonDocument::Compact);
 
     publish(topic, payload, true);
-    qDebug() << "MqttClient: Published discovery for" << objectId;
+
+    // COUNTED, not logged one line per entity.
+    //
+    // This was a qDebug() naming each objectId, so a startup carried 22 lines
+    // emitted inside 50 ms, followed by a summary line that already said the same
+    // thing. On a real tablet that made MqttClient the single largest class prefix
+    // in a startup session — 30 of 247 lines, 12% — and it repeats on every
+    // reconnect, not just launch.
+    //
+    // The list carries no per-run information: it is a fixed set compiled into
+    // publishHomeAssistantDiscovery(), identical every time, so a reader learns
+    // nothing from the 22nd line that the 1st did not tell them. What IS per-run
+    // is a FAILURE to publish one, and publish() already reports that at WARN
+    // (see its MQTTASYNC_SUCCESS check) — which the DEBUG line never did, since
+    // it printed unconditionally whether or not the send succeeded.
+    ++m_discoveryEntityCount;
 }
 
 void MqttClient::publishHomeAssistantDiscovery()
 {
     if (!m_settingsMqtt) return;
+
+    // Reset per call, not per process: this runs again on every reconnect, and a
+    // cumulative count would report 44 entities on the second pass.
+    m_discoveryEntityCount = 0;
 
     QString baseTopic = m_settingsMqtt->mqttBaseTopic();
     QJsonObject device = buildDeviceInfo();
@@ -1436,5 +1455,9 @@ void MqttClient::publishHomeAssistantDiscovery()
     }
 
     m_discoveryPublished = true;
-    qDebug() << "MqttClient: Home Assistant discovery published";
+    // The count is the part a reader can act on: it says the set was complete
+    // without spending a line per member. A short count is the signal that
+    // something returned early.
+    qDebug() << "MqttClient: Home Assistant discovery published —"
+             << m_discoveryEntityCount << "entities";
 }

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -193,6 +193,10 @@ private:
     QString m_status;
     bool m_connected = false;
     bool m_discoveryPublished = false;
+    // Entities published by the current publishHomeAssistantDiscovery() pass, so the
+    // one summary line can report the set was complete without a line per member.
+    // Reset at the top of that function — it runs again on every reconnect.
+    int m_discoveryEntityCount = 0;
     QString m_lastPublishedState;
     QString m_lastPublishedPhase;
     QString m_lastPublishedSubstate;


### PR DESCRIPTION
Found by reading the tablet's log with `debug_get_log families=true session=-1` — the same census pass that produced [#1719](https://github.com/Kulitorum/Decenza/pull/1719).

## The problem

`MqttClient` was the single largest class prefix in a startup session on real hardware — **30 of 247 lines, 12%** — and 22 of those were one burst inside 50 ms:

```
[3.848] DEBUG MqttClient: Published discovery for "state"
[3.850] DEBUG MqttClient: Published discovery for "phase"
…20 more…
[3.896] DEBUG MqttClient: Home Assistant discovery published
```

The summary line at the end already said it happened. It repeats on every reconnect, not just launch.

## Why the 22 lines carry no signal

The list is a **fixed set** compiled into `publishHomeAssistantDiscovery()` — identical every run — so a reader learns nothing from the 22nd line that the 1st did not tell them.

What *is* per-run is a **failure** to publish one, and `publish()` already reports that at WARN via its `MQTTASYNC_SUCCESS` check. The DEBUG line never did: it printed unconditionally, whether or not the send succeeded. So removing it removes no signal, and arguably removes a misleading one.

## The change

Per-entity `qDebug` replaced with a counter; the surviving summary reports it:

```
MqttClient: Home Assistant discovery published — 22 entities
```

A short count is now the signal that something returned early — which nothing reported before.

The counter resets at the top of `publishHomeAssistantDiscovery()` rather than at construction, because it runs again on every reconnect and a cumulative count would report 44 on the second pass.

## Effect

A tablet startup drops `MqttClient` from 30 lines to 8, and from largest class prefix to unremarkable.

Build and full suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)