### PR TITLE
Capture ART's abort message instead of the thread dump that follows it

### DIFF
--- a/src/core/crashhandler.cpp
+++ b/src/core/crashhandler.cpp
@@ -1,4 +1,5 @@
 #include "crashhandler.h"
+#include "logpaths.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -134,57 +135,114 @@ static void writeBacktraceToFile(FILE* f)
 // crashes, so an empty section must be attributable (exec denied vs. logd
 // rotated this pid out vs. capture killed) rather than read as "no entries".
 //
-// THE BUDGET IS THE DESIGN. The report is not read on the device — it is POSTed
-// to api.decenza.coffee, which slices it before opening or commenting on a
-// GitHub issue (Kulitorum/decenza-shotmap, backend/lambdas/crashReport.ts):
+// THE BUDGET IS THE DESIGN. What bounds the report is not what fits on the
+// device (CrashReportDialog.qml renders the whole thing) — it is that the report
+// is POSTed to api.decenza.coffee, which slices it before opening or commenting
+// on a GitHub issue. Verified 2026-08-02 against Kulitorum/decenza-shotmap,
+// backend/lambdas/crashReport.ts:
 //
-//     new issue body        crashLog.slice(0, 10000)
-//     comment on existing   crashLog.slice(0, 5000)      <-- the usual path
-//     debug log tail        debugLogTail.slice(0, 5000)
+//     new issue body        crashLog.slice(0, 10000)      + debugLogTail.slice(0, 5000)
+//     comment on existing   crashLog.slice(0,  5000)      and NO debugLogTail at all
+//                                                          (addCommentToIssue is
+//                                                           never passed the field)
 //
-// All three cut from the END. A recurring crash dedupes onto its existing
-// issue, so 5000 chars is the real budget, not 10000 — and in #1745 the header
-// and 29-frame backtrace had already spent ~4100 of it. Everything below is
-// sized against that, and any change here should be re-measured against those
-// slice() calls rather than against what fits on a screen.
+// Both cut from the END. Which path a report takes is decided by
+// findSimilarIssue(), whose search is filtered `is:open` — so a crash dedupes
+// onto its predecessor only while that predecessor is still OPEN. #1745 is the
+// fourth instance of this exact crash and still opened a NEW issue, because
+// #1408 and #1572 had been closed as duplicates: it got the 10000-char budget,
+// and its crash log arrived cut at exactly 10001 chars.
 //
-// #1745 is what this replaces: a blind `-t 200` unfiltered tail. ART's abort
-// block runs header -> ref-table dump (the Summary naming the leaked class) ->
-// "Runtime aborting..." -> a full per-thread stack dump of ~1000 lines. A tail
-// of 200 lands inside the thread dump, so the report carried 41 lines of other
-// threads' stacks and not one line of the diagnosis it exists to capture.
-// Hence: filter to fatal priority, take the HEAD of the block, and drop the
-// ~60-char "date pid tid F tag:" prefix that was costing half of every line.
+// So: 10000 normally, 5000 whenever someone has left the prior issue open. The
+// sizing below has to survive the 5000 case, and anything that grows what
+// precedes the capture has to be re-measured against both. In #1745 the header
+// and 29-frame backtrace alone were ~4117 chars.
+//
+// #1745 is what this replaces: a blind `-t 200` unfiltered tail, which returned
+// 41 lines of OTHER THREADS' stacks and not one line of diagnosis. ART emits its
+// abort block at fatal priority — the report's lines read " F rum.decenza_de:" —
+// but so is the per-thread stack dump that follows, so filtering alone would not
+// have fixed it. Taking the HEAD of the filtered stream is what cuts before the
+// thread dump.
+//
+// INFERRED, not sourced: that the ref-table dump (the Summary naming the leaked
+// class) precedes the thread dump. What #1745 does establish is that the abort
+// is raised from inside the log record — its frames #5-#6 are
+// `LogMessage::~LogMessage` -> `Runtime::Abort` — so the message text is written
+// to logd before any thread dump exists. Where ART places the ref-table dump
+// within that is not visible in any report we hold; the first post-fix capture
+// is what confirms or refutes it. Do not repeat the ordering as established.
 static constexpr size_t kFatalCaptureBudget = 4000;
+
+// Why the capture ended. Returned instead of a bare byte count because the
+// caller cannot otherwise tell "logcat had nothing to say" from "logcat never
+// ran", and it was printing a confident "not an ART abort" over both.
+enum class CaptureOutcome {
+    Content,      // bytes captured, stream ended on its own
+    BudgetHit,    // bytes captured, we stopped at byteBudget
+    NoEntries,    // child ran and exited cleanly with nothing to say
+    ExecFailed,
+    Dup2Failed,
+    PipeFailed,
+    ForkFailed,
+    SetupFailed,  // fcntl could not make the read non-blocking
+    ReadFailed,
+    TimedOut,     // deadline expired with the child still streaming
+    ChildLost,    // waitpid failed (ECHILD) — we killed it, output may be short
+    Unknown,      // nothing matched — print the raw status rather than guess
+};
+
+// True when the outcome means the section holds real captured content.
+static bool captureHasContent(CaptureOutcome o)
+{
+    return o == CaptureOutcome::Content || o == CaptureOutcome::BudgetHit;
+}
 
 // Read the child's output through a pipe and write at most byteBudget of it to
 // f. Head-anchored on purpose: `logcat -t N` gives the LAST N lines, which is
 // the #1745 bug, so the cap has to be applied by us, from the start of the
