### PR TITLE
Turn off precompiled headers on the cached CI legs

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -247,8 +247,8 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          # PCH off: it makes ccache treat ~88% of compiles as uncacheable.
-          # Reasoning and measurements at the PCH block in CMakeLists.txt.
+          # PCH off: a compile that consumes a PCH is uncacheable, so leaving it
+          # on made ccache miss ~88% of this leg's compiles. See PR #1738.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DENABLE_TSNET=ON \
             -DDECENZA_ENABLE_PCH=OFF \

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -247,8 +247,11 @@ jobs:
         run: |
           mkdir -p build
           cd build
+          # PCH off: it makes ccache treat ~88% of compiles as uncacheable.
+          # Reasoning and measurements at the PCH block in CMakeLists.txt.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DENABLE_TSNET=ON \
+            -DDECENZA_ENABLE_PCH=OFF \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 

--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -101,8 +101,8 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          # PCH off: it makes ccache treat ~86% of compiles as uncacheable.
-          # Reasoning and measurements at the PCH block in CMakeLists.txt.
+          # PCH off: a compile that consumes a PCH is uncacheable, so leaving it
+          # on made ccache miss ~86% of this leg's compiles. See PR #1738.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDECENZA_ENABLE_PCH=OFF \

--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -101,8 +101,11 @@ jobs:
         run: |
           mkdir -p build
           cd build
+          # PCH off: it makes ccache treat ~86% of compiles as uncacheable.
+          # Reasoning and measurements at the PCH block in CMakeLists.txt.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
+            -DDECENZA_ENABLE_PCH=OFF \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -101,8 +101,8 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          # PCH off: it makes ccache treat ~90% of compiles as uncacheable.
-          # Reasoning and measurements at the PCH block in CMakeLists.txt.
+          # PCH off: a compile that consumes a PCH is uncacheable, so leaving it
+          # on made ccache miss ~90% of this leg's compiles. See PR #1738.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDECENZA_ENABLE_PCH=OFF \

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -101,8 +101,11 @@ jobs:
         run: |
           mkdir -p build
           cd build
+          # PCH off: it makes ccache treat ~90% of compiles as uncacheable.
+          # Reasoning and measurements at the PCH block in CMakeLists.txt.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
+            -DDECENZA_ENABLE_PCH=OFF \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -180,8 +180,11 @@ jobs:
           OPENSSL_PREFIX="${RUNNER_TEMP}/openssl-universal"
           mkdir -p build/macos
           cd build/macos
+          # PCH off: it makes ccache treat ~88% of compiles as uncacheable.
+          # Reasoning and measurements at the PCH block in CMakeLists.txt.
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DENABLE_TSNET=ON \
+            -DDECENZA_ENABLE_PCH=OFF \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -180,8 +180,8 @@ jobs:
           OPENSSL_PREFIX="${RUNNER_TEMP}/openssl-universal"
           mkdir -p build/macos
           cd build/macos
-          # PCH off: it makes ccache treat ~88% of compiles as uncacheable.
-          # Reasoning and measurements at the PCH block in CMakeLists.txt.
+          # PCH off: a compile that consumes a PCH is uncacheable, so leaving it
+          # on made ccache miss ~88% of this leg's compiles. See PR #1738.
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DENABLE_TSNET=ON \
             -DDECENZA_ENABLE_PCH=OFF \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,16 +83,12 @@ endif()
 # CLI configure set no compiler launcher, and local development is the case this
 # exists for. CI throughput is explicitly the lower priority.
 #
