### PR TITLE
Log the drain's quiet path, and register [Storage] for it

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -64,6 +64,7 @@
 #ifdef Q_OS_ANDROID
 #include <QJniObject>
 #endif
+#include "../core/storagelogging.h"
 #include <QEventLoop>
 #include <QTimer>
 #include <QQmlEngine>
@@ -2495,8 +2496,8 @@ void MainController::drainDbWork(int timeoutMs, DrainReason reason) {
     // it fires at all. It cost a wrong answer once already, reading a shutdown log
     // that had run the drain and said nothing about it.
     if (allIdle()) {
-        qDebug() << (exiting ? "Storage writes: nothing queued at exit."
-                             : "Storage writes: nothing queued at backgrounding.");
+        STORAGE_LOG_STDERR("Drain", exiting ? QStringLiteral("nothing queued at exit")
+                                           : QStringLiteral("nothing queued at backgrounding"));
         return;
     }
 
@@ -2521,8 +2522,8 @@ void MainController::drainDbWork(int timeoutMs, DrainReason reason) {
     loop.exec(QEventLoop::ExcludeUserInputEvents);
 
     if (allIdle()) {
-        qDebug() << (exiting ? "Storage writes drained before exit."
-                             : "Storage writes drained before backgrounding.");
+        STORAGE_LOG_STDERR("Drain", exiting ? QStringLiteral("drained before exit")
+                                           : QStringLiteral("drained before backgrounding"));
         return;
     }
 
@@ -2549,15 +2550,15 @@ void MainController::drainDbWork(int timeoutMs, DrainReason reason) {
     // it is what LOGGING.md means by training readers to skim the tier that says
     // "look here".
     if (exiting)
-        qWarning() << "Storage writes did not drain within" << timeoutMs << "ms. Still busy:"
-                   << stuck.join(", ") << "- whether a queued write survives now depends on"
-                   << "whether its worker reaches it before exit, and that outcome is not"
-                   << "recorded in this log.";
+        STORAGE_WARN_STDERR("Drain", QString(
+            "did not drain within %1 ms. Still busy: %2 - whether a queued write "
+            "survives now depends on whether its worker reaches it before exit, and "
+            "that outcome is not recorded in this log").arg(timeoutMs).arg(stuck.join(", ")));
     else
-        qDebug() << "Storage writes still pending after" << timeoutMs
-                 << "ms at backgrounding. Still busy:" << stuck.join(", ")
-                 << "- the worker keeps running, so this is only a loss if the OS kills"
-                 << "the process before it finishes.";
+        STORAGE_LOG_STDERR("Drain", QString(
+            "still pending after %1 ms at backgrounding. Still busy: %2 - the worker "
+            "keeps running, so this is only a loss if the OS kills the process before "
+            "it finishes").arg(timeoutMs).arg(stuck.join(", ")));
 }
 
 void MainController::applyAllSettings() {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2485,8 +2485,20 @@ void MainController::drainDbWork(int timeoutMs, DrainReason reason) {
             && (!m_recipeStorage    || m_recipeStorage->isDbWorkIdle());
     };
 
-    if (allIdle())
+    const bool exiting = (reason == DrainReason::Exiting);
+
+    // Log the quiet path too. This is the COMMON outcome — nothing queued, nothing
+    // to wait for — and it used to return in silence, which made "the drain ran and
+    // found nothing" indistinguishable from "the drain never ran". That matters
+    // most where it can least be checked: on Android the suspend call site cannot
+    // be exercised from a desktop build, and this line is the only evidence that
+    // it fires at all. It cost a wrong answer once already, reading a shutdown log
+    // that had run the drain and said nothing about it.
+    if (allIdle()) {
+        qDebug() << (exiting ? "Storage writes: nothing queued at exit."
+                             : "Storage writes: nothing queued at backgrounding.");
         return;
+    }
 
     // Polled, not signalled: the workers count outstanding tasks in an atomic and
     // emit nothing when it reaches zero, so there is no edge to connect to. This
@@ -2507,8 +2519,6 @@ void MainController::drainDbWork(int timeoutMs, DrainReason reason) {
     // this one — abandoning the drain and discarding the write it is saving. The
     // quit-site comment claimed this protection before the flag was actually here.
     loop.exec(QEventLoop::ExcludeUserInputEvents);
-
-    const bool exiting = (reason == DrainReason::Exiting);
 
     if (allIdle()) {
         qDebug() << (exiting ? "Storage writes drained before exit."

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -8,6 +8,8 @@
 #include <QString>
 #include <QDebug>
 
+#include "core/storagelogging.h"
+
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -242,8 +244,9 @@ public:
         // lose queued work should wait on isIdle() before destroying the owner;
         // this warning is the backstop for the one that didn't.
         if (const int pending = m_outstanding->load(std::memory_order_acquire); pending > 0) {
-            qWarning() << m_name << "destroyed with" << pending
-                       << "DB task(s) still queued — those writes are being discarded.";
+            STORAGE_WARN_STDERR("Worker", QString(
+                "\"%1\" destroyed with %2 DB task(s) still queued - those writes are "
+                "being discarded").arg(m_name).arg(pending));
         }
         m_thread->quit();
         m_thread->wait();

--- a/src/core/logtags.h
+++ b/src/core/logtags.h
@@ -76,6 +76,7 @@
 #define DECENZA_LOG_MARKER_NETWORK       "Network"
 #define DECENZA_LOG_MARKER_SCREENSAVER   "Screensaver"
 #define DECENZA_LOG_MARKER_THEME         "Theme"
+#define DECENZA_LOG_MARKER_STORAGE       "Storage"
 #define DECENZA_LOG_MARKER_EQUIPMENT     "Equipment"
 
 // The registry. Each row: (marker literal, what the subsystem covers).
@@ -124,6 +125,14 @@
       "these as \"the screen went dark mid-shot\" or \"it never woke up\", and "  \
       "the answer is usually which of several independent things (idle timer, "   \
       "brightness, video) did or did not fire")                                   \
+    X(DECENZA_LOG_MARKER_STORAGE,                                                \
+      "Whether an edit you made actually reached the database. Answers \"I "      \
+      "rated that shot and it came back blank\" and \"my note vanished\": writes " \
+      "are queued to a background worker per storage, and a worker destroyed "     \
+      "with tasks still queued discards them. Covers the drain at quit and at "    \
+      "backgrounding, that discard, and the shot-file export those writes "        \
+      "trigger. Not about WHAT was stored — that is Equipment for gear identity "  \
+      "— only about whether the write survived")                                   \
     X(DECENZA_LOG_MARKER_THEME,                                                  \
       "Appearance: theme selection and switching, custom colours, background "    \
       "images and presets, and per-role font-size overrides. Separate from Font, " \

--- a/src/core/storagelogging.h
+++ b/src/core/storagelogging.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "core/logtags.h"
+
+#include <QDebug>
+#include <QString>
+
+// Shared logging helpers for storage durability: whether an edit the user made
+// actually reached the database.
+//
+// Every line gets the [Storage] marker from the registry (core/logtags.h) plus a
+// tag naming its own source:
+//
+//     [Storage][Drain] nothing queued at exit
+//     [Storage][Drain] drained before backgrounding
+//     [Storage][Worker] "CoffeeBagStorageWorker" destroyed with 2 DB task(s) still queued - those writes are being discarded
+//     [Storage][Export] shot export threads still running at exit - exported JSON for a just-edited shot may be stale
+//
+// Those are copied verbatim from the format strings, so a grep for a phrase here
+// finds the real line. Keep them that way when the wording changes.
+//
+// ---- Why this subsystem exists ------------------------------------------
+//
+// Because "I rated that shot and it came back blank" and "my note vanished" are
+// the same event, and neither was answerable from a submitted log. Writes are
+// queued to a per-storage background worker; a worker destroyed with tasks still
+// queued discards them. Nothing in production waited for that until the drain
+// landed, and the drain's own quiet path — nothing queued, the common outcome —
+// logged nothing at all, which made "it ran and found nothing" indistinguishable
+// from "it never ran". That cost a wrong reading of a real device log within an
+// hour of shipping.
+//
+// The narrative also spans three files (the drain in maincontroller.cpp, the
+// discard in dbutils.h, the export wait in main.cpp), so before this marker no
+// single grep returned it.
+//
+// Not filed under [Equipment]: that answers what gear a shot was pulled on and
+// why identity forked. This answers whether ANY write survived, for shots, bags,
+// recipes and equipment alike — a different question, and filing it under one of
+// its four subjects would send a reader hunting in the wrong place (see
+// LOGGING.md, "Don't let one subsystem claim a shared resource").
+//
+// ---- Choosing a helper --------------------------------------------------
+//
+//   STORAGE_LOG_*   qDebug   the ordinary outcome, including "nothing to do"
+//   STORAGE_INFO_*  qInfo    reserved; nothing here is part of a user's narrative
+//                            unless it went wrong
+//   STORAGE_WARN_*  qWarning work was actually discarded, or could not be waited for
+//
+// The suffix is the other half of the choice and is NOT cosmetic: _TAGGED also
+// emits logMessage and so reaches the in-app view, _STDERR does not. Every site
+// here is either a controller with no logMessage signal, a header-only worker
+// destructor, or main()'s shutdown handler — so _STDERR is the case in practice,
+// the same reason the SAW and Equipment helpers lean that way. Both are spelled
+// out; there is deliberately no bare STORAGE_LOG (see networklogging.h for why an
+// unsuffixed name is a trap across headers).
+
+#define STORAGE_LOG_TAGGED(tag, msg) \
+    DECENZA_SUBSYS_LOG(DECENZA_LOG_MARKER_STORAGE, tag, msg, qDebug)
+#define STORAGE_INFO_TAGGED(tag, msg) \
+    DECENZA_SUBSYS_LOG(DECENZA_LOG_MARKER_STORAGE, tag, msg, qInfo)
+#define STORAGE_WARN_TAGGED(tag, msg) \
+    DECENZA_SUBSYS_LOG(DECENZA_LOG_MARKER_STORAGE, tag, msg, qWarning)
+
+#define STORAGE_LOG_STDERR(tag, msg) \
+    DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_STORAGE, tag, msg, qDebug)
+#define STORAGE_INFO_STDERR(tag, msg) \
+    DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_STORAGE, tag, msg, qInfo)
+#define STORAGE_WARN_STDERR(tag, msg) \
+    DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_STORAGE, tag, msg, qWarning)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,7 @@ extern "C" const char* __ubsan_default_options()
 #include <QSysInfo>
 #include <memory>
 #include <vector>
+#include "core/storagelogging.h"
 #include <QElapsedTimer>
 #include <QNetworkAccessManager>
 #include <QMetaEnum>
@@ -4749,8 +4750,9 @@ int main(int argc, char *argv[])
             while (!shotHistoryExporter.isExportWorkIdle() && waited.elapsed() < 750)
                 QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 20);
             if (!shotHistoryExporter.isExportWorkIdle())
-                qWarning() << "Shot export threads still running at exit — the exported JSON for a"
-                           << "just-edited shot may be stale.";
+                STORAGE_WARN_STDERR("Export", QStringLiteral(
+                    "shot export threads still running at exit - the exported JSON for a "
+                    "just-edited shot may be stale"));
         }
 
         // Explicitly disconnect BLE so the GATT connection is released cleanly.


### PR DESCRIPTION
Two related problems, both about the drain being unobservable.

## 1. The quiet path logged nothing

`MainController::drainDbWork()` had two `allIdle()` checks and only the second logged:

```cpp
if (allIdle())
    return;                    // ← silent, and the COMMON case
...
loop.exec(...);
if (allIdle())
    qDebug() << "Storage writes drained before exit.";   // ← only if there was work
```

So "the drain ran and found nothing" and "the drain never ran" produced identical logs.

**That cost a wrong answer within the hour.** Reading a real shutdown from build 3518 on the DE1 tablet, the quit handler's own lines bracketed the call — `main.cpp:4600` and `:4791` both present, the drain at `:4738` between them — and nothing from the drain itself. I read that as the code being absent from the build. It wasn't; there was simply nothing queued.

It matters most where it can least be checked: the `ApplicationSuspended` call site cannot be exercised from a desktop build, so on Android this line is the only evidence the drain fires at all.

## 2. The lines carried no marker

Legal — `maincontroller.cpp` is in `MARKER_ONLY_GLOBS`, so rule 1 does not apply — but weaker than LOGGING.md's actual standard, and wrong for this narrative in particular. It spans three files:

| Line | File |
|---|---|
| drain outcomes | `maincontroller.cpp` |
| `destroyed with N DB task(s) still queued` | `dbutils.h` |
| export threads still running | `main.cpp` |

No single grep returned it — which is precisely what this change exists to fix.

`[Storage]` is now registered, answering *whether an edit reached the database*: "I rated that shot and it came back blank", "my note vanished". Deliberately **not** `[Equipment]`, which answers what gear a shot was pulled on and why identity forked. `[Storage]` covers shots, bags, recipes and equipment alike, so filing it under any one of its four subjects is the shared-resource trap LOGGING.md names.

Two edits to `logtags.h` plus `src/core/storagelogging.h`, following the existing helper shape. `_STDERR` throughout: every site is a controller with no `logMessage` signal, a header-only destructor, or `main()`'s shutdown handler.

## What you can now grep

```
[Storage][Drain]  nothing queued at exit
[Storage][Drain]  drained before backgrounding
[Storage][Worker] "CoffeeBagStorageWorker" destroyed with 2 DB task(s) still queued - those writes are being discarded
[Storage][Export] shot export threads still running at exit - the exported JSON for a just-edited shot may be stale
```

All four drain outcomes log exactly once: nothing queued, drained after waiting, timed out while exiting (WARN), timed out while backgrounding (DEBUG).

**Verification**: build clean, suite 110/110, zero warnings, log-marker gate green (12 helper headers, `[Storage]` registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)