-// stream. Returns bytes written; 0 means the capture produced nothing.
-static size_t captureLogcatToFile(FILE* f, bool fatalOnly, size_t byteBudget)
+// stream. `bytesOut` receives what was written (may be non-zero even on a
+// failure outcome — a stream can fail part-way).
+static CaptureOutcome captureLogcatToFile(FILE* f, bool fatalOnly,
+                                          size_t byteBudget, size_t* bytesOut,
+                                          int* rawStatusOut)
 {
+    *bytesOut = 0;
+    *rawStatusOut = 0;
+
     int fds[2];
-    if (pipe(fds) != 0) {
-        fprintf(f, "  (pipe failed — no capture)\n");
-        return 0;
-    }
+    if (pipe(fds) != 0)
+        return CaptureOutcome::PipeFailed;
 
     pid_t child = fork();
     if (child == 0) {
         close(fds[0]);
-        if (dup2(fds[1], STDOUT_FILENO) < 0 || dup2(fds[1], STDERR_FILENO) < 0)
+        // stdout ONLY. logcat's own stderr must NOT reach the content pipe:
+        // captureHasContent() gates whether the unfiltered fallback runs, so a
+        // device that rejects these arguments would have logcat's complaint
+        // counted as an ART abort and the fallback skipped — the one path that
+        // rescues a non-ART crash, disabled by the failure of the path it
+        // rescues. The exit status is what attributes such a failure instead.
+        if (dup2(fds[1], STDOUT_FILENO) < 0)
             _exit(126);
+        const int devNull = open("/dev/null", O_WRONLY);
+        if (devNull >= 0) {
+            (void)dup2(devNull, STDERR_FILENO);  // best effort; noise, not correctness
+            close(devNull);
+        }
         close(fds[1]);
         if (fatalOnly) {
-            // "*:F" is every tag at fatal priority — which, in normal
-            // operation, is ART's abort block and nothing else (the lines in
-            // #1745 read " F rum.decenza_de:"). "-v raw" drops the timestamp,
-            // pid, tid and tag prefix; the payload is what diagnoses the
-            // crash, and the prefix was eating ~50% of the budget above.
-            // "-t 20000" is a ceiling, not a window — we stop at byteBudget.
+            // "*:F" is every tag at fatal priority. "-v raw" drops the 49-char
+            // "date pid tid F tag: " prefix, which was 34% of the bytes
+            // captured in #1745 (2009 of 5824). Note ART's own "runtime.cc:NNN]"
+            // tag is message payload and survives -v raw.
+            //
+            // No "-t": it is a TAIL, and on the common non-ART crash the fatal
+            // filter matches nothing, so a wide "-t" only makes logcat walk the
+            // pid's whole retained history to produce zero bytes. --pid= plus
+            // the fatal filter is the bound that matters; byteBudget is the cap.
             execl("/system/bin/logcat", "logcat", "-d", "-v", "raw",
-                  "-t", "20000", s_logcatPidArg, "*:F",
-                  static_cast<char*>(nullptr));
+                  s_logcatPidArg, "*:F", static_cast<char*>(nullptr));
         } else {
             execl("/system/bin/logcat", "logcat", "-d", "-t", "200",
                   s_logcatPidArg, static_cast<char*>(nullptr));
@@ -194,24 +252,32 @@ static size_t captureLogcatToFile(FILE* f, bool fatalOnly, size_t byteBudget)
     if (child < 0) {
         close(fds[0]);
         close(fds[1]);
-        fprintf(f, "  (fork failed — no capture)\n");
-        return 0;
+        return CaptureOutcome::ForkFailed;
     }
 
     close(fds[1]);
-    // Non-blocking so the drain below can share the bounded wait loop: a
-    // blocking read on a wedged child would hang the crash handler.
-    fcntl(fds[0], F_SETFL, O_NONBLOCK);
+    // Non-blocking is what makes the deadline below real: a blocking read on a
+    // wedged child would hang the crash handler with no bound at all. So if it
+    // cannot be established, abandon the capture rather than run the loop
+    // without the property it depends on.
+    if (fcntl(fds[0], F_SETFL, O_NONBLOCK) != 0) {
+        close(fds[0]);
+        kill(child, SIGKILL);
+        waitpid(child, nullptr, WNOHANG);
+        return CaptureOutcome::SetupFailed;
+    }
 
     size_t written = 0;
     bool budgetHit = false;
     bool eof = false;
+    bool readFailed = false;
     bool reaped = false;
     int childStatus = 0;
+    int iterations = 0;
 
     // Bounded: logcat -d exits almost immediately, but never let a wedged child
     // hang the crash handler. ~3 s cap, then kill and move on.
-    for (int i = 0; i < 60 && !eof && !budgetHit; ++i) {
+    for (; iterations < 60 && !eof && !budgetHit && !readFailed; ++iterations) {
         for (;;) {
             char buf[1024];
             ssize_t n = read(fds[0], buf, sizeof(buf));
@@ -229,82 +295,167 @@ static size_t captureLogcatToFile(FILE* f, bool fatalOnly, size_t byteBudget)
                 }
                 continue;
             }
-            if (n == 0)
+            if (n == 0) {
                 eof = true;
-            break;  // EOF, EAGAIN, or error — yield to the wait below
-        }
-        if (eof || budgetHit)
+                break;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+                break;  // nothing ready yet — yield to the wait below
+            // A hard error (EIO on a failing device, EBADF). Left folded into
+            // the EAGAIN case it would never set eof, so the loop would burn
+            // the full 3 s re-reading a dead fd and then report success.
+            readFailed = true;
             break;
+        }
 
+        // Reap BEFORE the exit test. On the normal path logcat exits, the pipe
+        // closes, read() returns 0 and we leave immediately — so a waitpid
+        // placed after that test never ran on the path that always happens, and
+        // every successful capture went on to SIGKILL an already-dead child and
+        // sleep 50 ms for it.
         pid_t r = waitpid(child, &childStatus, WNOHANG);
         if (r == child) {
             reaped = true;
-            // The child is gone but the pipe may still hold buffered output;
-            // one more drain pass runs on the next iteration before we exit on
-            // EOF. Do not break here.
         } else if (r < 0) {
-            // ECHILD (e.g. SIGCHLD set to SIG_IGN elsewhere in the process):
-            // we can no longer observe the child, so stop waiting on it.
-            reaped = true;
-            childStatus = 0;
+            // ECHILD (e.g. SIGCHLD set to SIG_IGN elsewhere in the process): we
+            // can no longer observe the child, but we are still obliged to stop
+            // it — it holds the write end of a pipe we are about to close.
+            kill(child, SIGKILL);
+            close(fds[0]);
+            *bytesOut = written;
+            return CaptureOutcome::ChildLost;
         }
+        if (eof || budgetHit || readFailed)
+            break;
+
         struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
         nanosleep(&ts, nullptr);
     }
 
+    const bool timedOut = !eof && !budgetHit && !readFailed;
+
     close(fds[0]);
     if (!reaped) {
-        // Either timed out or we stopped early at the budget. Kill, then reap
-        // best-effort only — a blocking waitpid could hang the whole crash
-        // handler on a child stuck in uninterruptible sleep, which on a
-        // distressed device is exactly when this code runs.
+        // Kill, then reap best-effort only — a blocking waitpid could hang the
+        // whole crash handler on a child stuck in uninterruptible sleep, which
+        // on a distressed device is exactly when this code runs.
         kill(child, SIGKILL);
         struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
         nanosleep(&ts, nullptr);
         waitpid(child, &childStatus, WNOHANG);
     }
 
-    if (written == 0) {
-        if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 127)
-            fprintf(f, "  (logcat exec failed — no capture)\n");
-        else if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 126)
-            fprintf(f, "  (dup2 failed in capture child — no capture)\n");
-        else if (WIFSIGNALED(childStatus))
-            fprintf(f, "  (logcat died on signal %d)\n", WTERMSIG(childStatus));
-    } else if (budgetHit) {
-        fprintf(f, "\n  (capture stopped at %zu bytes — the server slices the "
-                   "report at 5000 chars on a duplicate issue, so anything past "
-                   "here would not have survived submission)\n", byteBudget);
-    } else {
+    // A short write makes `written` a lie, and `written` decides both the
+    // marker and whether the fallback runs. The code this replaced compared
+    // lseek() offsets and so actually observed the file; this restores that.
+    if (ferror(f))
+        readFailed = true;
+
+    *bytesOut = written;
+    *rawStatusOut = childStatus;
+    if (readFailed)
+        return CaptureOutcome::ReadFailed;
+    if (timedOut)
+        return CaptureOutcome::TimedOut;
+    if (budgetHit)
+        return CaptureOutcome::BudgetHit;
+    if (written > 0)
+        return CaptureOutcome::Content;
+    if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 127)
+        return CaptureOutcome::ExecFailed;
+    if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 126)
+        return CaptureOutcome::Dup2Failed;
+    if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 0)
+        return CaptureOutcome::NoEntries;
+    return CaptureOutcome::Unknown;
+}
+
+// One marker per outcome, and exactly one. This section exists to explain
+// crashes, so an empty or short section must be attributable — and must never
+// be MISattributed, which is worse: a truncated capture that prints "end of
+// capture" tells the reader ART's dump genuinely ended there.
+static void writeCaptureMarker(FILE* f, CaptureOutcome outcome, size_t bytes,
+                               size_t byteBudget, int rawStatus)
+{
+    switch (outcome) {
+    case CaptureOutcome::Content:
         fprintf(f, "  (end of capture)\n");
+        break;
+    case CaptureOutcome::BudgetHit:
+        fprintf(f, "\n  (capture stopped at %zu bytes — see the budget note in "
+                   "crashhandler.cpp; the rest would not have survived the "
+                   "server's slice)\n", byteBudget);
+        break;
+    case CaptureOutcome::NoEntries:
+        fprintf(f, "  (logcat ran and had nothing to report for this pid)\n");
+        break;
+    case CaptureOutcome::ExecFailed:
+        fprintf(f, "  (logcat exec failed — no capture)\n");
+        break;
+    case CaptureOutcome::Dup2Failed:
+        fprintf(f, "  (dup2 failed in capture child — no capture)\n");
+        break;
+    case CaptureOutcome::PipeFailed:
+        fprintf(f, "  (pipe failed — no capture)\n");
+        break;
+    case CaptureOutcome::ForkFailed:
+        fprintf(f, "  (fork failed — no capture)\n");
+        break;
+    case CaptureOutcome::SetupFailed:
+        fprintf(f, "  (could not set the capture pipe non-blocking — skipped "
+                   "rather than risk an unbounded read in the signal handler)\n");
+        break;
+    case CaptureOutcome::ReadFailed:
+        fprintf(f, "\n  (capture failed after %zu bytes — output above is "
+                   "incomplete)\n", bytes);
+        break;
+    case CaptureOutcome::TimedOut:
+        fprintf(f, "\n  (capture killed after 3s with %zu bytes — output above "
+                   "is truncated mid-stream, not complete)\n", bytes);
+        break;
+    case CaptureOutcome::ChildLost:
+        fprintf(f, "\n  (lost track of the capture child after %zu bytes and "
+                   "killed it — output above may be incomplete)\n", bytes);
+        break;
+    case CaptureOutcome::Unknown:
+        fprintf(f, "  (capture produced %zu bytes and ended unexplained; child "
+                   "status=0x%x)\n", bytes, static_cast<unsigned>(rawStatus));
+        break;
     }
-    return written;
 }
 
 // ART's own account of why it aborted. Written BEFORE our backtrace, which is
 // deliberate and is the other half of the #1745 fix: when ART aborts, our
 // backtrace names the JNI call that happened to hit the ceiling (a battery poll
 // in #1408/#1572/#1745) and ART's dump names the actual leak, so on a budget
