### PR TITLE
Collect stable-key caches on superseded tags too

### DIFF
--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -134,17 +134,31 @@ jobs:
       # would make the next re-tag rebuild from scratch. Ordering is by build
       # time for the same reason — see the note on NEWEST below.
       #
-      # Scoped tightly, since the surrounding steps are conservative about tags
-      # for good reason: only timestamped ccache/sccache keys, only on tag refs,
-      # only for tags that sort older than the newest one present. Stable-key
-      # entries (qt-*, openssl-*, gradle-*) are never touched.
-      - name: Drop compiler caches for superseded release tags
+      # Scoped to tag refs, and to tags older than the newest one present.
+      #
+      # This used to also require a timestamped ccache/sccache key, which left
+      # the STABLE-key entries on a shipped tag — qt-*, gradle-*, openssl-* —
+      # uncollectable by anything. They are scoped to that tag's ref like every
+      # other entry, so no future tag can read them either; the timestamp filter
+      # was about identifying compiler caches, and got read as a safety
+      # boundary. Measured on v2.0.1: 2.4 GB across six stable-key entries
+      # (qt-macos 629 MB, qt-windows 498, qt-android 475, qt-linux-arm64 397,
+      # gradle 373, openssl 24) that no step in this file would ever have
+      # touched. Nor would the deleted-branch step below — it deletes on a
+      # liveness signal, and a tag is always live.
+      #
+      # So the filter is now "tag-scoped and superseded", whatever the key
+      # shape. The newest tag is still fully protected, stable keys included:
+      # those are what make a re-tag's Qt install fast.
+      - name: Drop caches for superseded release tags
         if: ${{ steps.gate.outputs.skip == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
-          TS='-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$'
+          # No TS regex here any more: this step no longer distinguishes
+          # compiler caches from stable-key ones. The other steps still need
+          # theirs and define it locally.
 
           # Tag-scoped entries surface as refs/heads/refs/tags/X (the odd shape
           # the deleted-branch step below skips) as well as plain refs/tags/X.
@@ -162,9 +176,8 @@ jobs:
           if [ "$(printf '%s' "$RAW" | jq length)" -ge 500 ]; then
             echo "::warning::Cache listing hit the 500-entry limit; this prune may be partial."
           fi
-          if ! CACHES=$(printf '%s' "$RAW" | jq -r --arg ts "$TS" '
+          if ! CACHES=$(printf '%s' "$RAW" | jq -r '
                        .[]
-                       | select(.key | test($ts))
                        | select(.ref | test("^(refs/heads/)?refs/tags/"))
                        | "\(.id)\t\(.ref | sub("^(refs/heads/)?refs/tags/"; ""))\t\(.sizeInBytes)\t\(.key)"
                      '); then
@@ -193,13 +206,26 @@ jobs:
           # Self-contained on purpose: a tag whose build is still running cannot
           # appear here anyway, because the gate step skips the whole workflow
           # while any build is active.
-          NEWEST=$(printf '%s' "$RAW" | jq -r --arg ts "$TS" '
-                     [ .[]
-                       | select(.key | test($ts))
-                       | select(.ref | test("^(refs/heads/)?refs/tags/")) ]
+          # Computed over the SAME set the deletion loop walks. It must not be
+          # narrowed to timestamped keys while CACHES is not: on any prune where
+          # the tag entries are all stable-key — after this step has already
+          # collected the compiler caches, or on a repo whose current release
+          # has only restored (not re-saved) its Qt entry — max_by would return
+          # null, NEWEST would be the string "null", every real tag would
+          # compare unequal to it, and the loop would delete the live release's
+          # entries. Same set for both, or the protection silently inverts.
+          NEWEST=$(printf '%s' "$RAW" | jq -r '
+                     [ .[] | select(.ref | test("^(refs/heads/)?refs/tags/")) ]
                      | max_by(.createdAt)
                      | .ref | sub("^(refs/heads/)?refs/tags/"; "")
                    ')
+          # CACHES is non-empty here (checked above), so NEWEST must name a tag.
+          # If it doesn't, the jq changed shape underneath us — refuse rather
+          # than treat every entry as superseded.
+          if [ -z "$NEWEST" ] || [ "$NEWEST" = "null" ]; then
+            echo "::error::Could not determine the newest tag from $(printf '%s\n' "$CACHES" | grep -c .) tag-scoped entr(y|ies) — refusing to prune."
+            exit 1
+          fi
           CANDIDATES=$(printf '%s\n' "$CACHES" | awk -F'\t' -v n="$NEWEST" '$2 != n' | grep -c . || true)
           echo "Newest tag with caches: $NEWEST (keeping its entries); $CANDIDATES entr(y|ies) on older tags."
 


### PR DESCRIPTION
The "superseded release tags" step in [prune-caches.yml](.github/workflows/prune-caches.yml) filtered on a timestamped ccache/sccache key, so **stable-key entries on a shipped tag were collectable by nothing**: `qt-*`, `gradle-*`, `openssl-*`.

They're ref-scoped like every other entry, so no future tag can restore them. The timestamp filter existed to identify compiler caches and had been read as a safety boundary. The deleted-branch step doesn't reach them either — it deletes on a liveness signal, and a tag is always live.

Measured on v2.0.1: **2.4 GB across six entries** stranded per release, against a 10 GB cap.

| entry | size |
|---|---|
| `qt-macos-v2…` | 629 MB |
| `qt-windows-v3…` | 498 MB |
| `qt-android-v1…` | 475 MB |
| `qt-linux-arm64-v1…` | 397 MB |
| `gradle-android…` | 373 MB |
| `openssl-3.6.3-universal-macos` | 24 MB |

The filter is now "tag-scoped and superseded", whatever the key shape. The newest tag stays fully protected, stable keys included — those are what keep a re-tag's Qt install fast, which is the same reasoning that got tag-wide save-suppression reverted in `setup-compiler-cache/action.yml`.

## The part that isn't tidiness

`NEWEST` moves to the **same** widened set as the deletion list. Widening one without the other inverts the protection:

once a pass has collected a superseded tag's compiler caches, a later run can see only stable-key tag entries → `max_by` returns null → `NEWEST` becomes the string `"null"` → every real tag compares unequal → the loop deletes the **live release's** caches.

Reproduced against a fixture before fixing. The naive version:

```
### NEWEST the WRONG way (timestamped-only) ###
NEWEST=''
  WOULD DELETE qt-macos-v2      v2.0.1 (LIVE RELEASE)
  WOULD DELETE gradle-android   v2.0.1 (LIVE RELEASE)

### NEWEST the right way (same set) + guard ###
NEWEST='v2.0.1'
  nothing deleted — live release protected
```

A guard now refuses when `NEWEST` doesn't name a tag, rather than treating everything as superseded.

## Verification

Fixture with v2.0.0 + v2.0.1 + main:

- **deleted:** v2.0.0's `ccache-macos` (1870 MB), `qt-macos` (629 MB), `openssl` (24 MB) — the two stable keys are the new behaviour
- **kept:** all three v2.0.1 entries including stable keys
- **never selected:** both `main` entries

YAML parses; all five `run:` blocks pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)