### PR TITLE
Wait for the database workers before quitting

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -64,6 +64,8 @@
 #ifdef Q_OS_ANDROID
 #include <QJniObject>
 #endif
+#include <QEventLoop>
+#include <QTimer>
 #include <QQmlEngine>
 #include <QJSEngine>
 
@@ -2468,6 +2470,42 @@ void MainController::applyHotWaterSettings() {
 
 void MainController::applyFlushSettings() {
     sendMachineSettings(QStringLiteral("applyFlushSettings"));
+}
+
+bool MainController::drainDbWork(int timeoutMs) {
+    const auto allIdle = [this]() {
+        return (!m_shotHistory      || m_shotHistory->isDbWorkIdle())
+            && (!m_bagStorage       || m_bagStorage->isDbWorkIdle())
+            && (!m_equipmentStorage || m_equipmentStorage->isDbWorkIdle())
+            && (!m_recipeStorage    || m_recipeStorage->isDbWorkIdle());
+    };
+
+    if (allIdle())
+        return true;
+
+    // Polled, not signalled: the workers count outstanding tasks in an atomic and
+    // emit nothing when it reaches zero, so there is no edge to connect to. This
+    // is the periodic-task case the timer rule allows, not a timer standing in
+    // for a condition — the condition is checked directly on every tick.
+    QEventLoop loop;
+    QTimer poll;
+    poll.setInterval(20);
+    QObject::connect(&poll, &QTimer::timeout, &loop, [&]() {
+        if (allIdle())
+            loop.quit();
+    });
+    QTimer::singleShot(timeoutMs, &loop, [&loop]() { loop.quit(); });
+    poll.start();
+    loop.exec();
+
+    const bool drained = allIdle();
+    if (drained)
+        qDebug() << "Storage writes drained before exit.";
+    else
+        qWarning() << "Storage writes did not drain within" << timeoutMs
+                   << "ms — queued database work is about to be discarded. Expect a"
+                      "\"destroyed with N DB task(s) still queued\" warning next.";
+    return drained;
 }
 
 void MainController::applyAllSettings() {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2472,16 +2472,21 @@ void MainController::applyFlushSettings() {
     sendMachineSettings(QStringLiteral("applyFlushSettings"));
 }
 
-bool MainController::drainDbWork(int timeoutMs) {
+void MainController::drainDbWork(int timeoutMs) {
+    // isDbWriteWorkIdle() on the shot history, not isDbWorkIdle(): the latter also
+    // counts detached read/backup/import threads, which SerialDbWorker never
+    // tracks and ~SerialDbWorker therefore cannot discard. Waiting on those spent
+    // the whole budget on a quit-during-backup for nothing. The other three have
+    // no detached threads, so their isDbWorkIdle() is already write-only.
     const auto allIdle = [this]() {
-        return (!m_shotHistory      || m_shotHistory->isDbWorkIdle())
+        return (!m_shotHistory      || m_shotHistory->isDbWriteWorkIdle())
             && (!m_bagStorage       || m_bagStorage->isDbWorkIdle())
             && (!m_equipmentStorage || m_equipmentStorage->isDbWorkIdle())
             && (!m_recipeStorage    || m_recipeStorage->isDbWorkIdle());
     };
 
     if (allIdle())
-        return true;
+        return;
 
     // Polled, not signalled: the workers count outstanding tasks in an atomic and
     // emit nothing when it reaches zero, so there is no edge to connect to. This
@@ -2498,14 +2503,32 @@ bool MainController::drainDbWork(int timeoutMs) {
     poll.start();
     loop.exec();
 
-    const bool drained = allIdle();
-    if (drained)
+    if (allIdle()) {
         qDebug() << "Storage writes drained before exit.";
-    else
-        qWarning() << "Storage writes did not drain within" << timeoutMs
-                   << "ms — queued database work is about to be discarded. Expect a"
-                      "\"destroyed with N DB task(s) still queued\" warning next.";
-    return drained;
+        return;
+    }
+
+    // Name the storage. Four collapse into one message otherwise, and which one
+    // is stuck is the only fact that makes this actionable.
+    QStringList stuck;
+    if (m_shotHistory      && !m_shotHistory->isDbWriteWorkIdle()) stuck << "shots";
+    if (m_bagStorage       && !m_bagStorage->isDbWorkIdle())       stuck << "bags";
+    if (m_equipmentStorage && !m_equipmentStorage->isDbWorkIdle()) stuck << "equipment";
+    if (m_recipeStorage    && !m_recipeStorage->isDbWorkIdle())    stuck << "recipes";
+
+    // Deliberately does NOT tell the reader to look for ~SerialDbWorker's
+    // "destroyed with N DB task(s) still queued" line. That fires during static
+    // teardown, after AsyncLogger::uninstall() has already closed the log — so it
+    // reaches stderr/logcat and never the debug log a user submits. Pointing them
+    // at a line that cannot be there is worse than not mentioning it.
+    //
+    // Nor does it claim the writes ARE lost. The workers keep running through the
+    // rest of shutdown, and ~SerialDbWorker quits and then WAITS, so a task
+    // already in flight still commits; only queued-but-unstarted ones are dropped.
+    qWarning() << "Storage writes did not drain within" << timeoutMs << "ms. Still busy:"
+               << stuck.join(", ") << "- whether a queued write survives now depends on"
+               << "whether its worker reaches it before exit, and that outcome is not"
+               << "recorded in this log.";
 }
 
 void MainController::applyAllSettings() {
@@ -4123,8 +4146,21 @@ void MainController::factoryResetAndQuit()
         "()V");
 #endif
 
-    // 5. Quit the app
-    QCoreApplication::quit();
+    // 5. Quit the app — QUEUED, not a direct call.
+    //
+    // This runs from a QML onClicked handler (SettingsHistoryDataTab.qml), and
+    // QCoreApplication::quit() reaches aboutToQuit synchronously, so a direct
+    // call leaves that handler on the stack for the whole of shutdown. Anything
+    // in aboutToQuit that pumps events — the BLE drain, and now drainDbWork() —
+    // would then be a nested event loop beneath a live QML handler, which is the
+    // qFatal in qqmlengine.cpp:1370-1396 that aborted shipped iOS 2.0.0 (#1692),
+    // not merely a slowdown.
+    //
+    // Posting it lands aboutToQuit on a clean stack, which is exactly what
+    // QQmlApplicationEngine already does for Qt.quit() (it connects the QML
+    // engine's quit signal with Qt::QueuedConnection, qqmlapplicationengine.cpp).
+    // So the ordinary Quit button was always safe and this path was the outlier.
+    QMetaObject::invokeMethod(qApp, &QCoreApplication::quit, Qt::QueuedConnection);
 }
 
 void MainController::bumpTargetWeight(double deltaG)

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -359,6 +359,23 @@ public:
     // possible outcomes.
     Q_INVOKABLE void acceptRecipesFirstUpgrade(const QString& name, bool hasMilk);
 
+    // Wait until every storage's background DB worker has finished, or the
+    // budget runs out. Returns true if all four went idle.
+    //
+    // Call this before the storages are destroyed. `~SerialDbWorker` warns that
+    // it is discarding queued tasks, and until now nothing in production ever
+    // waited: the four `isDbWorkIdle()` accessors existed with no caller outside
+    // the tests, and `aboutToQuit` drained the BLE queue but not the database.
+    // So a dose, note, rating or Visualizer id written in the seconds before
+    // quit could vanish, with the warning going to a log nobody reads on the way
+    // out. Found from the other side, when a test destroyed a CoffeeBagStorage
+    // with two writes still queued.
+    //
+    // Bounded on purpose. This runs on the quit path, where Android will kill a
+    // process that takes too long, so a stuck worker must not hold the app open
+    // — the same reason the BLE drain beside it carries a safety-net timeout.
+    bool drainDbWork(int timeoutMs = 750);
+
 public slots:
     void applySteamSettings();
     void applyHotWaterSettings();

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -359,13 +359,14 @@ public:
     // possible outcomes.
     Q_INVOKABLE void acceptRecipesFirstUpgrade(const QString& name, bool hasMilk);
 
-    // Wait until every storage's background DB worker has finished, or the
-    // budget runs out. Returns true if all four went idle.
+    // Wait until every storage's background DB WRITE worker has finished, or the
+    // budget runs out. Logs both outcomes itself, so there is no result to check.
     //
     // Call this before the storages are destroyed. `~SerialDbWorker` warns that
     // it is discarding queued tasks, and until now nothing in production ever
-    // waited: the four `isDbWorkIdle()` accessors existed with no caller outside
-    // the tests, and `aboutToQuit` drained the BLE queue but not the database.
+    // waited: three storages had an `isDbWorkIdle()` with no caller outside the
+    // tests, `RecipeStorage` had no accessor at all, and `aboutToQuit` drained
+    // the BLE queue but not the database.
     // So a dose, note, rating or Visualizer id written in the seconds before
     // quit could vanish, with the warning going to a log nobody reads on the way
     // out. Found from the other side, when a test destroyed a CoffeeBagStorage
@@ -374,7 +375,21 @@ public:
     // Bounded on purpose. This runs on the quit path, where Android will kill a
     // process that takes too long, so a stuck worker must not hold the app open
     // — the same reason the BLE drain beside it carries a safety-net timeout.
-    bool drainDbWork(int timeoutMs = 750);
+    //
+    // WHAT THIS DOES NOT COVER, because the comment above otherwise reads as if
+    // the whole class of loss is closed. Only `aboutToQuit` calls this, and that
+    // signal is not emitted at all when the OS kills the process: an Android
+    // low-memory kill or force-stop, an iOS SIGKILL (the NORMAL iOS termination —
+    // qioseventdispatcher.mm:434 says so outright), a fatal signal reaching
+    // crashhandler.cpp's re-raise, or an ASan abort. Those lose queued writes with
+    // no warning whatsoever, since ~SerialDbWorker never runs either.
+    //
+    // Android is the primary platform and is usually backgrounded rather than
+    // quit, so this covers the deliberate in-app quit and little else there. The
+    // hook that would cover the rest is Qt::ApplicationSuspended (main.cpp), which
+    // exists and does not drain — deliberately out of scope here, because a wait
+    // on the backgrounding path risks an ANR and needs measurement on a device.
+    void drainDbWork(int timeoutMs = 750);
 
 public slots:
     void applySteamSettings();

--- a/src/history/recipestorage.cpp
+++ b/src/history/recipestorage.cpp
@@ -273,6 +273,11 @@ void RecipeStorage::initialize(const QString& dbPath)
     m_dbPath = dbPath;
 }
 
+bool RecipeStorage::isDbWorkIdle() const
+{
+    return !m_dbWorker || m_dbWorker->isIdle();
+}
+
 void RecipeStorage::runAsync(const QString& connPrefix,
                              std::function<void(QSqlDatabase&)> work,
                              std::function<void(bool dbOpened)> done)

--- a/src/history/recipestorage.h
+++ b/src/history/recipestorage.h
@@ -361,6 +361,13 @@ public:
                                     const QHash<qint64, qint64>& packageIdMap,
                                     const QHash<qint64, qint64>& bagIdMap);
 
+    // True when no background CRUD work is queued, running, or waiting to
+    // deliver its result — see ShotHistoryStorage::isDbWorkIdle() for the full
+    // rationale (same shape, same worker type). This was the one storage of the
+    // four carrying a SerialDbWorker without the accessor, which is why a
+    // shutdown drain could not cover it.
+    bool isDbWorkIdle() const;
+
 signals:
     void inventoryReady(const QVariantList& recipes);
     void archivedReady(const QVariantList& recipes);

--- a/src/history/shothistoryexporter.cpp
+++ b/src/history/shothistoryexporter.cpp
@@ -159,7 +159,15 @@ void ShotHistoryExporter::startBulkExport()
     const QString historyDir = m_profileStorage->userHistoryPath();
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([this, dbPath, historyDir, destroyed]() {
+    // Counts this thread for isExportWorkIdle(), so the shutdown drain can wait
+    // for it. Increment on construction, decrement when the last copy of the
+    // lambda dies — which covers the thread never entering its body at all.
+    auto inFlight = std::shared_ptr<void>(nullptr, [c = m_exportThreads](void*) {
+        c->fetch_sub(1, std::memory_order_release);
+    });
+    m_exportThreads->fetch_add(1, std::memory_order_relaxed);
+
+    QThread* thread = QThread::create([this, dbPath, historyDir, destroyed, inFlight]() {
         auto selectAllShots = [&dbPath](QList<ShotRefreshInfo>& out) {
             withTempDb(dbPath, "she_ids", [&](QSqlDatabase& db) {
                 QSqlQuery q(db);
@@ -229,7 +237,12 @@ void ShotHistoryExporter::exportSingleShot(qint64 shotId)
     const QString historyDir = m_profileStorage->userHistoryPath();
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([dbPath, historyDir, shotId, destroyed]() {
+    auto inFlight = std::shared_ptr<void>(nullptr, [c = m_exportThreads](void*) {
+        c->fetch_sub(1, std::memory_order_release);
+    });
+    m_exportThreads->fetch_add(1, std::memory_order_relaxed);
+
+    QThread* thread = QThread::create([dbPath, historyDir, shotId, destroyed, inFlight]() {
         if (*destroyed) return;
         writeShotJson(dbPath, historyDir, shotId);
     });
@@ -245,7 +258,12 @@ void ShotHistoryExporter::deleteExportedShot(qint64 shotId)
     if (historyDir.isEmpty()) return;
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([historyDir, shotId, destroyed]() {
+    auto inFlight = std::shared_ptr<void>(nullptr, [c = m_exportThreads](void*) {
+        c->fetch_sub(1, std::memory_order_release);
+    });
+    m_exportThreads->fetch_add(1, std::memory_order_relaxed);
+
+    QThread* thread = QThread::create([historyDir, shotId, destroyed, inFlight]() {
         if (*destroyed) return;
         QDir dir(historyDir);
         const QStringList matches = dir.entryList(

--- a/src/history/shothistoryexporter.h
+++ b/src/history/shothistoryexporter.h
@@ -42,6 +42,21 @@ signals:
     // (file mtime >= shot updated_at), so no write was performed.
     void bulkExportFinished(int written, int skipped, int failed);
 
+public:
+    // True when no export thread is running. The shutdown drain waits on this.
+    //
+    // It has to, because completing a DB write is only half of what the user
+    // asked for: a metadata write finishing during shutdown emits
+    // shotMetadataUpdated, which lands here and spawns the export thread below.
+    // This object is a stack local declared AFTER MainController in main(), so it
+    // is destroyed FIRST — and every thread body starts with `if (*destroyed)
+    // return;`. Without this wait, draining the database made the DB row current
+    // and left the exported JSON stale, silently and with no torn file to notice.
+    // Consistently-stale was a better failure than invisibly-disagreeing.
+    bool isExportWorkIdle() const {
+        return m_exportThreads->load(std::memory_order_acquire) == 0;
+    }
+
 private slots:
     void onExportToggleChanged();
     void onShotSaved(qint64 shotId);
@@ -58,5 +73,10 @@ private:
     ShotHistoryStorage* m_storage;
 
     std::shared_ptr<std::atomic<bool>> m_destroyed;
+    // shared_ptr for the same reason m_destroyed is: the guard's decrement can
+    // outlive this object, and a leaked count would make isExportWorkIdle()
+    // permanently false — hanging every future drain until its timeout.
+    std::shared_ptr<std::atomic<int>> m_exportThreads =
+        std::make_shared<std::atomic<int>>(0);
     std::atomic<bool> m_bulkRunning{false};
 };

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -136,6 +136,11 @@ bool ShotHistoryStorage::isDbWorkIdle() const
         && m_detachedDbThreads->load(std::memory_order_acquire) == 0;
 }
 
+bool ShotHistoryStorage::isDbWriteWorkIdle() const
+{
+    return !m_dbWorker || m_dbWorker->isIdle();
+}
+
 void ShotHistoryStorage::close()
 {
     if (m_db.isOpen()) {

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -380,6 +380,22 @@ public:
     // true when no async work has ever been posted (the worker is lazily created).
     bool isDbWorkIdle() const;
 
+    // Just the serialized WRITE worker, without the detached read/backup threads
+    // isDbWorkIdle() also counts. For a caller that only needs "will a queued
+    // write be lost if I destroy this now?" — which is the shutdown drain, and
+    // only that.
+    //
+    // The distinction is not cosmetic. Detached threads carry reads, plus backup
+    // and import; none of them is in SerialDbWorker's outstanding count, so none
+    // can be discarded by ~SerialDbWorker and there is nothing to protect. Making
+    // the drain wait on them charged its whole timeout to a quit-during-backup —
+    // which cannot finish in that budget anyway — and then printed a warning
+    // about discarded writes that were never at risk.
+    //
+    // The other three storages need no equivalent: they have no detached threads,
+    // so their isDbWorkIdle() is already write-only.
+    bool isDbWriteWorkIdle() const;
+
     // Checkpoint WAL to main database file
     void checkpoint();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4566,7 +4566,7 @@ int main(int argc, char *argv[])
     });
 
     // Cleanup on exit
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&accessibilityManager, &batteryManager, &de1Device, &de1ReconnectTimer, &physicalScale, &engine, &weightThread, &relayClient, &machineStatusSnapshot, &mainController]() {
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&accessibilityManager, &batteryManager, &de1Device, &de1ReconnectTimer, &physicalScale, &engine, &weightThread, &relayClient, &machineStatusSnapshot, &mainController, &scaleReconnectTimer, &shotHistoryExporter]() {
         qDebug() << "Application exiting - shutting down devices";
 
         // Leave an honest "disconnected" snapshot so the Home Screen widget
@@ -4647,17 +4647,6 @@ int main(int argc, char *argv[])
                 qWarning() << "BLE queue drain timed out after" << timeoutMs << "ms — sleep command may not have been delivered.";
         }
 
-        // Let the database workers finish before the storages are destroyed.
-        // The BLE drain above protects the machine; this protects the user's
-        // data. Until now nothing waited: a dose, note, rating or Visualizer id
-        // written seconds before quit could be discarded by ~SerialDbWorker with
-        // only a warning nobody was around to read.
-        //
-        // After the BLE wait rather than before, so a slow database cannot delay
-        // the sleep command the machine is waiting on. Bounded for the same
-        // reason that one is — Android kills a process that lingers on quit.
-        mainController.drainDbWork();
-
         // IMPORTANT: Ensure charger is ON before exiting
         // This matches de1app's app_exit behavior - always leave charger ON for safety
         batteryManager.ensureChargerOn();
@@ -4687,6 +4676,52 @@ int main(int argc, char *argv[])
         // wildcard form.
         de1ReconnectTimer.stop();
         QObject::disconnect(&de1Device, &DE1Device::connectedChanged, nullptr, nullptr);
+        scaleReconnectTimer.stop();
+
+        // Let the database write workers finish before the storages are
+        // destroyed. The BLE work above protects the machine; this protects the
+        // user's data. Until now nothing waited: a dose, note, rating or
+        // Visualizer id written seconds before quit could be discarded by
+        // ~SerialDbWorker with only a warning nobody was around to read.
+        //
+        // Placed HERE, not earlier, for two reasons found in review:
+        //
+        //  - It pumps events, and every reconnect ladder must be disarmed first.
+        //    A DE1 or scale reconnect tick landing inside the drain would start a
+        //    BLE scan microseconds before the disconnect below — the stale-GATT
+        //    state the comment above exists to avoid. Before this drain existed,
+        //    a quit with nothing BLE-connected processed no events here at all,
+        //    so that window is new and had to be closed rather than inherited.
+        //  - Both BLE waits above talk to hardware over a link that is about to
+        //    go away, including the charger write labelled important for safety.
+        //    The database is local and loses nothing by waiting, so it must not
+        //    be queued in front of either.
+        //
+        // ExcludeUserInputEvents because a second tap on Quit, delivered inside
+        // this loop, reaches QCoreApplication::exit() — which exits EVERY loop in
+        // data->eventLoops (qcoreapplication.cpp:1520-1529), including this one.
+        // That would abandon the drain and discard exactly the write it is here
+        // to save, at the hand of an impatient user.
+        //
+        // Bounded for the same reason the BLE waits are: Android kills a process
+        // that lingers on quit.
+        mainController.drainDbWork();
+
+        // A drained write may have just spawned an export thread (the exporter
+        // subscribes to shotSaved/shotMetadataUpdated), and this object is
+        // destroyed BEFORE MainController at scope exit — every export thread
+        // body starts with `if (*destroyed) return;`. Waiting on the database
+        // alone therefore made the DB row current while the exported JSON stayed
+        // stale, silently. Same bounded shape as the drain above.
+        {
+            QElapsedTimer waited;
+            waited.start();
+            while (!shotHistoryExporter.isExportWorkIdle() && waited.elapsed() < 750)
+                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 20);
+            if (!shotHistoryExporter.isExportWorkIdle())
+                qWarning() << "Shot export threads still running at exit — the exported JSON for a"
+                           << "just-edited shot may be stale.";
+        }
 
         // Explicitly disconnect BLE so the GATT connection is released cleanly.
         // Without this, if the app is force-killed (e.g. after a hang), Android's

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4566,7 +4566,7 @@ int main(int argc, char *argv[])
     });
 
     // Cleanup on exit
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&accessibilityManager, &batteryManager, &de1Device, &de1ReconnectTimer, &physicalScale, &engine, &weightThread, &relayClient, &machineStatusSnapshot]() {
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&accessibilityManager, &batteryManager, &de1Device, &de1ReconnectTimer, &physicalScale, &engine, &weightThread, &relayClient, &machineStatusSnapshot, &mainController]() {
         qDebug() << "Application exiting - shutting down devices";
 
         // Leave an honest "disconnected" snapshot so the Home Screen widget
@@ -4646,6 +4646,17 @@ int main(int argc, char *argv[])
             else
                 qWarning() << "BLE queue drain timed out after" << timeoutMs << "ms — sleep command may not have been delivered.";
         }
+
+        // Let the database workers finish before the storages are destroyed.
+        // The BLE drain above protects the machine; this protects the user's
+        // data. Until now nothing waited: a dose, note, rating or Visualizer id
+        // written seconds before quit could be discarded by ~SerialDbWorker with
+        // only a warning nobody was around to read.
+        //
+        // After the BLE wait rather than before, so a slow database cannot delay
+        // the sleep command the machine is waiting on. Bounded for the same
+        // reason that one is — Android kills a process that lingers on quit.
+        mainController.drainDbWork();
 
         // IMPORTANT: Ensure charger is ON before exiting
         // This matches de1app's app_exit behavior - always leave charger ON for safety

--- a/tests/tst_recipestorage.cpp
+++ b/tests/tst_recipestorage.cpp
@@ -284,6 +284,58 @@ private slots:
         });
     }
 
+    // --- shutdown drain contract ---
+
+    // isDbWorkIdle() is what MainController::drainDbWork() waits on before the
+    // storages are destroyed at quit. Nothing else exercises it on this class:
+    // RecipeStorage carried a SerialDbWorker without the accessor until that
+    // drain needed one, and an accessor that simply answered `true` would make
+    // the drain skip recipes with no symptom anywhere — a queued write silently
+    // discarded by ~SerialDbWorker, which is the defect the drain exists to fix.
+    //
+    // The `!isDbWorkIdle()` assertion is what gives this test teeth, and it is
+    // deterministic rather than a race: the counter is decremented by a ticket
+    // whose last holder is the result callback, delivered to the owner thread by
+    // queued connection (SerialDbWorker::roundTripTicket, dbutils.h:347). That
+    // callback cannot run until this function returns to the event loop, so the
+    // count is still non-zero on the line after the request. Stub the accessor
+    // to `return true` and this line fails immediately.
+    void isDbWorkIdleTracksQueuedWork() {
+        const QString path = freshDbPath();
+        withRawDb(path, "idle_seed", [&](QSqlDatabase& db) {
+            QVERIFY(RecipeStorage::ensureTableStatic(db));
+        });
+
+        qint64 createdId = -1;
+        {
+            RecipeStorage storage;
+            storage.initialize(path);
+            QVERIFY(storage.isDbWorkIdle());          // nothing posted yet
+
+            QSignalSpy spy(&storage, &RecipeStorage::recipeCreated);
+            storage.requestCreateRecipe({{"name", "Drain Me"}, {"profileTitle", "P"}});
+            QVERIFY(!storage.isDbWorkIdle());         // work outstanding
+
+            QTRY_COMPARE(spy.count(), 1);
+            QTRY_VERIFY(storage.isDbWorkIdle());      // and it goes back to idle
+            createdId = spy.at(0).at(0).toLongLong();
+            QVERIFY(createdId > 0);
+        }
+        // Destroyed only after idle, so ~SerialDbWorker has nothing to discard —
+        // failOnWarning() in init() turns its "destroyed with N DB task(s) still
+        // queued" into a failure if that ever stops holding.
+
+        // And the write is actually on disk, which is the point of waiting.
+        int rows = 0;
+        withRawDb(path, "idle_verify", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            QVERIFY(q.exec(QStringLiteral("SELECT COUNT(*) FROM recipes WHERE name = 'Drain Me'")));
+            QVERIFY(q.next());
+            rows = q.value(0).toInt();
+        });
+        QCOMPARE(rows, 1);
+    }
+
     // --- active-name uniqueness through the async request* paths ---
     // The helper test above covers the lookup predicate; these cover the guards
     // that use it, the emitted payloads, and the two new signals.


### PR DESCRIPTION
`~SerialDbWorker` warns that it is discarding queued tasks. Nothing in production ever waited for it.

Three storages had an `isDbWorkIdle()` whose only callers were tests, `RecipeStorage` had no accessor at all, and `aboutToQuit` drained the BLE queue but never the database. So a dose, note, rating or Visualizer id written in the seconds before quit could be discarded, with the only evidence a warning emitted while the process was on its way out.

Found from the other side in [#1731](https://github.com/Kulitorum/Decenza/pull/1731), where a test destroyed a `CoffeeBagStorage` with two writes still queued:

```
"CoffeeBagStorageWorker" destroyed with 2 DB task(s) still queued
  — those writes are being discarded.        (src/core/dbutils.h:245)
```

That was test hygiene. This is the same mechanism against real user data, without a witness.

## The change

- `RecipeStorage::isDbWorkIdle()` — the missing fourth accessor.
- `ShotHistoryStorage::isDbWriteWorkIdle()` — writes only, excluding the detached read/backup/import threads `isDbWorkIdle()` also counts.
- `MainController::drainDbWork(int timeoutMs = 750)` — waits for all four storages.
- `aboutToQuit` calls it, then waits for any export threads those writes spawned.
- `factoryResetAndQuit()` now posts the quit instead of calling it synchronously.

## What review changed, including two bugs in the fix itself

Three agents, seven substantive findings. The two that mattered most were introduced by this PR, not found in spite of it.

**The nested event loop ran beneath a live QML handler.** `factoryResetAndQuit()` called `QCoreApplication::quit()` directly from an `onClicked` handler, and that reaches `aboutToQuit` *synchronously* — so the handler stayed on the stack through all of shutdown, including this change's `QEventLoop::exec()`. That is the `qFatal` shape that aborted shipped iOS 2.0.0 (#1692). Pre-existing, but the drain made it far likelier to fire: on that path `Settings::factoryReset()` has just deleted the database files while all four workers are still armed, so the loop is guaranteed to spin. Now posted with `Qt::QueuedConnection`, which is what `QQmlApplicationEngine` already does for `Qt.quit()` — the ordinary Quit button was always safe and this path was the outlier.

**The drain abandoned export threads.** `ShotHistoryExporter` subscribes to `shotSaved` and `shotMetadataUpdated`, is declared after `MainController` in `main()` so is destroyed *first*, and every export thread body starts with `if (*destroyed) return;`. Completing a write during shutdown therefore spawned an export that was deterministically dropped — leaving a current DB row beside a stale exported JSON, silently, with `QSaveFile` guaranteeing no torn file to notice. Consistently-stale was a *better* failure than invisibly-disagreeing. Export threads are counted now and waited on.

Also fixed:

- The drain waited on detached read/backup/import threads, which `SerialDbWorker` never tracks and `~SerialDbWorker` therefore cannot discard — so a quit-during-backup spent the entire budget and then warned about writes that were never at risk.
- It pumped events with the reconnect ladders still armed; a DE1 or scale tick landing inside the loop starts a BLE scan microseconds before the disconnect below. Moved beneath the neutralization, and run with `ExcludeUserInputEvents` so a second tap on Quit cannot exit the drain loop (`qcoreapplication.cpp:1520-1529` exits *every* loop) and discard the very write it is saving.
- `scaleReconnectTimer` was never stopped in `aboutToQuit`, and not even captured. Pre-existing; fixed in passing.

## What this does not cover

**Only `aboutToQuit` triggers it.** An Android low-memory kill or force-stop, an iOS SIGKILL (the *normal* iOS termination — `qioseventdispatcher.mm:434` says so outright), a fatal signal reaching the crash handler's re-raise, or an ASan abort never emits it. Those lose queued writes with no warning at all, since `~SerialDbWorker` never runs either.

Android is the primary platform and is usually backgrounded rather than quit, so this covers the deliberate in-app quit and little else there. `Qt::ApplicationSuspended` is the hook that would cover the rest; it is deliberately out of scope, because a wait on the backgrounding path risks an ANR and needs measurement on a device.

The 750 ms budget is also not sized against `DbWriteTxn`'s own worst case (a contended write can wait the full 5 s `busy_timeout`). That is a deliberate trade against Android's shutdown deadline, and the warning no longer reads as though a timeout is anomalous.

## Verification

Build clean, suite 110/110, zero warnings, both text-invariant gates green.

`tst_RecipeStorage::isDbWorkIdleTracksQueuedWork` covers the accessor the drain depends on — new, previously uncovered, and silently load-bearing, since one answering `true` would make the drain skip recipes with no symptom. Its teeth are the `!isDbWorkIdle()` assertion immediately after posting, which is deterministic rather than a race: the counter's decrement rides a ticket whose last holder is the result callback, delivered to the owner thread by queued connection (`dbutils.h:347`), so it cannot run until the test returns to the event loop. Confirmed by breaking it — stubbing the accessor to `return true` fails both that assertion and `~SerialDbWorker`'s discard warning.

`drainDbWork()` itself is not unit-tested: no test instantiates `MainController` (`TESTING.md:262`), and reaching the timeout branch would need fault injection, which CLAUDE.md treats as a stop sign rather than a testing problem.

**Still needs a human**: the quit path itself. Enter a rating or note, quit immediately, restart, confirm it survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