-// that cuts from the end, ART's dump is what has to go first. Returns false
-// when there were no fatal entries, which is the normal case for SIGSEGV and
-// friends — the caller then falls back to the unfiltered tail, after the
-// backtrace, where it costs the backtrace nothing.
-static bool appendArtAbortMessageToFile(FILE* f)
+// that cuts from the end, ART's dump is what has to go first.
+//
+// Returns the outcome so the caller can tell "ART said nothing" (fall back to
+// the unfiltered tail) from "the capture itself failed" (the fallback would
+// fail identically, and a second theory printed under it would contradict the
+// first).
+static CaptureOutcome appendArtAbortMessageToFile(FILE* f)
 {
     fprintf(f, "\nART abort message (logcat, fatal priority only):\n");
-    if (captureLogcatToFile(f, /*fatalOnly=*/true, kFatalCaptureBudget) > 0)
-        return true;
-    fprintf(f, "  (no fatal-priority entries for this pid — not an ART abort, "
-               "or logd rotated them out)\n");
-    return false;
+    size_t bytes = 0;
+    int rawStatus = 0;
+    const CaptureOutcome outcome = captureLogcatToFile(
+        f, /*fatalOnly=*/true, kFatalCaptureBudget, &bytes, &rawStatus);
+    writeCaptureMarker(f, outcome, bytes, kFatalCaptureBudget, rawStatus);
+    if (outcome == CaptureOutcome::NoEntries)
+        fprintf(f, "  (so this was not an ART abort, or logd rotated its "
+                   "entries out)\n");
+    return outcome;
 }
 
-static void appendLogcatTailToFile(FILE* f)
+static void appendLogcatTailToFile(FILE* f, size_t byteBudget)
 {
     fprintf(f, "\nSystem log tail (logcat):\n");
-    if (captureLogcatToFile(f, /*fatalOnly=*/false, kFatalCaptureBudget) == 0)
-        fprintf(f, "  (logcat wrote nothing — entries for this pid may have "
-                   "rotated out of logd)\n");
+    size_t bytes = 0;
+    int rawStatus = 0;
+    const CaptureOutcome outcome =
+        captureLogcatToFile(f, /*fatalOnly=*/false, byteBudget, &bytes, &rawStatus);
+    writeCaptureMarker(f, outcome, bytes, byteBudget, rawStatus);
 }
 #endif
 
@@ -372,7 +523,7 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
     if (!f) return;
 
     // Write crash header
-    fprintf(f, "=== CRASH REPORT ===\n");
+    fprintf(f, "%s\n", kReportStart);
     fprintf(f, "Signal: %d (%s)\n", signal, signalName);
 
     // Get current time (basic, signal-safe-ish)
@@ -389,16 +540,24 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
     fprintf(f, "Thread: %lu\n", (unsigned long)GetCurrentThreadId());
 #endif
 
-    // Last debug message
+    // Last debug message, CAPPED. s_lastDebugMessage is char[4096] and holds
+    // whatever the last qDebug was — this app logs profile JSON and HTTP bodies,
+    // so an unbounded copy can spend most of the 5000-char head slice before the
+    // ART capture below has written a byte, and the report ends up looking
+    // exactly like #1745 again. The first line is the part that has ever been
+    // diagnostic (in #1745 it named the screensaver transition count).
     if (s_lastDebugMessage[0] != '\0') {
-        fprintf(f, "\nLast debug message:\n  %s\n", s_lastDebugMessage);
+        constexpr int kLastMessageMax = 512;
+        fprintf(f, "\nLast debug message:\n  %.*s%s\n",
+                kLastMessageMax, s_lastDebugMessage,
+                s_lastDebugMessage[kLastMessageMax] != '\0' ? " …(truncated)" : "");
     }
 
 #ifdef Q_OS_ANDROID
     // Ahead of the backtrace: see appendArtAbortMessageToFile(). Only into
     // crash.log (which becomes the report's "Crash Log" section) — not into the
     // debug.log copy below, whose tail is submitted separately.
-    const bool artAborted = appendArtAbortMessageToFile(f);
+    const CaptureOutcome artOutcome = appendArtAbortMessageToFile(f);
 #endif
 
     // Write backtrace
@@ -409,14 +568,21 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
 #endif
 
 #ifdef Q_OS_ANDROID
-    // Only when ART did not explain itself. An ART abort has already spent the
-    // budget on the fatal block, and the unfiltered tail there is the thread
-    // dump that #1745 wasted its whole report on.
-    if (!artAborted)
-        appendLogcatTailToFile(f);
+    // Only when ART ran and had nothing to say. Skipped when ART DID explain
+    // itself (the budget is spent, and the unfiltered tail there is the thread
+    // dump #1745 wasted its whole report on) and equally when the capture
+    // FAILED — the fallback runs the same binary the same way, so it would fail
+    // identically and stack a second, contradictory marker under the first.
+    //
+    // Smaller budget than the fatal pass: on this path the backtrace above has
+    // already spent ~4100 chars, so on a 5000-char comment only a few hundred
+    // survive submission anyway, and every byte here is also up to 3s of
+    // signal-handler time on a machine that may be mid-shot.
+    if (artOutcome == CaptureOutcome::NoEntries)
+        appendLogcatTailToFile(f, 1500);
 #endif
 
-    fprintf(f, "\n=== END CRASH REPORT ===\n");
+    fprintf(f, "\n%s\n", kReportEnd);
     fflush(f);
     fclose(f);
 
