### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 2.0.1 LANGUAGES CXX)
+project(Decenza VERSION 2.0.2 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
Version bump for the 2.0.2 pre-release. `versioncode.txt` is CI-managed and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)