-# OFF IN CI, passed explicitly by the four workflows that carry a warm ccache
-# (android, macos, linux, linux-arm64). A PCH and a compiler cache are
-# SUBSTITUTES, not complements, and where both are available the cache wins by
-# an order of magnitude — so this is the "lower priority" sentence above being
-# applied, not reversed.
-#
-# ccache will not cache a compile that consumes a PCH: the preprocessed output
-# no longer contains the PCH'd headers' text, so it cannot tell what it would be
-# caching, and it declines. Every leg lost almost its whole cache the day the
-# PCH landed (2026-07-31, #1730). Measured from the runs' own `ccache -s`:
+# OFF IN CI on the four legs with a warm ccache (android, macos, linux,
+# linux-arm64), passed as -DDECENZA_ENABLE_PCH=OFF by those workflows. A PCH and
+# a compiler cache are SUBSTITUTES: ccache will not cache a compile that
+# consumes a PCH, because the preprocessed output no longer contains the PCH'd
+# headers' text. Every warm leg lost almost its whole cache when the PCH landed
+# (2026-07-31, #1730), measured from the runs' own `ccache -s`:
 #
 #   leg          cacheable before -> after     hits before -> after
 #   android         457/484  ->   58/485          384  ->  30
@@ -100,27 +96,16 @@ endif()
 #   linux           910/910  ->   86/882          817  ->  70
 #   linux-arm64     508/508  ->   72/512          450  ->  60
 #
-# Android's Build step went 3m40s -> 5m00s/6m41s, macOS 6m28s -> 8m11s/13m28s.
-# On android the 30 surviving hits are exactly the 30 paho_mqtt_c objects, the
-# only target in that build without a PCH.
+# ~88% of TUs were hits, which cost nothing to compile, so the 31.6% above only
+# ever applied to the ~12% that miss. Not worth the other 88% recompiling.
 #
-# The arithmetic is why this is not close. ~88% of TUs were cache HITS, which
-# cost nothing to "compile"; the PCH's measured 31.6% only ever applied to the
-# ~12% that actually miss, so at best it bought ~4% of a warm CI build while
-# costing the full compile of the other 88%.
+# `sloppiness=pch_defines,time_macros` would let ccache cache through a PCH.
+# Not done: time_macros ignores __DATE__/__TIME__, which src/main.cpp uses in
+# its startup banner, so a cached object would log a stale build date.
 #