@@ -424,7 +590,7 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
     if (s_debugLogPath[0] != '\0') {
         FILE* debugLog = fopen(s_debugLogPath, "a");
         if (debugLog) {
-            fprintf(debugLog, "\n\n=== CRASH REPORT ===\n");
+            fprintf(debugLog, "\n\n%s\n", kReportStart);
             fprintf(debugLog, "Signal: %d (%s)\n", signal, signalName);
             fprintf(debugLog, "Time: %s", ctime(&now));
             if (s_lastDebugMessage[0] != '\0') {
@@ -433,7 +599,13 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
 #if defined(Q_OS_ANDROID) || defined(Q_OS_LINUX) || defined(Q_OS_WIN) || defined(Q_OS_MACOS) || defined(Q_OS_IOS)
             writeBacktraceToFile(debugLog);
 #endif
-            fprintf(debugLog, "\n=== END CRASH REPORT ===\n");
+            // Flushed BEFORE the end marker as well as after: writeBacktrace
+            // runs dladdr and __cxa_demangle (which mallocs) from a signal
+            // handler on a possibly-corrupt heap, so a second fault in there
+            // would leave a start marker with no end — and getDebugLogTail()
+            // treats that as "everything after is report text". It recovers now
+            // (see the EOF handling there), but losing less is better.
+            fprintf(debugLog, "\n%s\n", kReportEnd);
             fflush(debugLog);
             fclose(debugLog);
         }
@@ -472,8 +644,18 @@ void CrashHandler::install()
     QByteArray pathBytes = logPath.toUtf8();
     strncpy(s_crashLogPath, pathBytes.constData(), sizeof(s_crashLogPath) - 1);
 
-    // Also set up debug.log path for persistent crash logging
-    QString debugPath = dataPath + "/debug.log";
+    // Also set up debug.log path for persistent crash logging.
+    //
+    // DecenzaPaths::logsDirectory(), not dataPath — they differ on Android, and
+    // getting it wrong made this file a SECOND debug.log that only this class
+    // ever wrote to. WebDebugLogger puts every line of app narrative in
+    // logsDirectory()/debug.log (external storage, so a user can retrieve it);
+    // this used to append crash reports to AppDataLocation/debug.log, whose
+    // entire content was therefore crash reports. That is why the debug tail
+    // submitted with #1745 was one stale report and no narrative — not a
+    // missing filter, the wrong file. logpaths.h:22-26 exists to stop exactly
+    // this second copy quietly falling back to AppDataLocation.
+    QString debugPath = DecenzaPaths::logsDirectory() + "/debug.log";
     QByteArray debugPathBytes = debugPath.toUtf8();
     strncpy(s_debugLogPath, debugPathBytes.constData(), sizeof(s_debugLogPath) - 1);
 
@@ -596,9 +778,9 @@ QString CrashHandler::getDebugLogTail(int lines)
 {
     QString debugPath = QString::fromUtf8(s_debugLogPath);
     if (debugPath.isEmpty()) {
-        // Fallback if install() wasn't called yet
-        QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        debugPath = dataPath + "/debug.log";
+        // Fallback if install() wasn't called yet. Must resolve the same way
+        // install() does — see the note there on the two-debug.log bug.
+        debugPath = DecenzaPaths::logsDirectory() + "/debug.log";
     }
 
     QFile file(debugPath);
@@ -608,39 +790,72 @@ QString CrashHandler::getDebugLogTail(int lines)
 
     // Read all lines, dropping any crash-report block.
     //
-    // This tail is submitted as its own field (debugLogTail, sliced to 5000
-    // chars server-side) to answer a question the crash log cannot: what the
-    // app was doing before it died. Crash-report text in here answers nothing,
-    // because the same text is already being submitted as crashLog.
+    // This tail is submitted as its own field to answer a question the crash log
+    // cannot: what the app was doing before it died. Crash-report text in here
+    // answers nothing, because the same text is already submitted as crashLog.
+    // (Budget note: the server slices debugLogTail to 5000 chars when OPENING an
+    // issue and drops the field entirely when commenting on an existing one —
+    // see the table in this file's capture section.)
     //
-    // Two writers put it there, and both land at the very end of debug.log —
-    // exactly where this tail reads:
-    //   - writeCrashLog() appends the whole report for persistence, at crash
-    //     time, so it is the last thing in the file;
-    //   - main.cpp re-logs the previous run's crash log at startup (a single
-    //     qWarning record, so only its first line carries a log prefix).
-    // In #1745 the result was a 5000-char debug tail containing one stale crash
-    // report and not a single line of app narrative.
-    static const QLatin1String kBlockStart("=== CRASH REPORT ===");
-    static const QLatin1String kBlockEnd("=== END CRASH REPORT ===");
+    // Three writers put report text in this file:
+    //   - writeCrashLog() appends the whole report at crash time;
+    //   - main.cpp re-logs the previous run's crash log at startup, as THREE
+    //     qWarning records: "=== PREVIOUS CRASH DETECTED ===", then the report
+    //     body as one noquote record, then a standalone end marker. So the body's
+    //     interior lines carry no log prefix while the markers around it do —
+    //     which is why the match below is not anchored to the start of a line.
+    // main.cpp's trailing standalone end marker is LOAD-BEARING, not redundant:
+    // it closes a crash.log whose own end marker never made it to disk.
+    const QLatin1String kBlockStart(kReportStart);
+    const QLatin1String kBlockEnd(kReportEnd);
 
     QStringList allLines;
+    QStringList blockLines;   // held while inside a block, restored if it never closes
     bool insideCrashBlock = false;
+    bool sawAnyStart = false;
     QTextStream stream(&file);
     while (!stream.atEnd()) {
         const QString line = stream.readLine();
         if (line.contains(kBlockEnd)) {
+            // An end marker with no start has two causes, and they need opposite
+            // treatment, so they are told apart by POSITION:
+            //
+            //  - A trim. WebDebugLogger::trimLogFile() keeps the TAIL of the
+            //    file, so it can cut a block's opening line away and leave the
+            //    body and closer behind. Everything read so far is that body and
+            //    must go. This can only ever appear before the first start
+            //    marker, because a trim cuts the head and nothing else.
+            //  - main.cpp's standalone closer, which follows the report body's
+            //    OWN end marker (see above). By then a start has been seen, the
+            //    block is already closed, and the narrative before it is real.
+            if (!insideCrashBlock && !sawAnyStart)
+                allLines.clear();
             insideCrashBlock = false;
+            blockLines.clear();
             continue;
         }
         if (line.contains(kBlockStart)) {
             insideCrashBlock = true;
+            sawAnyStart = true;
+            blockLines.clear();
             continue;
         }
-        if (!insideCrashBlock)
+        if (insideCrashBlock)
+            blockLines.append(line);
+        else
             allLines.append(line);
     }
     file.close();
+
+    // A start marker that never closed. The producer is writeCrashLog()'s
+    // debug.log append, which can die mid-block (it calls dladdr and a
+    // malloc'ing demangler from a signal handler, on the heap that may have
+    // caused the crash). Latching to EOF would drop every line after it — for
+    // this run and every future one, since debug.log is append-mode and
+    // persists — and the empty QString that produced is indistinguishable from
+    // "could not open the file". A degraded tail beats a silent empty one.
+    if (insideCrashBlock)
+        allLines += blockLines;
 
     // Get last N lines
     qsizetype startIndex = qMax(qsizetype(0), allLines.size() - lines);

--- a/src/core/crashhandler.cpp
+++ b/src/core/crashhandler.cpp
@@ -21,6 +21,7 @@
 #include <dlfcn.h>
 #include <cxxabi.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <errno.h>
@@ -116,81 +117,194 @@ static void writeBacktraceToFile(FILE* f)
     }
 }
 
-// Append the tail of this process's logcat to the crash log. The point is the
-// abort message: when ART kills us (JNI errors like global reference table
-// overflow, CheckJNI failures), it logs the FATAL reason — and for ref-table
-// overflow, a dump of the table's dominant classes — to logd *before* raising
-// SIGABRT. Our own qDebug log never sees that text, so without this section a
+// Capture this process's logcat into the crash log. The point is the abort
+// message: when ART kills us (JNI errors like global reference table overflow,
+// CheckJNI failures), it logs the FATAL reason — and for ref-table overflow, a
+// dump of the table's dominant classes — to logd *before* raising SIGABRT. Our
+// own qDebug log never sees that text, so without this section a
 // SIGABRT-from-ART report shows where we were, but not why ART aborted (#1408).
 //
 // An app may always read its own logs (logd filters by UID, no READ_LOGS
 // needed). fork() in a signal handler is not strictly async-signal-safe, but
-// between fork and exec the child calls only dup2/execl/_exit (all AS-safe;
-// the fd is captured before the fork) and the rest of this crash handler
-// already relies on far less safe machinery (stdio, demangling).
+// between fork and exec the child calls only close/dup2/execl/_exit (all
+// AS-safe) and the rest of this crash handler already relies on far less safe
+// machinery (stdio, demangling).
 //
 // Every outcome writes a distinct marker line: this section exists to explain
 // crashes, so an empty section must be attributable (exec denied vs. logd
 // rotated this pid out vs. capture killed) rather than read as "no entries".
-static void appendLogcatTailToFile(FILE* f)
+//
+// THE BUDGET IS THE DESIGN. The report is not read on the device — it is POSTed
+// to api.decenza.coffee, which slices it before opening or commenting on a
+// GitHub issue (Kulitorum/decenza-shotmap, backend/lambdas/crashReport.ts):
+//
+//     new issue body        crashLog.slice(0, 10000)
+//     comment on existing   crashLog.slice(0, 5000)      <-- the usual path
+//     debug log tail        debugLogTail.slice(0, 5000)
+//
+// All three cut from the END. A recurring crash dedupes onto its existing
+// issue, so 5000 chars is the real budget, not 10000 — and in #1745 the header
+// and 29-frame backtrace had already spent ~4100 of it. Everything below is
+// sized against that, and any change here should be re-measured against those
+// slice() calls rather than against what fits on a screen.
+//
+// #1745 is what this replaces: a blind `-t 200` unfiltered tail. ART's abort
+// block runs header -> ref-table dump (the Summary naming the leaked class) ->
+// "Runtime aborting..." -> a full per-thread stack dump of ~1000 lines. A tail
+// of 200 lands inside the thread dump, so the report carried 41 lines of other
+// threads' stacks and not one line of the diagnosis it exists to capture.
+// Hence: filter to fatal priority, take the HEAD of the block, and drop the
+// ~60-char "date pid tid F tag:" prefix that was costing half of every line.
+static constexpr size_t kFatalCaptureBudget = 4000;
+
+// Read the child's output through a pipe and write at most byteBudget of it to
+// f. Head-anchored on purpose: `logcat -t N` gives the LAST N lines, which is
+// the #1745 bug, so the cap has to be applied by us, from the start of the
+// stream. Returns bytes written; 0 means the capture produced nothing.
+static size_t captureLogcatToFile(FILE* f, bool fatalOnly, size_t byteBudget)
 {
-    fprintf(f, "\nSystem log tail (logcat, includes ART abort message if any):\n");
-    // Flush stdio before the child writes to the shared file description so
-    // output doesn't interleave out of order.
-    fflush(f);
-    const int outFd = fileno(f);
-    const off_t startOffset = lseek(outFd, 0, SEEK_CUR);
+    int fds[2];
+    if (pipe(fds) != 0) {
+        fprintf(f, "  (pipe failed — no capture)\n");
+        return 0;
+    }
 
     pid_t child = fork();
     if (child == 0) {
-        if (dup2(outFd, STDOUT_FILENO) < 0 || dup2(outFd, STDERR_FILENO) < 0)
+        close(fds[0]);
+        if (dup2(fds[1], STDOUT_FILENO) < 0 || dup2(fds[1], STDERR_FILENO) < 0)
             _exit(126);
-        execl("/system/bin/logcat", "logcat", "-d", "-t", "200",
-              s_logcatPidArg, static_cast<char*>(nullptr));
+        close(fds[1]);
+        if (fatalOnly) {
+            // "*:F" is every tag at fatal priority — which, in normal
+            // operation, is ART's abort block and nothing else (the lines in
+            // #1745 read " F rum.decenza_de:"). "-v raw" drops the timestamp,
+            // pid, tid and tag prefix; the payload is what diagnoses the
+            // crash, and the prefix was eating ~50% of the budget above.
+            // "-t 20000" is a ceiling, not a window — we stop at byteBudget.
+            execl("/system/bin/logcat", "logcat", "-d", "-v", "raw",
+                  "-t", "20000", s_logcatPidArg, "*:F",
+                  static_cast<char*>(nullptr));
+        } else {
+            execl("/system/bin/logcat", "logcat", "-d", "-t", "200",
+                  s_logcatPidArg, static_cast<char*>(nullptr));
+        }
         _exit(127);
     }
     if (child < 0) {
-        fprintf(f, "  (fork failed, no logcat capture)\n");
-        return;
+        close(fds[0]);
+        close(fds[1]);
+        fprintf(f, "  (fork failed — no capture)\n");
+        return 0;
     }
 
-    // Bounded wait: logcat -d exits almost immediately, but never let a wedged
-    // child hang the crash handler. ~3 s cap, then kill and move on.
-    for (int i = 0; i < 60; ++i) {
-        int status = 0;
-        pid_t r = waitpid(child, &status, WNOHANG);
-        if (r == child) {
-            if (WIFEXITED(status) && WEXITSTATUS(status) == 127)
-                fprintf(f, "  (logcat exec failed — no capture)\n");
-            else if (WIFEXITED(status) && WEXITSTATUS(status) == 126)
-                fprintf(f, "  (dup2 failed in capture child — no capture)\n");
-            else if (WIFSIGNALED(status))
-                fprintf(f, "  (logcat died on signal %d)\n", WTERMSIG(status));
-            else if (lseek(outFd, 0, SEEK_CUR) == startOffset)
-                fprintf(f, "  (logcat ran but wrote nothing — entries for this pid may have rotated out of logd)\n");
-            else
-                fprintf(f, "  (end of logcat tail)\n");
-            return;
+    close(fds[1]);
+    // Non-blocking so the drain below can share the bounded wait loop: a
+    // blocking read on a wedged child would hang the crash handler.
+    fcntl(fds[0], F_SETFL, O_NONBLOCK);
+
+    size_t written = 0;
+    bool budgetHit = false;
+    bool eof = false;
+    bool reaped = false;
+    int childStatus = 0;
+
+    // Bounded: logcat -d exits almost immediately, but never let a wedged child
+    // hang the crash handler. ~3 s cap, then kill and move on.
+    for (int i = 0; i < 60 && !eof && !budgetHit; ++i) {
+        for (;;) {
+            char buf[1024];
+            ssize_t n = read(fds[0], buf, sizeof(buf));
+            if (n > 0) {
+                const size_t remaining = byteBudget - written;
+                const size_t take = (static_cast<size_t>(n) < remaining)
+                                        ? static_cast<size_t>(n) : remaining;
+                if (take > 0) {
+                    fwrite(buf, 1, take, f);
+                    written += take;
+                }
+                if (written >= byteBudget) {
+                    budgetHit = true;
+                    break;
+                }
+                continue;
+            }
+            if (n == 0)
+                eof = true;
+            break;  // EOF, EAGAIN, or error — yield to the wait below
         }
-        if (r < 0) {
+        if (eof || budgetHit)
+            break;
+
+        pid_t r = waitpid(child, &childStatus, WNOHANG);
+        if (r == child) {
+            reaped = true;
+            // The child is gone but the pipe may still hold buffered output;
+            // one more drain pass runs on the next iteration before we exit on
+            // EOF. Do not break here.
+        } else if (r < 0) {
             // ECHILD (e.g. SIGCHLD set to SIG_IGN elsewhere in the process):
-            // we can no longer observe the child, so make sure it isn't still
-            // writing into this file while we finish the report.
-            kill(child, SIGKILL);
-            fprintf(f, "  (waitpid failed, errno=%d — log tail above may be incomplete)\n", errno);
-            return;
+            // we can no longer observe the child, so stop waiting on it.
+            reaped = true;
+            childStatus = 0;
         }
         struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
         nanosleep(&ts, nullptr);
     }
-    // Timed out. Kill and reap best-effort only — a blocking waitpid here could
-    // hang the whole crash handler on a child stuck in uninterruptible sleep,
-    // which on a distressed device is exactly when this code runs.
-    kill(child, SIGKILL);
-    struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
-    nanosleep(&ts, nullptr);
-    waitpid(child, nullptr, WNOHANG);
-    fprintf(f, "  (logcat killed after 3s — output above may be truncated or missing)\n");
+
+    close(fds[0]);
+    if (!reaped) {
+        // Either timed out or we stopped early at the budget. Kill, then reap
+        // best-effort only — a blocking waitpid could hang the whole crash
+        // handler on a child stuck in uninterruptible sleep, which on a
+        // distressed device is exactly when this code runs.
+        kill(child, SIGKILL);
+        struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
+        nanosleep(&ts, nullptr);
+        waitpid(child, &childStatus, WNOHANG);
+    }
+
+    if (written == 0) {
+        if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 127)
+            fprintf(f, "  (logcat exec failed — no capture)\n");
+        else if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == 126)
+            fprintf(f, "  (dup2 failed in capture child — no capture)\n");
+        else if (WIFSIGNALED(childStatus))
+            fprintf(f, "  (logcat died on signal %d)\n", WTERMSIG(childStatus));
+    } else if (budgetHit) {
+        fprintf(f, "\n  (capture stopped at %zu bytes — the server slices the "
+                   "report at 5000 chars on a duplicate issue, so anything past "
+                   "here would not have survived submission)\n", byteBudget);
+    } else {
+        fprintf(f, "  (end of capture)\n");
+    }
+    return written;
+}
+
+// ART's own account of why it aborted. Written BEFORE our backtrace, which is
+// deliberate and is the other half of the #1745 fix: when ART aborts, our
+// backtrace names the JNI call that happened to hit the ceiling (a battery poll
+// in #1408/#1572/#1745) and ART's dump names the actual leak, so on a budget
+// that cuts from the end, ART's dump is what has to go first. Returns false
+// when there were no fatal entries, which is the normal case for SIGSEGV and
+// friends — the caller then falls back to the unfiltered tail, after the
+// backtrace, where it costs the backtrace nothing.
+static bool appendArtAbortMessageToFile(FILE* f)
+{
+    fprintf(f, "\nART abort message (logcat, fatal priority only):\n");
+    if (captureLogcatToFile(f, /*fatalOnly=*/true, kFatalCaptureBudget) > 0)
+        return true;
+    fprintf(f, "  (no fatal-priority entries for this pid — not an ART abort, "
+               "or logd rotated them out)\n");
+    return false;
+}
+
+static void appendLogcatTailToFile(FILE* f)
+{
+    fprintf(f, "\nSystem log tail (logcat):\n");
+    if (captureLogcatToFile(f, /*fatalOnly=*/false, kFatalCaptureBudget) == 0)
+        fprintf(f, "  (logcat wrote nothing — entries for this pid may have "
+                   "rotated out of logd)\n");
 }
 #endif
 
@@ -280,6 +394,13 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
         fprintf(f, "\nLast debug message:\n  %s\n", s_lastDebugMessage);
     }
 
+#ifdef Q_OS_ANDROID
+    // Ahead of the backtrace: see appendArtAbortMessageToFile(). Only into
+    // crash.log (which becomes the report's "Crash Log" section) — not into the
+    // debug.log copy below, whose tail is submitted separately.
+    const bool artAborted = appendArtAbortMessageToFile(f);
+#endif
+
     // Write backtrace
 #if defined(Q_OS_ANDROID) || defined(Q_OS_LINUX) || defined(Q_OS_WIN) || defined(Q_OS_MACOS) || defined(Q_OS_IOS)
     writeBacktraceToFile(f);
@@ -288,9 +409,11 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
 #endif
 
 #ifdef Q_OS_ANDROID
-    // Only into crash.log (which becomes the report's "Crash Log" section) —
-    // not into the debug.log copy below, whose tail is submitted separately.
-    appendLogcatTailToFile(f);
+    // Only when ART did not explain itself. An ART abort has already spent the
+    // budget on the fatal block, and the unfiltered tail there is the thread
+    // dump that #1745 wasted its whole report on.
+    if (!artAborted)
+        appendLogcatTailToFile(f);
 #endif
 
     fprintf(f, "\n=== END CRASH REPORT ===\n");
@@ -483,11 +606,39 @@ QString CrashHandler::getDebugLogTail(int lines)
         return QString();
     }
 
