### PR TITLE
Do not switch back to a WiFi primary that is already connected

### DIFF
--- a/openspec/changes/no-switch-back-to-connected-primary/.openspec.yaml
+++ b/openspec/changes/no-switch-back-to-connected-primary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/no-switch-back-to-connected-primary/design.md
+++ b/openspec/changes/no-switch-back-to-connected-primary/design.md
@@ -1,0 +1,75 @@
+# Design
+
+## Context
+
+`maybeAutoConnectBrowsedScale()` is the single auto-connect path shared by three
+callers: the user scan's DNS-SD browse handler, the user scan's A-record probe
+handler, and the reconnect browse's handler. Sharing it is deliberate — an
+earlier duplicate of the saved-scale match drifted from the row dedupe and let a
+browse hit rewrite a row out from under the matcher.
+
+Its already-connected branch exists because `main.cpp`'s single-scale invariant
+silently drops a `scaleDiscovered` emission while a scale is connected. Routing
+through `wifiPrimaryReachable` → `switchToWifiPrimary()` is what gets past that,
+because the switch-back drops the current scale *before* emitting.
+
+The branch's condition was `m_scaleDevice && m_scaleDevice->isConnected()`,
+which does not distinguish a backup from the primary itself.
+
+## Goals / Non-Goals
+
+- **Goal:** request a switch-back only when there is something to switch back
+  *from*.
+- **Goal:** keep one implementation shared by all three callers.
+- **Non-Goal:** teach `BLEManager` the connected scale's identity. `ScaleDevice`
+  exposes no address or hostname accessor, and adding one for this would mean a
+  downcast to `DecentScaleWifi` or a new tracked member — more machinery than
+  the question needs.
+
+## Decisions
+
+### Use `m_wifiDirectAttemptFailed` as the backup discriminator
+
+The flag's lifecycle already means exactly "the direct attempt to the saved WiFi
+primary failed and nothing has since proved otherwise":
+
+- Set in `onScaleConnectionTimeout()`, only for a saved `wifi:` primary and only
+  on a non-manual attempt (`blemanager.cpp:1861`).
+- Cleared by any connect that is **not** the WiFi→BLE fallback
+  (`onScaleConnectedChanged`, `:1722`).
+- Cleared when the saved address changes (`setSavedScaleAddress`, `:2069`).
+
+So while a scale is connected, `true` can only mean the connect was the fallback
+— i.e. a backup — and `false` means the connected scale is the primary. No new
+state is introduced and no existing state changes meaning.
+
+**Alternative considered:** compare the connected device's hostname to the saved
+address. Rejected — it needs an accessor `ScaleDevice` does not have, and a
+downcast at a layer that otherwise treats scales polymorphically. It would also
+be *less* correct in one case: a manually connected third WiFi scale is a backup
+by any reasonable reading, and the flag classifies it correctly while a hostname
+comparison would too, at strictly more cost.
+
+**Alternative considered:** suppress duplicate switch-back requests (the log
+shows two). Rejected as treating the symptom — one needless disconnect is the
+bug, not two.
+
+### Express it as a static predicate
+
+`shouldRequestSwitchBack(bool scaleConnected, bool directAttemptFailed)` joins
+`shouldBrowseOnReconnect()` and `browsedScaleIsSavedPrimary()`. Same reasoning
+as those: the rule is otherwise reachable only by faking a connection timeout,
+and the project treats needing fault injection to reach a branch as a stop sign.
+As a pure function the four-case truth table is asserted directly, in an
+existing test file, at the cost of one test slot.
+
+## Risks / Trade-offs
+
+- **A backup connected by some path that does not set the flag would not trigger
+  a switch-back.** The only such path is a scale connected without the primary's
+  direct attempt ever having timed out — in which case the app has no evidence
+  the primary was unreachable, and overriding the user's connection would be the
+  wrong move anyway.
+- **Behaviour depends on a flag maintained elsewhere.** Mitigated by the
+  predicate's comment naming the three sites that own its lifecycle, and by the
+  comment at the clearing site now pointing back at this rule.

