### PR TITLE
Stop the memory peak line ratcheting up through RSS jitter

### DIFF
--- a/src/core/memorymonitor.cpp
+++ b/src/core/memorymonitor.cpp
@@ -55,9 +55,27 @@ void MemoryMonitor::onSampleTimerTick()
         m_firstSample = false;
     }
 
-    const bool newPeak = (rss > m_peakRss);
-    if (newPeak)
+    // TRACKING the peak is exact and unconditional — peakRssMB() and the JSON
+    // snapshot report it, and a threshold there would make them wrong.
+    if (rss > m_peakRss)
         m_peakRss = rss;
+
+    // PRINTING a peak is a separate decision, and it needs the same 5 MB band the
+    // RSS gate below uses. "Any new peak always prints" ratchets on noise: on a
+    // real tablet RSS jitters 111-120 MB, so the peak climbed 113.7 -> 114.1 ->
+    // 116.2 -> 119.1 -> 120.3 and printed five times in the first 36 minutes.
+    // Those are not five events, they are one plateau being sampled, and a peak
+    // 0.4 MB above the last is not news. The tell was that the lines stopped
+    // entirely once 120.3 was reached — nothing had changed except that the
+    // ratchet ran out of headroom.
+    //
+    // Measured against the last peak PRINTED, so a genuine climb still reports
+    // once per 5 MB gained and cannot be starved by intermediate noise.
+    constexpr quint64 kPeakLogStepBytes = 5ull * 1024 * 1024;
+    const bool newPeak = (m_lastLoggedPeakRss == 0)
+                         || (m_peakRss >= m_lastLoggedPeakRss + kPeakLogStepBytes);
+    if (newPeak)
+        m_lastLoggedPeakRss = m_peakRss;
 
     MemorySample sample;
     sample.timestampMs = QDateTime::currentMSecsSinceEpoch();
@@ -79,8 +97,9 @@ void MemoryMonitor::onSampleTimerTick()
     //
     // The gate text is QUANTIZED rather than the message itself, because the message never repeats
     // byte-for-byte — RSS moves 0.1 MB between any two samples. "Same plateau" collapses while a
-    // real step change prints at once. A new peak always prints: it is the one sample that cannot
-    // be reconstructed from a later line.
+    // real step change prints at once. A new peak prints too — it is the one sample that cannot be
+    // reconstructed from a later line — but only once per 5 MB gained; see the peak gate above for
+    // why "any new peak" was wrong.
     //
     // QUANTIZED AGAINST THE LAST LINE PRINTED, NOT A FIXED BUCKET. This used
     // static_cast<int>(rssMB / 5.0), and a real Android capture shows why that fails: RSS sat at

--- a/src/core/memorymonitor.h
+++ b/src/core/memorymonitor.h
@@ -81,6 +81,11 @@ private:
     // RSS as of the last line PRINTED — the anchor the 5 MB band is measured from, so a value
     // sitting on a fixed bucket edge cannot oscillate across it. Negative until the first line.
     double m_lastLoggedRssMB = -1.0;
+    // Peak RSS as of the last line printed BECAUSE of a new peak. Distinct from m_peakRss, which
+    // tracks the true peak exactly for peakRssMB() and the JSON snapshot: this one only decides
+    // whether a peak is worth a line, so a peak ratcheting up through jitter stays quiet. Zero
+    // until the first line.
+    quint64 m_lastLoggedPeakRss = 0;
 
     // Per-class QObject tracking
     QHash<QString, int> m_classCounts;          // Current snapshot


### PR DESCRIPTION
Found by reading the tablet's 2h 7m session with `debug_get_log families=true session=-1` — the verification pass for [#1719](https://github.com/Kulitorum/Decenza/pull/1719) and [#1721](https://github.com/Kulitorum/Decenza/pull/1721).

## What the log showed

Those two PRs worked: `[Screensaver]` went 260 → 5 lines per session, `MqttClient` 30 → 10, `[Memory]` 160 → 22, and a 2-hour session carried **zero WARNs**.

But `[Memory]`'s remaining 22 split into two causes, and one is a defect:

- **~12 lines** are the 10-minute `LogCollapse` window heartbeat restating a plateau. Working as designed, and the `(+9 identical in the preceding 600 s)` suffixes show the collapse folding 4–10 samples per line.
- **~6 lines** are `newPeak`, which is this bug.

## The bug

`const bool newPeak = (rss > m_peakRss)` — no threshold. RSS jitters 111–120 MB, so the peak ratchets up through noise:

```
peak: 113.7 → 114.1 → 116.2 → 119.1 → 120.3
```

Five lines in the first 36 minutes for one plateau being sampled. A peak 0.4 MB above the last is not news.

The tell: the peak lines **stopped entirely** once 120.3 was reached. Nothing had changed about the app — the ratchet had just run out of headroom.

This is the same shape as the two gates already fixed in this file and `ScreensaverPage`: a threshold-free comparison against a jittery value.

## The fix

Peak **tracking** stays exact and unconditional — `peakRssMB()` and the JSON snapshot report `m_peakRss`, and a threshold there would make them wrong.

Only the decision to **print** a peak takes the same 5 MB band the RSS gate uses, measured against the last peak *printed*, so a genuine climb still reports once per 5 MB gained and cannot be starved by intermediate noise.

Expected effect on the same session: `[Memory]` 22 → ~16, with the remainder being the deliberate window heartbeat.

Full suite: 110 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)