-    // Read all lines and get the last N
+    // Read all lines, dropping any crash-report block.
+    //
+    // This tail is submitted as its own field (debugLogTail, sliced to 5000
+    // chars server-side) to answer a question the crash log cannot: what the
+    // app was doing before it died. Crash-report text in here answers nothing,
+    // because the same text is already being submitted as crashLog.
+    //
+    // Two writers put it there, and both land at the very end of debug.log —
+    // exactly where this tail reads:
+    //   - writeCrashLog() appends the whole report for persistence, at crash
+    //     time, so it is the last thing in the file;
+    //   - main.cpp re-logs the previous run's crash log at startup (a single
+    //     qWarning record, so only its first line carries a log prefix).
+    // In #1745 the result was a 5000-char debug tail containing one stale crash
+    // report and not a single line of app narrative.
+    static const QLatin1String kBlockStart("=== CRASH REPORT ===");
+    static const QLatin1String kBlockEnd("=== END CRASH REPORT ===");
+
     QStringList allLines;
+    bool insideCrashBlock = false;
     QTextStream stream(&file);
     while (!stream.atEnd()) {
-        allLines.append(stream.readLine());
+        const QString line = stream.readLine();
+        if (line.contains(kBlockEnd)) {
+            insideCrashBlock = false;
+            continue;
+        }
+        if (line.contains(kBlockStart)) {
+            insideCrashBlock = true;
+            continue;
+        }
+        if (!insideCrashBlock)
+            allLines.append(line);
     }
     file.close();
 