--- a/openspec/changes/no-switch-back-to-connected-primary/proposal.md
+++ b/openspec/changes/no-switch-back-to-connected-primary/proposal.md
@@ -1,0 +1,48 @@
+# Do not switch back to a primary that is already connected
+
+## Why
+
+The browse-driven switch-back added in `browse-for-wifi-scale-reconnect` decides
+that the connected scale is a *backup* from `m_scaleDevice->isConnected()` alone.
+That test is true just as often when the connected scale IS the saved primary,
+and `maybeAutoConnectBrowsedScale()` is called from the user scan's handlers as
+well as the reconnect browse's. So a user scan that re-finds a perfectly healthy
+primary asks to switch back to it, and `switchToWifiPrimary()` disconnects the
+scale and redials the same hostname at the same IP.
+
+Observed on the tablet, 2026-08-01 (session start 11:17:55):
+
+```
+[  4.154] WebSocket connected — peer=192.168.10.145:80
+[ 22.273] Starting device scan...
+[ 22.636] Reconnect browse found the saved primary hds.local at 192.168.10.145
+          while a backup scale is connected — requesting switch-back
+[ 22.683] (again — once for the DNS-SD hit, once for the mDNS hit)
+[ 30.897] WebSocket disconnected (expected)
+[ 32.494] Auto-reconnect attempt 1 → connected to the same scale
+```
+
+The user loses the scale for ~8 s each time they press Scan, and the log line
+blames a "backup scale" that does not exist. Weight readings stop for that
+window; a scan during a shot would take the scale away mid-pour.
+
+## What Changes
+
+- The switch-back is gated on evidence that the connected scale is actually a
+  backup, not merely on something being connected. `m_wifiDirectAttemptFailed`
+  already carries exactly that meaning: it is set only when the direct attempt
+  to the saved WiFi primary times out, and cleared by any connect that is not
+  the WiFi→BLE fallback.
+- When the primary is the connected scale, the browse result is a no-op — no
+  switch-back and no `scaleDiscovered` emission.
+- The log line drops "Reconnect", which was wrong for the two scan-side callers.
+
+No user-facing setting, no new state, no change to the reconnect ladder itself.
+The genuine backup case — direct attempt timed out, WiFi→BLE fallback connected,
+browse then finds the primary — is unchanged.
+
+## Impact
+
+- Affected specs: `wifi-scale-discovery`
+- Affected code: `src/ble/blemanager.h`, `src/ble/blemanager.cpp`,
+  `tests/tst_wifiscalediscovery.cpp`

