### PR TITLE
Give the WiFi scale reconnect the same mDNS deadline discovery uses

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -2333,14 +2333,16 @@ void BLEManager::scanForDevices() {
     // to its hostname, and running the fallback only when the browse came back
     // empty would hide the old scale whenever a new one is present.
     //
-    // The 5 s A-record timeout is unchanged: the HDS responder regularly takes
-    // 2-4 s to reply (likely the ESP32 waking from power-save). The browse runs
-    // longer, alongside the ~15 s BLE scan, because a DNS-SD browse's first
-    // callback is a dump of the resolver's cache — stale instances included —
-    // and the resolver's own pruning of those arrives seconds later.
+    // The A-record timeout is kHdsResolveTimeoutMs, shared with the reconnect
+    // path; the responder latency that sets it is documented on the constant.
+    // The browse runs longer, alongside the ~15 s BLE scan, because a DNS-SD
+    // browse's first callback is a dump of the resolver's cache — stale
+    // instances included — and the resolver's own pruning of those arrives
+    // seconds later.
     ensureWifiDiscovery();
     m_wifiDiscovery->browse(15000);
-    m_wifiDiscovery->probe(WifiScaleDiscovery::defaultFallbackHostnames(), 5000);
+    m_wifiDiscovery->probe(WifiScaleDiscovery::defaultFallbackHostnames(),
+                           WifiScaleDiscovery::kHdsResolveTimeoutMs);
 
     // USB is otherwise a free-running background poll that the scan button never
     // touched, so a scale plugged in just before a scan appeared only when the
@@ -2374,7 +2376,8 @@ void BLEManager::browseWifiScales(int timeoutMs) {
                        .arg(MdnsResolver::activeBrowseBackendName())
                        .arg(timeoutMs));
     m_wifiDiscovery->browse(timeoutMs);
-    m_wifiDiscovery->probe(WifiScaleDiscovery::defaultFallbackHostnames(), 5000);
+    m_wifiDiscovery->probe(WifiScaleDiscovery::defaultFallbackHostnames(),
+                           WifiScaleDiscovery::kHdsResolveTimeoutMs);
     emit scanningChanged();
 }
 

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -45,6 +45,9 @@ template struct AccessBypass<WsPrivateSocketTag, &QWebSocketPrivate::m_pSocket>;
 } // namespace
 
 #include "../../network/mdnsresolver.h"
+// For kHdsResolveTimeoutMs — the A-record deadline is a property of the HDS
+// responder, shared with the discovery path, so both read it from one place.
+#include "../../network/wifiscalediscovery.h"
 
 #define WIFI_LOG(msg)  SCALE_LOG("DecentScaleWifi", msg)
 #define WIFI_INFO(msg) SCALE_INFO("DecentScaleWifi", msg)