--- a/src/core/crashhandler.h
+++ b/src/core/crashhandler.h
@@ -14,6 +14,18 @@
 class CrashHandler
 {
 public:
+    /// The markers bracketing a crash report, wherever one is written.
+    ///
+    /// One definition because there are six producers (crash.log's own pair, the
+    /// debug.log copy's pair, and main.cpp's two standalone re-log markers) and
+    /// ONE consumer — getDebugLogTail(), which strips these blocks out of the
+    /// tail it submits. Hand-copied, a writer could be respelled alone and the
+    /// stripper would silently stop matching: the crash-report duplication of
+    /// #1745 returns in full and no test notices, because a fixture spells the
+    /// marker itself rather than asking a writer for it.
+    static constexpr const char* kReportStart = "=== CRASH REPORT ===";
+    static constexpr const char* kReportEnd   = "=== END CRASH REPORT ===";
+
     /// Install signal handlers. Call once at startup.
     static void install();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1128,9 +1128,16 @@ int main(int argc, char *argv[])
     if (CrashHandler::hasCrashLog()) {
         previousCrashLog = CrashHandler::readCrashLog();
         previousDebugLogTail = CrashHandler::getDebugLogTail(50);
+        // The trailing end marker is NOT redundant with the one inside
+        // previousCrashLog, and must not be tidied away. writeCrashLog() can die
+        // before it writes its own closer (it demangles from a signal handler on
+        // a possibly-corrupt heap), and this line is what closes the block for
+        // CrashHandler::getDebugLogTail(), which strips these blocks out of the
+        // tail it submits. Both markers come from CrashHandler so a respelling
+        // cannot desynchronise the writer from the stripper.
         qWarning() << "=== PREVIOUS CRASH DETECTED ===";
         qWarning().noquote() << previousCrashLog;
-        qWarning() << "=== END CRASH REPORT ===";
+        qWarning() << CrashHandler::kReportEnd;
     }
     checkpoint("Crash check done");
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1472,9 +1472,11 @@ target_link_libraries(tst_mcptools_presets PRIVATE decenza_a11ylib decenza_appse
 target_include_directories(tst_mcptools_presets PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_webdebuglogger: WebDebugLogger session-index cache (improve-mcp-debug-log-search),
-# plus CrashHandler::getDebugLogTail(), which reads the same debug.log and whose
-# result is the crash report's debugLogTail field. crashhandler.cpp is compiled
-# into this target alone — no other test needs it, so no intermediate library. ---
+# plus CrashHandler::getDebugLogTail(), which reads the debug.log WebDebugLogger
+# writes and whose result is the crash report's debugLogTail field. (Both resolve
+# DecenzaPaths::logsDirectory() as of #1746; before that CrashHandler used
+# AppDataLocation, a different file on Android.) crashhandler.cpp is compiled into
+# this target alone — no other test needs it, so no intermediate library. ---
 add_decenza_test(tst_webdebuglogger
     tst_webdebuglogger.cpp
     ${CMAKE_SOURCE_DIR}/src/core/crashhandler.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1471,9 +1471,13 @@ add_decenza_test(tst_mcptools_presets
 target_link_libraries(tst_mcptools_presets PRIVATE decenza_a11ylib decenza_appserviceslib decenza_profilelib decenza_shotlib Qt6::TextToSpeech Qt6::Multimedia paho-mqtt3a-static)
 target_include_directories(tst_mcptools_presets PRIVATE ${CMAKE_BINARY_DIR})
 
-# --- tst_webdebuglogger: WebDebugLogger session-index cache (improve-mcp-debug-log-search) ---
+# --- tst_webdebuglogger: WebDebugLogger session-index cache (improve-mcp-debug-log-search),
+# plus CrashHandler::getDebugLogTail(), which reads the same debug.log and whose
+# result is the crash report's debugLogTail field. crashhandler.cpp is compiled
+# into this target alone — no other test needs it, so no intermediate library. ---
 add_decenza_test(tst_webdebuglogger
     tst_webdebuglogger.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/crashhandler.cpp
 )
 target_link_libraries(tst_webdebuglogger PRIVATE decenza_webdebugloggerlib)
 

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -846,6 +846,11 @@ private slots:
         QCOMPARE(updated.at(3).at(1).toBool(), false);
         QCOMPARE(finished.count(), 1);
         QCOMPARE(restocked.count(), 1);
+
+        // The signal counts above are delivered from the task body, which runs
+        // before the worker's outstanding count drops — so the last update can
+        // still be in flight when this slot returns.
+        drainDbWork(storage);
     }
 
     void migration24AddsSyncPendingColumn() {
@@ -1924,6 +1929,14 @@ private slots:
         // And clearing the bag drops to the profile.
         dye.setActiveBagId(-1);
         QCOMPARE(dye.doseOwner(), SettingsDye::DoseOwner::Profile);
+
+        // setActiveBagId posts TWO tasks (settings_dye.cpp): requestBag, whose
+        // bagReady resolves the rung above, and requestTouchLastUsed, which
+        // nothing waits on. Draining on doseLadderResolved() therefore leaves
+        // the touch write queued, and ~SerialDbWorker discards and warns about
+        // it under failOnWarning — intermittently, since the write usually wins
+        // the race with the destructor.
+        drainDbWork(storage);
     }
 
     // Selecting a source is not the same as knowing what it designs: both rows
@@ -1984,6 +1997,9 @@ private slots:
         QVERIFY(dye.doseLadderResolved());
         dye.setActiveBagId(-1);
         QVERIFY(dye.doseLadderResolved());
+
+        // Same unwaited requestTouchLastUsed as settingsDyeDoseLadder.
+        drainDbWork(storage);
     }
 
     // setActiveBagKeepFields is the shot-replay path: it adopts the bag link
@@ -2013,6 +2029,10 @@ private slots:
         // the caller — but the rung knows the bag has one.
         QCOMPARE(dye.dyeBeanWeight(), 21.0);
         QCOMPARE(dye.doseOwner(), SettingsDye::DoseOwner::Bag);
+
+        // setActiveBagKeepFields posts the same requestBag + requestTouchLastUsed
+        // pair, and only the first is waited on above.
+        drainDbWork(storage);
     }
 
     // SettingsDye is the equipment switch + dual-write-through orchestrator
@@ -2045,9 +2065,14 @@ private slots:
 
         // Select the bag and let its async apply settle (applyActiveBag sets
         // activeEquipmentId from the bag's equipment_id, which would otherwise
-        // race the switch below).
+        // race the switch below). Wait on the WORK, not on a duration: idle is
+        // false until run()'s done callback has been delivered on this thread,
+        // which is what applyActiveBag runs from — and it also covers the
+        // requestTouchLastUsed that setActiveBagId posts behind requestBag. The
+        // 400 ms fixed loop this replaces was the "timers as guards" pattern
+        // CLAUDE.md forbids, and isDbWorkIdle() exists precisely to retire it.
         dye.setActiveBagId(static_cast<int>(bagId));
-        for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(10); }
+        drainDbWork(bagStorage);
 
         // Switch equipment: identity + last dial applied synchronously from the map.
         QVariantMap pkg;

--- a/tests/tst_webdebuglogger.cpp
+++ b/tests/tst_webdebuglogger.cpp
@@ -30,8 +30,32 @@ class tst_WebDebugLogger : public QObject {
         QTextStream(&f) << content;
     }
 
+    // Writes `content` where CrashHandler::getDebugLogTail() will look for it.
+    // Test mode (enabled for the whole run in initTestCase) redirects
+    // AppDataLocation — and hence DecenzaPaths::logsDirectory()'s desktop answer
+    // — under ~/.qttest, scoped by this binary's name, so neither a parallel
+    // ctest run nor the developer's real log is touched.
+    static void writeDebugLog(const QString& content)
+    {
+        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        QVERIFY2(QDir().mkpath(dir), "failed to create test app-data directory");
+        writeFile(dir + "/debug.log", content);
+    }
+
+    // Asked of CrashHandler rather than spelled out, so a respelt marker fails
+    // these tests instead of silently disabling the strip in production.
+    static QString startMarker() { return QString::fromLatin1(CrashHandler::kReportStart); }
+    static QString endMarker()   { return QString::fromLatin1(CrashHandler::kReportEnd); }
+
 private slots:
     void init() { QTest::failOnWarning(); }
+
+    // Enabled once for the whole run rather than per slot: a QVERIFY failure
+    // returns from the slot immediately, so a per-slot disable is skipped on
+    // exactly the run where it matters and leaks a process-global path
+    // redirection into whatever executes next.
+    void initTestCase() { QStandardPaths::setTestModeEnabled(true); }
+    void cleanupTestCase() { QStandardPaths::setTestModeEnabled(false); }
 
     void sessionIndex_findsBoundariesAndCounts()
     {
@@ -654,29 +678,30 @@ private slots:
         QVERIFY(all[1].contains(QStringLiteral("from the slot")));
     }
 
-    // CrashHandler::getDebugLogTail() reads the same debug.log this class writes,
-    // and its result is submitted as the crash report's separate debugLogTail
-    // field (sliced to 5000 chars by the server). Its whole job is to carry what
-    // the app was doing before it died — so crash-report text in it is 5000 chars
-    // of duplicate, since the same text ships as crashLog. Two writers append
-    // that text at the very end of debug.log, which is exactly where this tail
-    // reads: writeCrashLog() at crash time, and main.cpp re-logging the previous
-    // run's report at startup. In #1745 the whole tail was one stale report.
+    // ---- CrashHandler::getDebugLogTail() ----------------------------------
+    //
+    // Same debug.log this class writes: both resolve DecenzaPaths::logsDirectory()
+    // (they did NOT before #1746 — CrashHandler used AppDataLocation, which on
+    // Android is a different file whose only content was crash reports, which is
+    // why #1745's submitted tail had no app narrative in it at all).
+    //
+    // The tail's job is to say what the app was doing before it died. Crash-report
+    // text in it is pure duplicate — the same text ships as crashLog — so these
+    // blocks are stripped. Fixtures below use CrashHandler's own marker constants
+    // rather than spelling them, so a respelt marker fails here instead of
+    // silently disabling the strip in production.
+
     void debugLogTail_dropsTheCrashReportBlock()
     {
-        QStandardPaths::setTestModeEnabled(true);
-        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        QVERIFY(QDir().mkpath(dir));
-
-        writeFile(dir + "/debug.log",
+        writeDebugLog(
             "[   0.100] INFO  app line one\n"
             "[   0.200] INFO  app line two\n"
             "\n"
-            "=== CRASH REPORT ===\n"
+            + startMarker() + "\n"
             "Signal: 6 (SIGABRT (Abort))\n"
             "Backtrace (29 frames):\n"
             "  #0: 0x6f925a7490\n"
-            "=== END CRASH REPORT ===\n");
+            + endMarker() + "\n");
 
         const QString tail = CrashHandler::getDebugLogTail(50);
 
@@ -685,25 +710,22 @@ private slots:
         QVERIFY(!tail.contains(QStringLiteral("SIGABRT")));
         QVERIFY(!tail.contains(QStringLiteral("Backtrace")));
         QVERIFY(!tail.contains(QStringLiteral("CRASH REPORT")));
-
-        QStandardPaths::setTestModeEnabled(false);
     }
 
-    // The startup writer emits the whole previous report as ONE qWarning record,
-    // so the logger's "[   N.NNN] WARN " prefix lands on the block's first line
-    // only. Matching the marker anywhere in the line, rather than at its start,
-    // is what makes that block strippable too.
+    // The startup re-log's real on-disk shape, which is NOT one record: main.cpp
+    // emits "=== PREVIOUS CRASH DETECTED ===", then the report body as one
+    // noquote record, then a standalone end marker. So the body's interior lines
+    // carry no log prefix while the markers around it do, and the body brings its
+    // own unprefixed end marker along. Matching anywhere in the line, rather than
+    // at its start, is what makes that strippable.
     void debugLogTail_dropsAPrefixedCrashReportBlock()
     {
-        QStandardPaths::setTestModeEnabled(true);
-        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        QVERIFY(QDir().mkpath(dir));
-
-        writeFile(dir + "/debug.log",
+        writeDebugLog(
             "[   0.100] INFO  app line one\n"
-            "[   0.200] WARN  === CRASH REPORT ===\n"
+            "[   0.200] WARN  " + startMarker() + "\n"
             "Signal: 11 (SIGSEGV (Segmentation fault))\n"
-            "[   0.300] WARN  === END CRASH REPORT ===\n"
+            + endMarker() + "\n"                                  // body's own, unprefixed
+            "[   0.300] WARN  " + endMarker() + "\n"              // main.cpp's standalone
             "[   0.400] INFO  app line after\n");
 
         const QString tail = CrashHandler::getDebugLogTail(50);
@@ -712,8 +734,75 @@ private slots:
         QVERIFY(tail.contains(QStringLiteral("app line after")));
         QVERIFY(!tail.contains(QStringLiteral("SIGSEGV")));
         QVERIFY(!tail.contains(QStringLiteral("CRASH REPORT")));
+    }
 
-        QStandardPaths::setTestModeEnabled(false);
+    // A block that never closes must not swallow the file. writeCrashLog()'s
+    // debug.log append can die mid-block — it demangles from a signal handler on
+    // the heap that may have caused the crash — and debug.log is append-mode, so
+    // latching to EOF would blank the tail for that run AND every later one. The
+    // empty QString that produced is also what "could not open the file" returns,
+    // so the failure would be unattributable at the far end.
+    void debugLogTail_survivesAnUnterminatedBlock()
+    {
+        writeDebugLog(
+            "[   0.100] INFO  app line one\n"
+            + startMarker() + "\n"
+            "Signal: 6 (SIGABRT (Abort))\n"
+            "  #0: 0x6f925a7490\n");   // died here — no end marker
+
+        const QString tail = CrashHandler::getDebugLogTail(50);
+
+        QVERIFY(!tail.isEmpty());
+        QVERIFY(tail.contains(QStringLiteral("app line one")));
+    }
+
+    // WebDebugLogger::trimLogFile() keeps the TAIL of the file, so a trim can cut
+    // a block's opening line away and leave its body and closer behind. Read
+    // naively, that orphan body is exactly the report text this function exists
+    // to remove — reappearing in the one situation that produces it, a debug.log
+    // big enough to have been trimmed.
+    //
+    // Told apart from main.cpp's standalone closer by position, not by shape:
+    // a trim cuts the head, so a headless body can only precede the first start
+    // marker. The slot above covers the other side of that rule — get it wrong
+    // and the redundant closer wipes the narrative before it.
+    void debugLogTail_dropsABlockWhoseStartWasTrimmedAway()
+    {
+        writeDebugLog(
+            "Backtrace (29 frames):\n"          // orphaned body, start marker trimmed off
+            "  #0: 0x6f925a7490\n"
+            "Signal: 6 (SIGABRT (Abort))\n"
+            + endMarker() + "\n"
+            "[   0.400] INFO  app line after\n");
+
+        const QString tail = CrashHandler::getDebugLogTail(50);
+
+        QVERIFY(tail.contains(QStringLiteral("app line after")));
+        QVERIFY(!tail.contains(QStringLiteral("SIGABRT")));
+        QVERIFY(!tail.contains(QStringLiteral("Backtrace")));
+    }
+
+    // The strip must run BEFORE the last-N slice, not after. Stripping after
+    // would spend the caller's line budget on crash text and hand back a nearly
+    // empty tail — which is #1745's symptom precisely, and which the small
+    // fixtures above cannot see because they never reach the budget at all.
+    void debugLogTail_spendsItsLineBudgetOnNarrativeNotCrashText()
+    {
+        QString content;
+        for (int i = 0; i < 60; ++i)
+            content += QStringLiteral("[   0.%1] INFO  narrative line %2\n")
+                           .arg(i, 3, 10, QLatin1Char('0')).arg(i);
+        content += startMarker() + "\n";
+        for (int i = 0; i < 40; ++i)
+            content += QStringLiteral("  #%1: 0x6f925a7490\n").arg(i);
+        content += endMarker() + "\n";
+        writeDebugLog(content);
+
+        const QStringList tail = CrashHandler::getDebugLogTail(50).split('\n');
+
+        QCOMPARE(tail.size(), 50);
+        QCOMPARE(tail.first(), QStringLiteral("[   0.010] INFO  narrative line 10"));
+        QCOMPARE(tail.last(), QStringLiteral("[   0.059] INFO  narrative line 59"));
     }
 };
 

--- a/tests/tst_webdebuglogger.cpp
+++ b/tests/tst_webdebuglogger.cpp
@@ -1,11 +1,14 @@
 #include <QtTest>
 #include <QDateTime>
+#include <QDir>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QFile>
 #include <QRegularExpression>
 #include <QSet>
 #include <QTextStream>
 
+#include "core/crashhandler.h"
 #include "mcp/mcplogfilter.h"
 #include "network/webdebuglogger.h"
 
@@ -649,6 +652,68 @@ private slots:
         QCOMPARE(all.size(), 2);
         QVERIFY(all[0].contains(QStringLiteral("first")));
         QVERIFY(all[1].contains(QStringLiteral("from the slot")));
+    }
+
+    // CrashHandler::getDebugLogTail() reads the same debug.log this class writes,
+    // and its result is submitted as the crash report's separate debugLogTail
+    // field (sliced to 5000 chars by the server). Its whole job is to carry what
+    // the app was doing before it died — so crash-report text in it is 5000 chars
+    // of duplicate, since the same text ships as crashLog. Two writers append
+    // that text at the very end of debug.log, which is exactly where this tail
+    // reads: writeCrashLog() at crash time, and main.cpp re-logging the previous
+    // run's report at startup. In #1745 the whole tail was one stale report.
+    void debugLogTail_dropsTheCrashReportBlock()
+    {
+        QStandardPaths::setTestModeEnabled(true);
+        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        QVERIFY(QDir().mkpath(dir));
+
+        writeFile(dir + "/debug.log",
+            "[   0.100] INFO  app line one\n"
+            "[   0.200] INFO  app line two\n"
+            "\n"
+            "=== CRASH REPORT ===\n"
+            "Signal: 6 (SIGABRT (Abort))\n"
+            "Backtrace (29 frames):\n"
+            "  #0: 0x6f925a7490\n"
+            "=== END CRASH REPORT ===\n");
+
+        const QString tail = CrashHandler::getDebugLogTail(50);
+
+        QVERIFY(tail.contains(QStringLiteral("app line one")));
+        QVERIFY(tail.contains(QStringLiteral("app line two")));
+        QVERIFY(!tail.contains(QStringLiteral("SIGABRT")));
+        QVERIFY(!tail.contains(QStringLiteral("Backtrace")));
+        QVERIFY(!tail.contains(QStringLiteral("CRASH REPORT")));
+
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+    // The startup writer emits the whole previous report as ONE qWarning record,
+    // so the logger's "[   N.NNN] WARN " prefix lands on the block's first line
+    // only. Matching the marker anywhere in the line, rather than at its start,
+    // is what makes that block strippable too.
+    void debugLogTail_dropsAPrefixedCrashReportBlock()
+    {
+        QStandardPaths::setTestModeEnabled(true);
+        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        QVERIFY(QDir().mkpath(dir));
+
+        writeFile(dir + "/debug.log",
+            "[   0.100] INFO  app line one\n"
+            "[   0.200] WARN  === CRASH REPORT ===\n"
+            "Signal: 11 (SIGSEGV (Segmentation fault))\n"
+            "[   0.300] WARN  === END CRASH REPORT ===\n"
+            "[   0.400] INFO  app line after\n");
+
+        const QString tail = CrashHandler::getDebugLogTail(50);
+
+        QVERIFY(tail.contains(QStringLiteral("app line one")));
+        QVERIFY(tail.contains(QStringLiteral("app line after")));
+        QVERIFY(!tail.contains(QStringLiteral("SIGSEGV")));
+        QVERIFY(!tail.contains(QStringLiteral("CRASH REPORT")));
+
+        QStandardPaths::setTestModeEnabled(false);
     }
 };
 


