### PR TITLE
Delete the unused captureHasContent(), which broke the Android build

### DIFF
--- a/src/core/crashhandler.cpp
+++ b/src/core/crashhandler.cpp
@@ -192,11 +192,6 @@ enum class CaptureOutcome {
     Unknown,      // nothing matched — print the raw status rather than guess
 };
 
-// True when the outcome means the section holds real captured content.
-static bool captureHasContent(CaptureOutcome o)
-{
-    return o == CaptureOutcome::Content || o == CaptureOutcome::BudgetHit;
-}
 
 // Read the child's output through a pipe and write at most byteBudget of it to
 // f. Head-anchored on purpose: `logcat -t N` gives the LAST N lines, which is
@@ -218,11 +213,13 @@ static CaptureOutcome captureLogcatToFile(FILE* f, bool fatalOnly,
     if (child == 0) {
         close(fds[0]);
         // stdout ONLY. logcat's own stderr must NOT reach the content pipe:
-        // captureHasContent() gates whether the unfiltered fallback runs, so a
-        // device that rejects these arguments would have logcat's complaint
-        // counted as an ART abort and the fallback skipped — the one path that
-        // rescues a non-ART crash, disabled by the failure of the path it
-        // rescues. The exit status is what attributes such a failure instead.
+        // the unfiltered fallback runs only on CaptureOutcome::NoEntries, and
+        // that outcome requires the stream to have produced nothing. A device
+        // that rejects these arguments would put logcat's complaint in the
+        // pipe, which counts as captured bytes, yields Content instead of
+        // NoEntries, and skips the fallback — the one path that rescues a
+        // non-ART crash, disabled by the failure of the path it rescues. The
+        // exit status is what attributes such a failure instead.
         if (dup2(fds[1], STDOUT_FILENO) < 0)
             _exit(126);
         const int devNull = open("/dev/null", O_WRONLY);


### PR DESCRIPTION
The v2.0.2 Android release build failed:

```
crashhandler.cpp:196:13: error: unused function 'captureHasContent' [-Werror,-Wunused-function]
```

`captureHasContent()` arrived with #1746 and was never called — the only mention was inside a comment. macOS and Linux never compile this file's `Q_OS_ANDROID` section, so neither a local build nor the merge caught it, and it reached `main`.

## Deleted, not wired up

Calling it would be a behaviour bug. The fallback gate is a positive test:

```cpp
if (artOutcome == CaptureOutcome::NoEntries)
    appendLogcatTailToFile(f, 1500);
```

and the comment above it says the unfiltered tail must be skipped **both** when ART had content **and** when the capture failed — "the fallback runs the same binary the same way, so it would fail identically and stack a second, contradictory marker under the first."

`!captureHasContent(o)` is true for every failure outcome (`ExecFailed`, `TimedOut`, `ForkFailed`, …), so substituting it would run the fallback on precisely the paths documented not to. The helper is a leftover from an earlier design where the gate was "no content".

The comment that cited it is rewritten to name the actual mechanism: a stderr leak into the content pipe counts as captured bytes, which yields `Content` rather than `NoEntries` and skips the fallback. Same hazard, correct mechanism.

Verified with an Android CI build on this branch — the only way to compile this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)