@@ -316,7 +319,46 @@ void DecentScaleWifi::attemptHostname() {
         WIFI_LOG(QString("Resolving %1 via mDNS (Android)...").arg(host));
         QPointer<DecentScaleWifi> guard(this);
         QThread* thread = QThread::create([this, guard, host, generation]() {
-            const QString ip = MdnsResolver::resolveHostname(host);
+            // kHdsResolveTimeoutMs, NOT MdnsResolver's 2000 ms default — this
+            // responder is slower than that default assumes, and taking the
+            // default here silently is what made reconnect fail. The responder
+            // latency and the field evidence live on the constant; WHY THIS
+            // CALL SITE BOUNDS IT lives here:
+            //
+            // The worst single connect cycle is resolve fails (5 s) →
+            // dialCachedIpAfterResolveFailure → cached-IP recognition timeout
+            // (5 s) → re-resolve (5 s) → recognition (5 s) = 20 s, which is
+            // EXACTLY BLEManager::m_scaleConnectionTimer's interval
+            // (blemanager.cpp, setInterval(20000)). Not "well inside" it —
+            // equal to it. Before this timeout was made explicit the same chain
+            // was 2+5+2+5 = 14 s and had 6 s of slack; there is now none.
+            //
+            // The tie is currently safe: onScaleConnectionTimeout takes the
+            // WiFi→BLE fallback, and the driver's own give-up branch only
+            // aborts, because recognitionFailed is wired solely for manual
+            // "Add WiFi Scale" entries. Either order ends the attempt.
+            //
+            // So: kHdsResolveTimeoutMs CANNOT BE RAISED AGAIN without first
+            // shortening this chain or lengthening that timer. Re-derive the
+            // sum before touching either number — do not trust this comment if
+            // you have changed a step, re-count the steps.
+            //
+            // Blocks a detached QThread::create worker (NOT a QThreadPool task,
+            // so ~QCoreApplication does not wait on it) for up to the timeout.
+            // No cancel token is passed, matching MqttClient's equivalent
+            // resolve; the QPointer guard and generation check below discard a
+            // stale result, but the thread itself still runs to completion.
+            //
+            // NOTE necessary, possibly not sufficient. The one observed success
+            // resolved in 362 ms — inside the OLD 2 s window — while a DNS-SD
+            // browse ran concurrently, so "the responder needs browse traffic
+            // to wake" survives as an alternative this timeout does not
+            // address. If reconnect still misses at this timeout, that is the
+            // answer, and the fix is to browse from the reconnect path (the
+            // auto-connect wiring already exists in BLEManager's resultFound
+            // handler).
+            const QString ip = MdnsResolver::resolveHostname(
+                host, WifiScaleDiscovery::kHdsResolveTimeoutMs);
             // Back on the object's thread. `guard` gates liveness — the object
             // may have been destroyed during the blocking resolve. The `!guard`
             // check runs first (short-circuit), so member access via `this`

--- a/src/network/wifiscalediscovery.h
+++ b/src/network/wifiscalediscovery.h
@@ -61,6 +61,14 @@ public:
     // power throughout. A user-initiated scan 3 minutes after one of those
     // misses resolved the same hostname in 362 ms.
     //
+    // Corroborated independently on macOS, which resolves through QHostInfo
+    // rather than this mDNS path: a hostname fallback there took 3.68 s to
+    // answer (log: "Resolving hdstest.local via QHostInfo..." at t=8.822 ->
+    // resolved at t=12.504). Different OS, different resolver, same 2-4 s
+    // band — so the latency is a property of the responder, not of any one
+    // resolver implementation, and a 2 s deadline is too short for it
+    // everywhere, not just on Android.
+    //
     // Raising this is NOT free, and the binding constraint is on the reconnect
     // side: see the worst-case chain derived at DecentScaleWifi's call site,
     // which already consumes the whole of BLEManager's 20 s scale-connection

--- a/src/network/wifiscalediscovery.h
+++ b/src/network/wifiscalediscovery.h
@@ -46,6 +46,27 @@ public:
 
     static constexpr int kDefaultTimeoutMs = 2000;
 
+    // How long to wait for an HDS A-record answer, for EVERY path that asks —
+    // this class's own probe() and DecentScaleWifi's Android reconnect resolve
+    // alike. It lives here, above both, because it is a property of the
+    // responder rather than of either caller.
+    //
+    // The HDS responder regularly takes 2-4 s to reply, likely the ESP32 waking
+    // from WiFi power-save, so MdnsResolver's 2000 ms default is too short for
+    // it. That is not a style preference: the reconnect path silently took the
+    // 2000 ms default while discovery passed 5000, the two disagreed about a
+    // documented property of the same device, and a tablet log showed 82
+    // consecutive reconnect misses over 7.5 h — every one ending at ~2003 ms
+    // having received nothing — against a scale that was awake and on mains
+    // power throughout. A user-initiated scan 3 minutes after one of those
+    // misses resolved the same hostname in 362 ms.
+    //
+    // Raising this is NOT free, and the binding constraint is on the reconnect
+    // side: see the worst-case chain derived at DecentScaleWifi's call site,
+    // which already consumes the whole of BLEManager's 20 s scale-connection
+    // timer. Read that before changing this number.
+    static constexpr int kHdsResolveTimeoutMs = 5000;
+
     // The DNS-SD service openscale advertises (v3.0.9+).
     static constexpr const char* kServiceType = "_decentscale._tcp.local";
 


### PR DESCRIPTION
## What

`DecentScaleWifi::attemptHostname()` called `MdnsResolver::resolveHostname(host)` with no timeout, taking the **2000 ms default**. The discovery path passes **5000 ms**. Same device, same responder, two different deadlines — and the reconnect path had the short one.

One line of behaviour change; the rest is a named constant and the reasoning behind it.

```diff
- const QString ip = MdnsResolver::resolveHostname(host);
+ const QString ip = MdnsResolver::resolveHostname(host, kMdnsResolveTimeoutMs);
```

## Why

The HDS responder regularly takes 2-4 s to reply (likely the ESP32 waking from WiFi power-save). That isn't a guess — it's written down at the discovery call site in `blemanager.cpp` as the reason that path uses 5000 ms. The reconnect path silently took the default and gave up 2 s in.

Cost, from a tablet log (2.0.1 build 3519, SM-X210, 7h52m session):

- **82 consecutive reconnect misses over 7.5 hours**, every one ending at ~2003 ms with `records= 0` — nothing received at all.
- The scale was awake and on mains power throughout (`battery_percent: 100, charging: true` when it finally connected).
- The user spent the whole session on FlowScale instead of the real scale.
- A user-initiated scan three minutes after one of those misses resolved the same hostname in **362 ms**.

The resolver itself was fine: `homeassistant-chv.local` resolved through the *same* `resolveHostname()` function in 3 ms, 300 ms before the first `hds.local` miss. So this is not a multicast lock, not permissions, and not the network.

## Honest limits

**Necessary, possibly not sufficient.** The one observed success resolved in 362 ms — comfortably inside the old 2 s window — while a DNS-SD browse was running concurrently. So "the responder needs browse traffic to wake" survives as an alternative explanation that this change does not address. The header comment records that, and says what to do about it: browse from the reconnect path, where the auto-connect wiring already exists in `BLEManager`'s `resultFound` handler.

If the next beta still shows misses — now ending at ~5003 ms with `records= 0` — that outcome falsifies the timeout theory cleanly and promotes the browse fix.

**Verification is deferred.** The edited line is inside `#ifdef Q_OS_ANDROID`, so the macOS build does not compile it. Local suite is a regression check only; field verification arrives with the next beta.

## Not in this PR

Two further defects found in the same investigation, deliberately left out to keep this one falsifiable on its own:

1. Reconnect never re-resolves after a *transport* error — a cached-IP `Host unreachable` short-circuits before the mDNS fallback, so a scale that moved DHCP lease never comes back without a manual scan. Reproduced on macOS.
2. Reconnect never browses, though `#1689` built the browse and the auto-connect handler that consumes it.

## Test plan

- [ ] Full local suite (macOS) green
- [ ] Android behaviour observed in the next beta — look for `[MdnsResolver] done host= hds.local` with `elapsed=` in the 2000-5000 ms band and `aRecords= 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)