### PR DESCRIPTION
## What

Android crash reports have carried a logcat tail since #1409, added so that a JNI global-reference-table overflow would finally arrive with ART's own dump naming the leaking class. #1745 is the first report from a build that has the instrumentation — and it captured 41 lines of *other threads' stacks* and nothing else.

The capture was `logcat -d -t 200`, a blind unfiltered tail. ART's abort block is ordered:

```
JNI ERROR (app bug): global reference table overflow (max=51200)
global reference table dump:  ... Summary: <the class we need>
Runtime aborting...
<per-thread stack dump, ~1000 lines>
```

A 200-line tail lands inside the thread dump every time. The diagnosis was always ~1000 lines above the window.

## The budget is the design

The report is not read on the device — it is POSTed to `api.decenza.coffee`, and `Kulitorum/decenza-shotmap`'s `backend/lambdas/crashReport.ts` slices it:

| path | budget | cut from |
|---|---|---|
| new issue body | `crashLog.slice(0, 10000)` | end |
| comment on existing issue | `crashLog.slice(0, 5000)` | end |
| debug log tail | `debugLogTail.slice(0, 5000)` | end |

A recurring crash dedupes onto its existing issue, so **5000 chars is the real budget**, not 10000. In #1745 the header and 29-frame backtrace had already spent ~4100 of it. Those limits are now recorded at the call site so the next change here is measured against them.

