### PR TITLE
Pin libtailscale decenza-v1.94.1-5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,21 @@ Read [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs
 
 The `cmake`/`ctest` invocations in `docs/CLAUDE_MD/TESTING.md` and `docs/CLAUDE_MD/PLATFORM_BUILD.md` are **reference for humans and CI**, not instructions for an assistant. Run their equivalent through the MCP.
 
-**No CI job builds or tests a pull request — run the full suite locally before opening one.** That is the gate, via `mcp__qtcreator__run_tests` (scope `all`). Nothing on GitHub will catch a compile error or a failing test before merge.
+**No CI job builds or tests a pull request *automatically* — run the full suite locally before opening one.** That is the default gate, via `mcp__qtcreator__run_tests` (scope `all`). Nothing on GitHub fires on its own to catch a compile error or a failing test before merge.
+
+**But CI can be pointed at a branch on demand, and for the test suite that is `linux-release.yml`.** It configures `-DBUILD_TESTS=ON` and runs `ctest --output-on-failure --repeat until-pass:3`, then reports any test that only passed on retry. It is `workflow_dispatch`, so it runs only when dispatched:
+
+```bash
+gh workflow run linux-release.yml --ref <branch> -f upload_to_release=false
+```
+
+Read "no PR CI" as "nothing runs unless you ask", not "there is no way to get CI to build and test this branch" — the second reading is wrong, and it is how this file was previously read into telling a contributor the suite could only be run locally. The other release workflows dispatch the same way and are the right call for platform-specific changes; `linux-release.yml` is the one that runs tests. Note what a Linux run does **not** cover: `ENABLE_TSNET` is OFF there, so anything reached only through `cmake/tsnet.cmake` is not exercised, and platform-guarded code is compiled only by that platform's own workflow.
 
 That is narrower than "there is no PR CI", which this file used to say and which is wrong: `text-invariants.yml` **does** run on `pull_request`, filtered to the surfaces in its own `paths:` list — **`src/**` among them**. (Not enumerated here: the two copies of that list in this repo's docs were each already one entry short.)
 
 **`src/**` is in that list, so a pure C++ change is gated too**, and this file used to omit it. That omission is what let a merge land red: `check_log_markers.py` rejected a new `[Equipment]` line in `maincontroller.cpp`, the PR was merged without its own run being read, and `main` went red. Nothing blocks that — it is not a required status check, by design, because requiring it would put a check on the critical path of every push. **Read the run before you merge; the gate cannot do it for you.** It is build-free by design — pure Python over the source, no Qt, no compile, seconds (the workflow header carries the measured figure) — which is exactly why it can afford to run per-PR while nothing else does. Read it as the shape a new PR-time check has to fit: if a check needs the app built, it does not belong there.
 
-Everything else is post-merge or on demand. `nightly-sanitizers.yml` re-runs the suite on `main` each night under UBSan and ASan. Platform-guarded code (`#ifdef Q_OS_IOS` etc.) is compiled only by the tag-push release workflows, so verify platform-specific changes with a CI test build of that platform (see `docs/CLAUDE_MD/CI_CD.md`).
+Everything else is post-merge or on demand — "on demand" meaning the `workflow_dispatch` release workflows above, which is a real option and not a euphemism for "never". `nightly-sanitizers.yml` re-runs the suite on `main` each night under UBSan and ASan. Platform-guarded code (`#ifdef Q_OS_IOS` etc.) is compiled only by the tag-push release workflows, so verify platform-specific changes with a CI test build of that platform (see `docs/CLAUDE_MD/CI_CD.md`).
 
 **Debug builds are sanitizer-instrumented automatically** — ASan *and* UBSan on every desktop platform including macOS, so a normal local test run already reports undefined behaviour and memory errors. UBSan is in recovering mode there (it reports and continues); an explicit `-DENABLE_UBSAN=ON` gives the halting mode CI uses. Release builds are untouched.
 

--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -10,20 +10,20 @@
 # The pinned release + per-artifact SHA-256 come from the release manifest.json.
 # Bump TSNET_TAG (and the hashes) to adopt a newer libtailscale build.
 
-set(TSNET_TAG "decenza-v1.94.1-4" CACHE STRING "libtailscale prebuilt release tag")
+set(TSNET_TAG "decenza-v1.94.1-5" CACHE STRING "libtailscale prebuilt release tag")
 set(TSNET_BASE_URL "https://github.com/skialpine/libtailscale/releases/download/${TSNET_TAG}")
 set(TSNET_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/tsnet-${TSNET_TAG}")
 
 # Per-platform artifact + expected SHA-256 (from manifest.json).
 if(IOS)
     set(_tsnet_zip "libtailscale-ios.zip")
-    set(_tsnet_sha "f1c5477695563c9ef75b5e65ab14ed69675515861dc6766454bf6f0b4dde505b")
+    set(_tsnet_sha "706cbbd25d60dce49f5935018931a500e48cd4d498847294eeafdc6efbb0b739")
 elseif(ANDROID)
     set(_tsnet_zip "libtailscale-android.zip")
-    set(_tsnet_sha "d345a7ef03854b9d5e1d6753c3dc463f27577e516492a3a144f406f217813bb1")
+    set(_tsnet_sha "80331572de0565b0be2465b67d8839efb564008281776393430b19d85cbdb3e0")
 elseif(APPLE)
     set(_tsnet_zip "libtailscale-macos.zip")
-    set(_tsnet_sha "642ed347483aded62b759419ff1740ec50d9d6c110fbebf51637caa41a146864")
+    set(_tsnet_sha "9e6b42c895a7cd660c1233aead0c693417033a431b93450b79af9c0aeafc3582")
 else()
     message(FATAL_ERROR "ENABLE_TSNET: no prebuilt libtailscale artifact for this platform yet "
                         "(supported: macOS, Android, iOS). Use Mode C (BYO URL) instead.")

--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -8,9 +8,39 @@
 #   decenza_link_tsnet(<tgt>) links the prebuilt library + platform frameworks
 #
 # The pinned release + per-artifact SHA-256 come from the release manifest.json.
-# Bump TSNET_TAG (and the hashes) to adopt a newer libtailscale build.
+# To adopt a newer libtailscale build, bump _TSNET_EXPECTED_TAG *and* the three
+# hashes below, together — they are one unit. See the guard directly under them.
 
-set(TSNET_TAG "decenza-v1.94.1-5" CACHE STRING "libtailscale prebuilt release tag")
+# The tag this source tree expects. Not a cache variable: it is the pin, and a
+# stale build directory must not be able to silently disagree with it.
+set(_TSNET_EXPECTED_TAG "decenza-v1.94.1-5")
+
+set(TSNET_TAG "${_TSNET_EXPECTED_TAG}" CACHE STRING "libtailscale prebuilt release tag")
+
+# Guard: a cached TSNET_TAG wins over the default above, so bumping the pin does
+# NOTHING to an existing build directory — it keeps downloading and linking the
+# OLD library while the source says otherwise. That is a silent wrong-artifact
+# build, and it survived four tag bumps unnoticed: verifying decenza-v1.94.1-5
+# locally initially "passed" against the -4 archive still named in the cache.
+#
+# It cannot be fixed by just re-reading the file, because the SHA-256s below are
+# plain variables while the tag is cached — so a mismatched pair doesn't even
+# fail honestly: an intentional `-DTSNET_TAG=<other>` against this tree's hashes
+# dies as `download ... failed`, which reads like a network problem.
+#
+# So refuse, and say exactly what to run. CI is unaffected (it configures fresh
+# build dirs; no workflow caches CMakeCache.txt) — this only ever fires locally.
+if(NOT TSNET_TAG STREQUAL _TSNET_EXPECTED_TAG)
+    message(FATAL_ERROR
+        "tsnet: this source tree pins ${_TSNET_EXPECTED_TAG}, but this build "
+        "directory has TSNET_TAG=${TSNET_TAG} cached.\n"
+        "The hashes in cmake/tsnet.cmake belong to ${_TSNET_EXPECTED_TAG}, so "
+        "building against ${TSNET_TAG} would link the wrong libtailscale.\n"
+        "Fix the build directory:\n"
+        "    cmake -DTSNET_TAG=${_TSNET_EXPECTED_TAG} ${CMAKE_BINARY_DIR}\n"
+        "To deliberately test a different release, change _TSNET_EXPECTED_TAG "
+        "and its three SHA-256s in cmake/tsnet.cmake instead — they are one unit.")
+endif()
 set(TSNET_BASE_URL "https://github.com/skialpine/libtailscale/releases/download/${TSNET_TAG}")
 set(TSNET_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/tsnet-${TSNET_TAG}")
 


### PR DESCRIPTION
Bumps `TSNET_TAG` and the three per-platform SHA-256 hashes in [cmake/tsnet.cmake](cmake/tsnet.cmake) to pick up [skialpine/libtailscale#2](https://github.com/skialpine/libtailscale/pull/2).

## macOS only — the fork crash

tsnet forked `lsof -n -a -u<uid> -c IPNExtension -F` on **every LocalAPI request**. `TsnetGetAuthURL`/`TsnetGetBackendState` are polled during connect, so it fired repeatedly.

It never did anything for us. That lookup finds the Mac App Store Tailscale GUI's random LocalAPI port and token; tsnet serves its own LocalAPI over an in-process `memnet` listener with no `RequiredPassword`, so the token is never checked, and with no GUI installed `lsof` matches nothing anyway.

And `fork()` in our ASan-instrumented debug builds crashed the child pre-exec:

```
EXC_BREAKPOINT (SIGKILL)
BUG IN CLIENT OF LIBPLATFORM: os_unfair_lock is corrupt, or owner thread exited without unlocking
crashed on child side of fork pre-exec
```

Same failure mode as the `dscl` exec that `ts_omit_ssh` fixed.

Verified by measurement, not by reading: a recording `lsof` shim first on `PATH`, over a full `tailscale_up()` cycle against the in-process test control server — **6 forks before, 0 after**. That measurement is also what caught a first attempt at the fix that removed exactly zero forks.

`safesocket_darwin.go` is the only file that installs this lookup, so iOS (`GOOS=ios`) and Android never had it.

## All platforms — Funnel errors stop being silent

`TsnetEnableFunnelToLocalhostPlaintextHttp1` discarded `SetServeConfig`'s error and instead checked `sc.AllowFunnel[hp]` — its own map literal, set to `true` a few lines earlier and never mutated by `SetServeConfig`. The branch was dead and the function returned success unconditionally, so a Funnel refused by tailnet policy looked like a working one.

[`McpTunnelTsnet`](src/mcp/mcptunnel_tsnet.cpp#L185) already handles non-zero correctly — warns and retries on the next poll — so the visible effect is an `enable funnel failed:` line that was previously invisible. No regression risk on Android/iOS.

## Hashes

Taken from the release `manifest.json` and independently verified against the downloaded artifacts:

| artifact | sha256 |
|---|---|
| macos | `9e6b42c8…afc3582` |
| ios | `706cbbd2…bb0b739` |
| android | `80331572…5cbdb3e0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)