-# ccache CAN be told to cache through a PCH with
-# `--set-config=sloppiness=pch_defines,time_macros`. Deliberately not done:
-# `time_macros` makes ccache ignore __DATE__/__TIME__, which src/main.cpp uses
-# in its startup banner, so a cached object would report a stale build date into
-# user-submitted logs. It also only pays off if the ~28-47 MB PCH artefact is
-# byte-identical across runners, which nobody has verified.
-#
-# Deliberately NOT applied to two legs. iOS and Windows already resolve to OFF
-# above, and passing a flag there could only ever turn the known-broken (iOS) or
-# never-tested (Windows) combination back ON. nightly-sanitizers.yml is also
-# left alone: it decides its own caching at runtime and often builds genuinely
-# cold, which is the one CI case where a PCH is a straight 31.6% win.
+# iOS and Windows are left to the branch below rather than given the flag —
+# there it could only turn the known-broken/never-tested combination back ON.
+# nightly-sanitizers.yml often builds cold, where the PCH is a straight win.
 #
 # To force either way: -DDECENZA_ENABLE_PCH=ON/OFF.
 if(NOT DEFINED DECENZA_ENABLE_PCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,33 +79,16 @@ endif()
 # ever exercised the combination. Turning it on is a separate change that must
 # be measured on a Windows runner with a warm sccache.
 #
+# OFF in CI on the four legs that carry a warm ccache (android, macos, linux,
+# linux-arm64), passed as -DDECENZA_ENABLE_PCH=OFF by those workflows rather
+# than decided here. A PCH and a compiler cache are SUBSTITUTES: ccache will not
+# cache a compile that consumes a PCH, since the preprocessed output no longer
+# contains the PCH'd headers' text. Enabling the PCH cost those legs ~90% of
+# their cache hits and roughly doubled the macOS build; numbers in PR #1738.
+#
 # ON everywhere else, which includes every local build: Qt Creator and a plain
-# CLI configure set no compiler launcher, and local development is the case this
-# exists for. CI throughput is explicitly the lower priority.
-#
-# OFF IN CI on the four legs with a warm ccache (android, macos, linux,
-# linux-arm64), passed as -DDECENZA_ENABLE_PCH=OFF by those workflows. A PCH and
-# a compiler cache are SUBSTITUTES: ccache will not cache a compile that
-# consumes a PCH, because the preprocessed output no longer contains the PCH'd
-# headers' text. Every warm leg lost almost its whole cache when the PCH landed
-# (2026-07-31, #1730), measured from the runs' own `ccache -s`:
-#
-#   leg          cacheable before -> after     hits before -> after
-#   android         457/484  ->   58/485          384  ->  30
-#   macos          1022/1032 ->  128/1046         902  -> 120
-#   linux           910/910  ->   86/882          817  ->  70
-#   linux-arm64     508/508  ->   72/512          450  ->  60
-#
-# ~88% of TUs were hits, which cost nothing to compile, so the 31.6% above only
-# ever applied to the ~12% that miss. Not worth the other 88% recompiling.
-#
-# `sloppiness=pch_defines,time_macros` would let ccache cache through a PCH.
-# Not done: time_macros ignores __DATE__/__TIME__, which src/main.cpp uses in
-# its startup banner, so a cached object would log a stale build date.
-#
-# iOS and Windows are left to the branch below rather than given the flag —
-# there it could only turn the known-broken/never-tested combination back ON.
-# nightly-sanitizers.yml often builds cold, where the PCH is a straight win.
+# CLI configure set no compiler launcher, so there is no cache to lose, and
+# local development is the case this exists for.
 #
 # To force either way: -DDECENZA_ENABLE_PCH=ON/OFF.
 if(NOT DEFINED DECENZA_ENABLE_PCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,45 @@ endif()
 # CLI configure set no compiler launcher, and local development is the case this
 # exists for. CI throughput is explicitly the lower priority.
 #
+# OFF IN CI, passed explicitly by the four workflows that carry a warm ccache
+# (android, macos, linux, linux-arm64). A PCH and a compiler cache are
+# SUBSTITUTES, not complements, and where both are available the cache wins by
+# an order of magnitude — so this is the "lower priority" sentence above being
+# applied, not reversed.
+#
+# ccache will not cache a compile that consumes a PCH: the preprocessed output
+# no longer contains the PCH'd headers' text, so it cannot tell what it would be
+# caching, and it declines. Every leg lost almost its whole cache the day the
+# PCH landed (2026-07-31, #1730). Measured from the runs' own `ccache -s`:
+#
+#   leg          cacheable before -> after     hits before -> after
+#   android         457/484  ->   58/485          384  ->  30
+#   macos          1022/1032 ->  128/1046         902  -> 120
+#   linux           910/910  ->   86/882          817  ->  70
+#   linux-arm64     508/508  ->   72/512          450  ->  60
+#
+# Android's Build step went 3m40s -> 5m00s/6m41s, macOS 6m28s -> 8m11s/13m28s.
+# On android the 30 surviving hits are exactly the 30 paho_mqtt_c objects, the
+# only target in that build without a PCH.
+#
+# The arithmetic is why this is not close. ~88% of TUs were cache HITS, which
+# cost nothing to "compile"; the PCH's measured 31.6% only ever applied to the
+# ~12% that actually miss, so at best it bought ~4% of a warm CI build while
+# costing the full compile of the other 88%.
+#
+# ccache CAN be told to cache through a PCH with
+# `--set-config=sloppiness=pch_defines,time_macros`. Deliberately not done:
+# `time_macros` makes ccache ignore __DATE__/__TIME__, which src/main.cpp uses
+# in its startup banner, so a cached object would report a stale build date into
+# user-submitted logs. It also only pays off if the ~28-47 MB PCH artefact is
+# byte-identical across runners, which nobody has verified.
+#
+# Deliberately NOT applied to two legs. iOS and Windows already resolve to OFF
+# above, and passing a flag there could only ever turn the known-broken (iOS) or
+# never-tested (Windows) combination back ON. nightly-sanitizers.yml is also
+# left alone: it decides its own caching at runtime and often builds genuinely
+# cold, which is the one CI case where a PCH is a straight 31.6% win.
+#
 # To force either way: -DDECENZA_ENABLE_PCH=ON/OFF.
 if(NOT DEFINED DECENZA_ENABLE_PCH)
     if(WIN32 OR IOS)


### PR DESCRIPTION
## What

Pass `-DDECENZA_ENABLE_PCH=OFF` in the four CI workflows that carry a warm ccache: android, macos, linux, linux-arm64. Local builds are untouched.

## Why

A PCH and a compiler cache are **substitutes, not complements**, and where both are available the cache wins by an order of magnitude.

ccache will not cache a compile that consumes a PCH: with `-include cmake_pch.hxx` the preprocessed output no longer contains the PCH'd headers' text, so ccache cannot tell what it would be caching and declines. Every warm leg lost almost its whole cache the day #1730 landed (2026-07-31). Measured from the runs' own `ccache -s`:

| leg | cacheable before | after | hits before | after |
|---|---|---|---|---|
| android | 457/484 | **58/485** | 384 | **30** |
| macos | 1022/1032 | **128/1046** | 902 | **120** |
| linux | 910/910 | **86/882** | 817 | **70** |
| linux-arm64 | 508/508 | **72/512** | 450 | **60** |

Build step wall clock: Android 3m40s → 5m00s/6m41s, macOS 6m28s → 8m11s/13m28s.

Corroboration that the PCH is the mechanism and not a coincidence: on Android the 30 surviving hits are exactly the 30 `paho_mqtt_c` objects — the only target in that build without a PCH. The runs' own config dump also shows `sloppiness = ` empty.

The arithmetic is why this is not close. ~88% of TUs were cache *hits*, which cost nothing to "compile". The PCH's measured 31.6% only ever applied to the ~12% that actually miss, so at best it bought ~4% of a warm CI build while costing the full compile of the other 88%.

## Why not fix ccache instead

`--set-config=sloppiness=pch_defines,time_macros` would let ccache cache through a PCH. Deliberately not done:

- `time_macros` makes ccache ignore `__DATE__`/`__TIME__`, which `src/main.cpp:911` uses in its startup banner. A cached object would report a stale build date into user-submitted logs.
- It only pays off if the ~28-47 MB PCH artefact is byte-identical across runners. Nobody has verified that; if it is not, all 407/918 entries miss anyway and the relaxation buys nothing.
- macOS ccache is already at `Cache size (GB): 2.0 / 2.0 (99.94%)` and evicting. Adding PCH artefacts makes that worse.

## Scope — what is deliberately left out

- **iOS and Windows.** Both already resolve to OFF in `CMakeLists.txt`. Passing a flag there could only ever turn the known-broken (iOS, `CMakeLists.txt:57-73`) or never-tested (Windows/sccache) combination back **ON**.
- **`nightly-sanitizers.yml`.** It decides its own caching at runtime and often builds genuinely cold — the one CI case where a PCH is a straight 31.6% win.
- This does not reverse #1730. `CMakeLists.txt:82-84` already states the PCH exists for local development and that "CI throughput is explicitly the lower priority". This applies that sentence rather than contradicting it; local builds keep the full 31.6%.

## Verification

Comment-only change to `CMakeLists.txt` (the reasoning and the measured tables live there, next to the decision they justify); the four workflow edits add one flag each. All four workflow files re-parse as valid YAML. No `src/**` or `qml/**` change, so `text-invariants.yml` does not run on this PR.

The behavioural check is one run per leg after merge: `Configure CMake` should log `Precompiled headers: OFF`, and `Post Set up ccache` should return `Cacheable calls` to the ~94-100% column above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)