--- a/openspec/changes/no-switch-back-to-connected-primary/specs/wifi-scale-discovery/spec.md
+++ b/openspec/changes/no-switch-back-to-connected-primary/specs/wifi-scale-discovery/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Saved WiFi scale reconnect resolves by service browse
+
+When a WiFi scale is the saved primary and a reconnect attempt fails to establish a connection, the app SHALL run a DNS-SD service browse for `_decentscale._tcp.local` as part of the reconnect ladder, and SHALL auto-connect when a resolved instance matches the saved primary address.
+
+This exists because the direct A-record query for the saved hostname has been observed to enter a state where it returns nothing at all, for hours, while the scale is plainly reachable. On Android: 82 consecutive reconnect attempts over 7.5 h each received **zero** mDNS records, while the scale was awake, mains-powered and serving WebSocket traffic on its IP; a DNS-SD browse resolved the same hostname in 362 ms, and raising the A-query deadline from 2 s to 5 s did not change the outcome.
+
+That state is NOT a property of the responder, and this requirement must not be read as saying so. A later run on the same tablet and the same scale resolved `hds.local` by direct A-query in **357 ms — one query, one record** — and connected without any browse. The distinguishing factor was a tablet reboot between the two sessions, matching an earlier finding that mDNS discovery is reliable after a reboot and that pre-reboot failures were tablet-side stale state. Treat the failure as a host-side condition the app cannot detect or clear, not as scale or protocol behaviour.
+
+The browse is justified by that being unrecoverable from inside the app: when the direct query returns nothing there is no signal to distinguish "stale resolver state" from "scale genuinely absent", and the browse succeeds in both readings of the first case.
+
+The browse SHALL run on every platform. The same SYMPTOM has been seen off Android — macOS once logged `QHostInfo resolution failed for hdstest.local: Host not found` on the reconnect path while a browse resolved that host in 1.32 s — but one occurrence through a different resolver is not evidence of a shared root cause, and that macOS state did not recur. Running everywhere is a cheap hedge against a failure whose cause is not established, not a claim that every platform has the same defect. `MdnsResolver::browseService()` selects the system Bonjour backend on Apple platforms and the mjansson backend elsewhere.
+
+The reconnect browse SHALL be isolated from user-initiated scanning:
+
+- It SHALL NOT cancel, supersede or shorten a browse belonging to a user-initiated scan.
+- It SHALL NOT set the scanning indicator, and SHALL NOT make the "Scan for Devices" control read "Scanning…".
+- It SHALL NOT clear the discovered-devices list that a user scan populated.
+
+The reconnect browse SHALL use a deadline shorter than the user-scan browse, because it repeats on the reconnect ladder rather than running once per user action.
+
+The existing anti-substitution guarantee is unchanged: a browsed instance is auto-connected only when its address matches the saved primary.
+
+Matching the saved primary while a scale is already connected SHALL NOT by itself cause a switch-back. A switch-back SHALL be requested only when the connected scale is a backup — that is, when the direct attempt to the saved WiFi primary has already failed and has not since been superseded by a connect to the primary. When the saved primary IS the connected scale, the browse result SHALL be a no-op: the app SHALL NOT disconnect it, SHALL NOT redial it, and SHALL NOT log that a backup scale is connected.
+
+This is not a hypothetical ordering. Deciding "a backup is connected" from connectedness alone made every user scan disconnect and redial the healthy primary, because the same auto-connect path serves the user scan's browse and A-record probe as well as the reconnect browse. Measured on the tablet: connected at t=4.2 s, scan at t=22.3 s, two switch-back requests, torn down at t=30.9 s, reconnected to the same hostname and IP at t=32.6 s — roughly 8 s with no weight readings, repeated on every press of Scan.
+
+#### Scenario: Stale cached IP is recovered without user action
+- **WHEN** a WiFi scale is the saved primary, its cached IP no longer reaches it, and a direct hostname lookup returns no records
+- **THEN** the reconnect ladder runs a service browse, the scale's current address is resolved from the browse, and the app connects to it without the user opening the Connections page
+
+#### Scenario: Reconnect browse does not disturb a user scan
+- **WHEN** the user has a scan in progress and a reconnect tick fires
+- **THEN** the user's browse continues to its own deadline, its discovered rows are not cleared, and the scanning indicator reflects only the user's scan
+
+#### Scenario: Reconnect browse is invisible in the UI
+- **WHEN** a reconnect browse is running and no user scan is in progress
+- **THEN** the "Scan for Devices" control remains idle and enabled, and no scanning indicator is shown
+
+#### Scenario: A different scale on the LAN is not substituted
+- **WHEN** a reconnect browse resolves a scale whose address does not match the saved primary
+- **THEN** the app does not auto-connect to it
+
+#### Scenario: No browse when no WiFi scale is saved
+- **WHEN** the saved primary scale address does not begin with `"wifi:"`
+- **THEN** no reconnect browse is started, and no WiFi discovery traffic is generated outside a user-initiated scan
+
+#### Scenario: Browse is not run when the direct attempt succeeds
+- **WHEN** a reconnect attempt connects successfully via the cached IP
+- **THEN** no reconnect browse is started for that attempt
+
+#### Scenario: Scanning while the saved WiFi primary is connected does not drop it
+- **WHEN** the saved WiFi primary is connected and the user taps "Scan for devices", and the scan's browse and A-record probe both resolve that same primary
+- **THEN** the scale stays connected throughout — no disconnect, no redial, no gap in weight readings — and no switch-back is requested by either hit
+
+#### Scenario: Switch-back still runs when a backup is the connected scale
+- **WHEN** the direct attempt to the saved WiFi primary has failed, the WiFi→BLE fallback has connected a backup scale, and a browse then resolves the saved primary
+- **THEN** the app requests the switch-back, drops the backup, and connects the primary at the freshly browsed address
+