## Changes

**Capture** (`src/core/crashhandler.cpp`)
- Filter to fatal priority (`*:F`) — in normal operation that is ART's abort block and nothing else.
- Take the **head** of it, through a `pipe()`, capped at 4000 bytes. `logcat -t N` is tail-semantics, so the cap has to be applied here or the same bug returns at a larger size.
- `-v raw` drops the ~60-char `date pid tid F tag:` prefix that was costing half of every captured line (5905 chars bought only 41 lines in #1745).
- Written **before** the backtrace: on an ART abort our backtrace names the JNI call that happened to hit the ceiling — a battery poll in #1408, #1572 and #1745 — while ART's dump names the actual leak. On a budget that cuts from the end, ART's dump goes first.
- The unfiltered `-t 200` tail survives as a fallback for crashes ART did not explain (SIGSEGV and friends), after the backtrace, where it costs the backtrace nothing.

**Debug tail** (`CrashHandler::getDebugLogTail()`)

The report's other field had the same disease. It exists to say what the app was doing before it died; in #1745 all 5000 chars were one stale crash report — text already submitted as `crashLog`. Two writers append that block at the very end of `debug.log`, exactly where this tail reads: `writeCrashLog()` at crash time, and `main.cpp` re-logging the previous run's report at startup. Both are now skipped. The marker is matched anywhere in a line, not at line start, because the startup writer emits the whole report as a single `qWarning` record so only its first line carries a log prefix.

## Tests

Two slots in `tst_webdebuglogger` (which already owns `debug.log`'s on-disk behaviour) covering both block shapes — raw, and prefixed by the logger. `crashhandler.cpp` is compiled into that one target; no intermediate library, and `check_test_source_duplication.py` stays at zero.

The capture itself is Android-only code inside a signal handler and is not reachable from a test.

## Verification

- Full suite via Qt Creator: **110 passed, 0 failed, 0 warnings.**
- The first run failed `tst_CoffeeBags::settingsDyeDoseLadder` — the long-standing intermittent — and the second commit here fixes it rather than re-rolling. `SettingsDye::setActiveBagId` posts two tasks (`requestBag`, then `requestTouchLastUsed`); the test gated on `doseLadderResolved()`, which only the first satisfies, so the touch write was still queued when `storage` went out of scope and `~SerialDbWorker` discarded it. `drainDbWork()` (`QTRY_VERIFY(isDbWorkIdle())`) already existed in that file for exactly this; three sibling slots had the same gap and are drained too. Not a production defect — `MainController` drains those workers on `aboutToQuit` (`maincontroller.cpp:2484`). The same commit converts a 400 ms `processEvents()/msleep()` wait to the event-based one.
- `check_log_markers.py` and `check_test_source_duplication.py` both clean.

Does not fix the leak — it makes the next report able to name it. #1745 stays open until a report from a build carrying this change arrives with the ref-table Summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (4 agents) — what it changed

The first pass shipped two real defects that the review caught and this branch now fixes.

**1. The debug-tail half was fixing the wrong file.** `WebDebugLogger` writes app narrative to `DecenzaPaths::logsDirectory()/debug.log` — external storage on Android. `CrashHandler` wrote and read `AppDataLocation/debug.log`, a **different file there**, whose only writer was `writeCrashLog()`. That file's entire content was crash reports, which is the actual reason #1745's tail had no narrative in it — not a missing filter, the wrong path. Stripping blocks from it would have shipped an *empty* tail. Both sites now resolve `logsDirectory()`.

**2. The capture traded an exhaustive account of what happened for an assumption.** `origin/main` compared `lseek()` offsets and had a marker for every outcome; the rewrite had a bare byte count. A 3s timeout reported `(end of capture)`; several zero-byte outcomes wrote nothing and the caller printed "not an ART abort" over them; `read()` errors were folded in with EAGAIN (3s spin in the signal handler, then "success"); ECHILD skipped the `SIGKILL`; `fcntl`/`fwrite` unchecked. Now a `CaptureOutcome` enum with one marker per outcome.

Also fixed from the review: the reap moved above the exit test (every successful capture was SIGKILLing an already-dead child and sleeping 50 ms); logcat's stderr moved off the content pipe (it could mark a failed capture as an ART abort and suppress the fallback); `Last debug message` capped at 512 chars (a `char[4096]` printed *before* the ART capture); `-t` dropped from the fatal pass; the markers centralised as `CrashHandler::kReportStart/kReportEnd` across six writers and one reader.

Comment corrections, verified against the sources rather than from memory: the server dedupes only onto **open** issues, so #1745 took the 10000-char path (#1408/#1572 were closed) and a *comment* carries no `debugLogTail` field at all; the prefix is 49 chars / 34% of the capture, not ~60 / half; the report **is** rendered on device; `main.cpp` emits three `qWarning` records. The ART ref-table ordering is now marked **inferred** — #1745 establishes only that the abort is raised from inside the log record (frames #5-#6).

Three new test slots for shapes the first pair could not see: an unterminated block, a block whose opener a log trim cut away, and a 60-line fixture that would catch a strip-after-slice reorder. The trim case and `main.cpp`'s deliberate redundant end marker are told apart by position — and getting that wrong is exactly what the test run caught before merge.