--- a/openspec/changes/no-switch-back-to-connected-primary/tasks.md
+++ b/openspec/changes/no-switch-back-to-connected-primary/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## 1. Gate the switch-back
+
+- [x] 1.1 Add `BLEManager::shouldRequestSwitchBack(bool scaleConnected, bool directAttemptFailed)` beside the other reconnect predicates in `src/ble/blemanager.h`, documenting why `m_wifiDirectAttemptFailed` is the backup discriminator and citing the observed outage.
+- [x] 1.2 Apply it in `maybeAutoConnectBrowsedScale()` (`src/ble/blemanager.cpp`): when a scale is connected and the predicate is false, return without emitting `wifiPrimaryReachable` and without falling through to `scaleDiscovered`.
+- [x] 1.3 Drop "Reconnect" from the switch-back log line — the same function serves the user scan's browse and probe.
+- [x] 1.4 Correct the comment in `onScaleConnectedChanged()` that asserted an already-connected scale always routes through `switchToWifiPrimary()`.
+
+## 2. Tests
+
+- [x] 2.1 Add `switchBackOnlyWhenTheConnectedScaleIsABackup()` to `tests/tst_wifiscalediscovery.cpp` covering all four (connected, directAttemptFailed) combinations.
+- [x] 2.2 Verify the test can fail: revert 1.2 and confirm the `(true, false)` assertion goes red.
+- [x] 2.3 Run the full suite via the Qt Creator MCP (`run_tests`, scope `all`) before opening the PR.
+
+## 3. Ship
+
+- [ ] 3.1 Open the PR against `main` and review it.
+- [ ] 3.2 `openspec archive no-switch-back-to-connected-primary` as the last commit on the branch.
+
+## Notes
+
+No manual entry in the wiki manual: the change removes an unintended disconnect,
+it does not add or alter a documented user-visible feature.

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1734,9 +1734,14 @@ void BLEManager::onScaleConnectedChanged() {
         //
         // Letting it finish is safe because maybeAutoConnectBrowsedScale acts
         // only on an exact saved-primary match, and when a scale is already
-        // connected it routes through wifiPrimaryReachable -> switchToWifiPrimary
-        // rather than emitting scaleDiscovered into main.cpp's single-scale
-        // guard. The browse ends on its own deadline either way.
+        // connected it either routes through wifiPrimaryReachable ->
+        // switchToWifiPrimary or does nothing at all — never emitting
+        // scaleDiscovered into main.cpp's single-scale guard. Which of the two
+        // depends on m_wifiDirectAttemptFailed, cleared just above: a browse
+        // that lands after THIS connect (the primary itself) is a no-op. That
+        // second half is the fix for a switch-back that fired against the
+        // primary; see shouldRequestSwitchBack(). The browse ends on its own
+        // deadline either way.
         scaleDebug(QStringLiteral("Scale connected"));
         emit scaleConnected();  // UI auto-dismisses the scale-disconnect / no-scale notice on reconnect
     } else {
@@ -2672,12 +2677,22 @@ void BLEManager::maybeAutoConnectBrowsedScale(const WifiScaleResult& result) {
     // Without this branch the feature does nothing whenever a BLE fallback is
     // available: the browse resolves, the emit is dropped, and the reconnect
     // ladder has already stopped.
-    if (m_scaleDevice && m_scaleDevice->isConnected()) {
+    //
+    // "A scale is connected" is NOT on its own evidence that it is a backup —
+    // see shouldRequestSwitchBack(), and the outage that reading it that way
+    // caused. When the primary is what is already connected there is nothing to
+    // switch back to, and the plain emit below must not run either: main.cpp's
+    // single-scale guard drops it, which is the correct outcome.
+    const bool scaleConnected = m_scaleDevice && m_scaleDevice->isConnected();
+    if (scaleConnected) {
+        if (!shouldRequestSwitchBack(scaleConnected, m_wifiDirectAttemptFailed)) return;
         // Hand the freshly browsed address to the switch-back. It cannot use the
         // persisted cache here: a stale cached IP is the whole reason this browse
         // ran, so dialing it again would fail the same way.
         m_browsedPrimaryIp = result.address;
-        scaleInfo(QStringLiteral("Reconnect browse found the saved primary %1 at %2 while a "
+        // Deliberately not "reconnect browse": this function serves the user
+        // scan's browse and probe too, and all three reach this line.
+        scaleInfo(QStringLiteral("Browse found the saved primary %1 at %2 while a "
                                  "backup scale is connected — requesting switch-back")
                       .arg(result.hostname, result.address));
         emit wifiPrimaryReachable(true);

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -891,6 +891,26 @@ public:
         return address.compare(savedScaleAddress, Qt::CaseInsensitive) == 0;
     }
 
+    /// Whether finding the saved primary should trigger a switch-back, given a
+    /// scale is already connected. The connected scale is a BACKUP only if the
+    /// direct attempt to the primary failed: `directAttemptFailed` is set solely
+    /// by onScaleConnectionTimeout for the saved WiFi scale, and cleared by any
+    /// connect that is not the WiFi->BLE fallback. So while a scale is
+    /// connected, true means "this is the fallback backup" and false means "the
+    /// primary itself is connected".
+    ///
+    /// Without this gate the switch-back fired against the primary ITSELF. A
+    /// user scan re-finds the healthy primary, the caller sees only
+    /// `isConnected()`, calls it a backup, and switch-back disconnects and
+    /// redials the same scale: an 8 s outage for nothing, twice per scan (once
+    /// for the DNS-SD hit, once for the mDNS hit). Observed 2026-08-01 on the
+    /// tablet — connected at t=4.2 s, scan at t=22.3, torn down at t=30.9,
+    /// back at t=32.6 on the same hostname and the same IP.
+    static bool shouldRequestSwitchBack(bool scaleConnected, bool directAttemptFailed) {
+        if (!scaleConnected) return false;
+        return directAttemptFailed;
+    }
+
 private:
     // Auto-connect a browsed instance when it IS the saved primary. One
     // implementation, called from both discovery handlers — the scan's and the

--- a/tests/tst_wifiscalediscovery.cpp
+++ b/tests/tst_wifiscalediscovery.cpp
@@ -278,6 +278,24 @@ private slots:
         QVERIFY(BLEManager::browsedScaleIsSavedPrimary(
             QStringLiteral("hds.local"), QStringLiteral("WIFI:HDS.LOCAL")));
     }
+
+    // Finding the saved primary while it is ALREADY the connected scale must not
+    // request a switch-back. It used to: the caller tested only isConnected(),
+    // so a user scan that re-found the healthy primary disconnected and redialed
+    // it — an ~8 s outage, twice per scan. m_wifiDirectAttemptFailed is the
+    // discriminator, because it is set only when the direct attempt to the
+    // primary timed out and is cleared by any connect that is not the fallback.
+    void switchBackOnlyWhenTheConnectedScaleIsABackup() {
+        // Primary itself connected: the direct attempt succeeded, so no switch.
+        QVERIFY(!BLEManager::shouldRequestSwitchBack(true, false));
+        // Direct attempt failed, then a scale connected — the WiFi->BLE fallback
+        // backup. This is the case the switch-back exists for.
+        QVERIFY(BLEManager::shouldRequestSwitchBack(true, true));
+        // No scale connected: the caller takes the plain scaleDiscovered path
+        // instead, regardless of how the direct attempt went.
+        QVERIFY(!BLEManager::shouldRequestSwitchBack(false, true));
+        QVERIFY(!BLEManager::shouldRequestSwitchBack(false, false));
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_WifiScaleDiscovery)


### PR DESCRIPTION
## The bug

Pressing **Scan for devices** while the saved WiFi scale was connected disconnected it and redialled it — about 8 seconds with no weight readings, every time.

`maybeAutoConnectBrowsedScale()` decided the connected scale was a *backup* from `m_scaleDevice->isConnected()` alone. That test is just as true when the connected scale IS the saved primary, and this function is shared by three callers: the user scan's DNS-SD browse handler, the user scan's A-record probe handler, and the reconnect browse's. So a user scan that re-found the healthy primary asked to switch back to it, and `switchToWifiPrimary()` dropped the scale and dialled the same hostname at the same IP.

From the tablet log, session starting 2026-08-01 11:17:55:

```
[  4.154] WebSocket connected — peer=192.168.10.145:80
[ 22.273] Starting device scan...
[ 22.636] Reconnect browse found the saved primary hds.local at 192.168.10.145
          while a backup scale is connected — requesting switch-back
[ 22.683] (again — once for the DNS-SD hit, once for the mDNS hit)
[ 30.897] WebSocket disconnected (expected)
[ 32.494] Auto-reconnect attempt 1 → connected to the same scale
```

A scan during a shot would have taken the scale away mid-pour.

## The fix

Gate the switch-back on `m_wifiDirectAttemptFailed`, which already carries exactly the needed meaning — set only by the connection timeout for a saved `wifi:` primary, cleared by any connect that is not the WiFi→BLE fallback, cleared again when the saved address changes. So while a scale is connected, `true` can only mean the connect was the fallback (a backup) and `false` means the primary itself is connected. No new state, no existing state repurposed.

Rejected alternatives are in the change's `design.md`: comparing the connected device's hostname needs an accessor `ScaleDevice` does not have plus a downcast, for no more correctness; suppressing the duplicate request treats the symptom, since one needless disconnect is the bug.

Also drops "Reconnect" from that log line — wrong for the two scan-side callers — and corrects the comment in `onScaleConnectedChanged()` that asserted an already-connected scale always routes through `switchToWifiPrimary()`.

## Verification

- `switchBackOnlyWhenTheConnectedScaleIsABackup()` covers all four `(connected, directAttemptFailed)` combinations. Added as a slot in an existing file, not a new one.
- **Confirmed it can fail:** restoring the old semantics (`return directAttemptFailed || scaleConnected`) turned it red — 109 passed / 1 failed. Restored, and the full suite is 110 passed, 0 failed, 0 skipped, no warnings.
- Spec delta under `openspec/changes/no-switch-back-to-connected-primary/`, validated; log-marker gate passes.

No wiki manual entry: this removes an unintended disconnect rather than adding or altering a documented feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)