### PR TITLE
Plan: serve MCP 2026-07-28 as a dual-era server

### DIFF
--- a/openspec/changes/add-mcp-dual-era-2026/.openspec.yaml
+++ b/openspec/changes/add-mcp-dual-era-2026/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/add-mcp-dual-era-2026/design.md
+++ b/openspec/changes/add-mcp-dual-era-2026/design.md
@@ -1,0 +1,205 @@
+## Context
+
+`McpServer::handleHttpRequest` is the single entry point for both callers —
+ShotServer's `/mcp` route and `McpRemoteAccess`'s tokenized remote route. It
+currently implements one thing: the handshake-based era, `2024-11-05` through
+`2025-11-25`, with `m_sessions` at its centre. That pool is referenced 23 times
+in the file and carries a session-idle reaper, an orphan reaper inside
+`findOrCreateSession`, `MaxTotalSessions` eviction, two ceilings, a tombstone
+set, and an auto-recovery branch whose own comment records that it exists
+because `mcp-remote` cannot re-initialize itself.
+
+`2026-07-28` does not extend that model, it deletes it. There is no handshake:
+each request declares its version in `_meta` (mirrored in the
+`MCP-Protocol-Version` header), and the server accepts or rejects each request
+independently. The spec's terms are **legacy** for handshake-based revisions,
+**modern** for per-request-metadata ones, and **dual-era** for an
+implementation serving both — which it explicitly permits "concurrently on the
+same endpoint or process".
+
+The constraint that decides the whole shape is one row of the compatibility
+matrix: **legacy client + modern-only server fails, with no recovery.** The
+handshake that would have negotiated a fallback is what was removed. So modern
+is added beside legacy, never in place of it, and the legacy half stays until
+no client needs it — a horizon of years, backed by the revision's new
+twelve-month minimum deprecation windows.
+
+Three pieces of our server are keyed on the session and therefore have no
+modern equivalent yet: the rate limiter (`McpSession::controlCallCount()`), the
+SSE resource-update broadcast (an HTTP GET stream the modern era removes), and
+the in-app confirmation gate (`m_pendingConfirmation`, which stores a
+`sessionId`). Those three, not the protocol plumbing, are the actual work.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One endpoint serves both eras, with era selected per request.
+- Every legacy revision behaves **byte-identically** to today. The existing
+  protocol and session test files are the regression net and must pass
+  untouched.
+- Control-category tools are rate-limited in the modern era before they are
+  reachable in the modern era. Not after.
+- Both eras work over **both** callers — `McpRemoteAccess` as well as
+  ShotServer. The remote route is a separate entry that has been missed before.
+
+**Non-Goals:**
+
+- **Deleting the session machinery.** Legacy needs all of it. The simplification
+  the modern era offers is only realised the day legacy is dropped, which this
+  change does not do and should not pretend to.
+- **Tasks, MRTR (`input_required`), MCP Apps, OpenTelemetry trace context.**
+  None is required of a server. MRTR in particular is not a replacement for our
+  in-app confirmation: that asks the user *at the machine*, not the client, so
+  it is not an elicitation and there is nothing to migrate.
+- **Advertising `2026-07-28` in `supportedProtocolVersions()` until the modern
+  path is complete.** The list is a promise; adding to it early makes us lie to
+  `server/discover` callers.
+- **Removing `-32002` for legacy resource-not-found.** It is correct for every
+  revision we currently negotiate. The modern era uses `-32602`.
+
+## Decisions
+
+### Era is selected by the request, not by a mode flag
+
+A request selects its era the way the spec says a dual-era server should read
+it: an `initialize` request means legacy; a request carrying modern per-request
+`_meta` means modern. No configuration switch, no separate port, no build flag.
+
+*Why:* an era flag would have to be set before the server knows who is calling,
+and both callers multiplex clients of unknown era over one endpoint. It would
+also create a state no test could cover cheaply — every case doubled.
+
+*Consequence:* the discriminator must be cheap and unambiguous, because it runs
+before anything else. The decisive signal is the modern-only header set
+(`Mcp-Method`, `Mcp-Name`) plus `_meta.io.modelcontextprotocol/protocolVersion`
+in the body; legacy requests carry neither. `MCP-Protocol-Version` alone is NOT
+a discriminator — legacy has sent it since `2025-06-18`.
+
+### An ambiguous request is legacy
+
+If the era cannot be determined, serve legacy.
+
+*Why:* the failure modes are not symmetric. Mis-routing a legacy request to the
+modern path breaks a client that works today; mis-routing a modern request to
+the legacy path produces a `400`/JSON-RPC error, which is exactly what the
+spec's client-side detection expects to see and recover from — "if the body is
+empty or is not a recognized modern JSON-RPC error, fall back to `initialize`".
+The default that costs a working client nothing is legacy.
+
+### Rate limiting is the gate on the whole modern path
+
+Control- and settings-category tools stay **unreachable** in the modern era
+until a session-independent limiter exists.
+
+*Why:* `session->controlCallCount()` is the only thing standing between a
+client and unbounded `machine_start_*` calls. A stateless request has no
+session to count against. Shipping the modern path without solving this first
+would put an unlimited control surface on a machine that heats water to 90 °C
+and this is not a theoretical objection — the limiter was added because it was
+needed.
+
+*Preferred key:* the transport-level caller identity each route already has —
+the remote-access token for `McpRemoteAccess`, the peer address for ShotServer.
+Both are per-caller and neither requires retained protocol state.
+
+*Alternative considered:* a global limiter with no key. Rejected — one client
+could then starve another, which is the failure the per-session counter was
+shaped to avoid.
+
+*Alternative considered:* let modern requests borrow a hidden session keyed on
+transport identity. Rejected — that is a session by another name, reintroduces
+every reaper, and the resulting behaviour would be neither era's.
+
+### Modern subscriptions are additive, and may lag
+
+`subscriptions/listen` (long-lived POST) is implemented *after* the
+request/response path works, and until it is, a modern client simply has no
+resource notifications.
+
+*Why:* it is the only piece requiring new socket handling — ShotServer holds
+a socket open for SSE on GET today, and a long-lived POST stream is a shape it
+has not seen. Sequencing it last keeps that risk off the critical path, and a
+modern client with no notifications still works; it polls.
+
+### `server/discover` is implemented, but clients are not assumed to call it
+
+Both routes must work: discovery up front, and inline invocation that hits
+`UnsupportedProtocolVersionError` (`-32022`) and retries from the `supported`
+list.
+
+*Why:* the spec makes `server/discover` a server MUST and a client MAY. Testing
+only the discovery path would leave the more likely one uncovered.
+
+### Deterministic ordering and cacheable results land first, and land for both eras
+
+`tools/list` ordering and `ttlMs`/`cacheScope` are independent of era selection.
+
+*Why:* they are the only parts of this revision with a user-visible payoff that
+does not require a modern client to exist — 96 tool descriptions stop being
+re-fetched, and the ordering fix is worth taking on its own. Landing them first
+also means the big change is not carrying small wins hostage.
+
+*Note on the ordering bug:* the registry is a `QHash`, and Qt randomizes the
+hash seed per process unless `QT_HASH_SEED=0`
+(`qtbase/src/corelib/tools/qhash.cpp:121-127`, `:178`). The order is therefore
+stable within a run and different across restarts — which is the worst case for
+a client cache, because nothing looks wrong until you compare two runs.
+
+## Risks / Trade-offs
+
+- **Era misdetection breaks a working client** → The ambiguous case defaults to
+  legacy, and the existing test files must pass unmodified. Any diff to them is
+  a signal the legacy path moved, not that a test needed updating.
+- **The modern path doubles the surface `McpServer` must get right**, and this
+  is a file where a review already found a batch element being dispatched before
+  its refusal → Share the dispatch layer (`handleJsonRpc` and below) between
+  eras; only the envelope — version resolution, session lookup, response
+  framing — forks. If a fix has to be made twice, the fork is in the wrong
+  place.
+- **Modern control tools ship unlimited** → Structural, not procedural: the
+  category gate refuses control/settings on the modern path until the limiter
+  exists, so the unsafe intermediate state cannot be reached by forgetting.
+- **`subscriptions/listen` needs long-lived POST handling in ShotServer** →
+  Sequenced last; a modern client without it degrades to polling rather than
+  breaking.
+- **We implement a revision no client speaks to us yet, so bugs sit undiscovered**
+  → It ships dark by construction. Treat the test suite as the only evidence
+  until a real modern client appears, and do not claim field validation the way
+  the legacy path now has it.
+- **The simplification everyone wants does not arrive with this change** →
+  Deleting the session machinery needs legacy *dropped*, which is a separate
+  decision years out. Stated here so the change is not undersold as a cleanup.
+
+## Migration Plan
+
+No data migration, no persisted state, no settings. The rollout is ordering,
+not deployment:
+
+1. Era-independent wins (ordering, cacheable results) — shippable alone.
+2. Modern envelope: era detection, per-request version handling,
+   `server/discover`, `UnsupportedProtocolVersionError`. Read-category tools
+   only.
+3. Session-independent rate limiter; control/settings categories opened on the
+   modern path.
+4. `subscriptions/listen`.
+5. `2026-07-28` added to `supportedProtocolVersions()` — last, because that list
+   is what `server/discover` promises.
+
+Rollback is per-step; nothing before step 5 is visible to a client that does not
+already speak modern.
+
+## Open Questions
+
+- **What is the right rate-limit key for ShotServer's route?** The peer address
+  is available, but a LAN behind one NAT collapses to a single key. The remote
+  route has a token and is unambiguous. Worth deciding against real client
+  shapes rather than in the abstract.
+- **Does the in-app confirmation gate need a modern form at all?** It stores a
+  `sessionId` to route the answer back. A stateless caller has none, so either
+  the modern path refuses confirmation-gated tools (defensible — they are the
+  `machine_start_*` family) or the gate learns a request-scoped handle. Not
+  decided here; step 2 excludes those tools anyway.
+- **When does legacy get dropped?** Not this change, and not soon. Worth a note
+  in `MCP_SERVER.md` recording that the answer is "when no client needs it",
+  so the question is not re-litigated every time the session code annoys someone.

--- a/openspec/changes/add-mcp-dual-era-2026/proposal.md
+++ b/openspec/changes/add-mcp-dual-era-2026/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+MCP revision `2026-07-28` removes protocol-level sessions and the
+`initialize` handshake outright: every request carries its own version,
+identity and capabilities in `_meta`, and servers advertise themselves through
+a new `server/discover` RPC. The spec calls the two worlds **legacy**
+(`2025-11-25` and earlier, handshake-based) and **modern**, and names a server
+that speaks both **dual-era**.
+
+The compatibility matrix leaves a server no choice about sequencing. A legacy
+client on a modern-only server **fails with no recovery path** — the spec is
+explicit that "legacy clients have no fall-forward mechanism", because the
+handshake that would have negotiated a fallback is the thing that was removed.
+A legacy client on a dual-era server works unchanged. So a server adopts modern
+by *adding* it, never by switching, and the legacy half stays for years.
+
+Doing it is worth it for reasons beyond conformance. Sessions are the single
+largest source of accidental complexity in `McpServer` — a session pool with
+three separate reapers, two ceilings, an eviction path, tombstones, and an
+auto-recovery branch that exists *only* because cloud connectors re-initialize
+per request and never echo the session header. That branch is this server
+bending a session model around clients that never wanted one; the modern era
+makes per-request the model. The revision also adds cacheable list results,
+which matters here more than most: we serve 96 tools with paragraph-length
+descriptions on every single connection.
+
+## What Changes
+
+- **A modern request path, served statelessly, alongside the existing one.**
+  A request carrying modern per-request `_meta` is served per `2026-07-28`; an
+  `initialize` request selects the existing legacy semantics. The spec permits
+  both eras concurrently on one endpoint, which is what we do — one port, one
+  handler, two eras.
+- **`server/discover` is implemented.** Modern clients MAY call it to learn our
+  supported versions up front; those that do not get
+  `UnsupportedProtocolVersionError` (`-32022`) carrying the `supported` list and
+  retry. Both routes must work.
+- **Version handling moves off the session for modern requests.** `_meta`'s
+  `io.modelcontextprotocol/protocolVersion`, and the `MCP-Protocol-Version`
+  header, become the source of truth rather than a value negotiated once and
+  stored.
+- **Rate limiting gains a session-independent key.** Today the limiter counts
+  against `McpSession::controlCallCount()`. A stateless request has no session
+  to count against, so the modern path needs its own key before it can carry
+  control-category tools at all. **This is the gating item, not a detail** — an
+  unlimited control path on a machine that brews coffee is worse than the
+  complexity sessions cost.
+- **Resource-update notifications move to `subscriptions/listen` for modern
+  clients.** Our three SSE broadcasts (`machine/state`, `profiles/active`,
+  `shots/recent`) are pushed today over the HTTP GET stream that the modern era
+  removes. Legacy clients keep the GET stream unchanged.
+- **List results become cacheable.** `tools/list`, `resources/list` and
+  `resources/read` gain `ttlMs` and `cacheScope`, so clients stop re-fetching
+  96 tool descriptions per connection.
+- **`tools/list` returns a deterministic order.** A `SHOULD` in the new
+  revision, and one we fail today for an unrelated reason: the registry is a
+  `QHash`, whose iteration order Qt randomizes per process. Applies to both
+  eras and is worth taking regardless of the rest.
+- **Modern-era error codes.** Resource-not-found becomes `-32602` for modern
+  requests (`-32002` stays correct for legacy), and the MCP-reserved range
+  moves to `-32020`+.
+- **NOT BREAKING for any current client.** Every legacy revision we negotiate
+  today keeps its exact behaviour. That is the point of the shape.
+
+Explicit non-goals: we do not adopt the Tasks extension, MRTR
+(`input_required`), the MCP Apps extension, or OpenTelemetry trace context.
+None is required of a server, and MRTR in particular does not replace our
+in-app confirmation — that asks the user **at the machine**, not the client, so
+it is not an elicitation and has no modern equivalent to migrate to.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-dual-era-protocol`: how one endpoint serves both protocol eras — which
+  era a request selects and how, `server/discover`, per-request version
+  handling, `UnsupportedProtocolVersionError`, and the guarantee that legacy
+  behaviour is unchanged.
+- `mcp-stateless-requests`: what a modern request may rely on without a
+  session — rate limiting, resource subscriptions, and the confirmation gate,
+  each of which is keyed on the session today.
+
+### Modified Capabilities
+
+- `mcp-server`: adds deterministic list ordering and cacheable list results
+  (both era-independent), and scopes the existing session requirements —
+  termination, the concurrency limits, the pool bound, ephemeral reaping — to
+  the legacy era, since the modern era has no sessions for them to govern.
+
+## Impact
+
+- `src/mcp/mcpserver.{h,cpp}` — era selection in `handleHttpRequest`, the
+  modern request path, `server/discover`, per-request version handling. The
+  legacy path is not rewritten.
+- `src/mcp/mcpsession.h` — unchanged in behaviour; the rate-limit counter it
+  owns gains a session-independent sibling for the modern path.
+- `src/mcp/mcptoolregistry.h`, `src/mcp/mcpresourceregistry.h` — deterministic
+  ordering, `ttlMs`/`cacheScope` on list results.
+- `src/mcp/mcpremoteaccess.cpp` — the second caller into `handleHttpRequest`;
+  both eras must work over the remote surface, not just ShotServer's.
+- `src/network/shotserver.cpp` — routes `/mcp` and is era-agnostic, but the
+  modern subscription stream is a long-lived POST rather than a GET, which its
+  socket handling has not seen before.
+- `tests/tst_mcpserver_protocol.cpp`, `tests/tst_mcpserver_session.cpp` — the
+  existing suite becomes the legacy-era regression net and must keep passing
+  untouched; modern coverage is added beside it.
+- `docs/CLAUDE_MD/MCP_SERVER.md` — which era a client gets and why, and what
+  a contributor must do to a tool so it works in both.
+- **Wire-visible only to clients that opt into modern.** No client speaks
+  `2026-07-28` to us today, so this ships dark and stays dark until one does.

--- a/openspec/changes/add-mcp-dual-era-2026/specs/mcp-dual-era-protocol/spec.md
+++ b/openspec/changes/add-mcp-dual-era-2026/specs/mcp-dual-era-protocol/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: One Endpoint Serves Both Protocol Eras
+
+The server SHALL serve both protocol eras on the same endpoint: the legacy
+era, in which a client establishes a session with an `initialize` handshake,
+and the modern era, in which every request carries its own protocol version as
+per-request metadata.
+
+The era SHALL be selected per request, from the request itself. The server
+SHALL NOT require configuration, a separate port, or a build option to choose
+between them.
+
+#### Scenario: A legacy client connects
+
+- **WHEN** a client sends an `initialize` request
+- **THEN** the server serves that client under the negotiated legacy revision, unchanged from its behaviour before the modern era existed
+
+#### Scenario: A modern client connects
+
+- **WHEN** a client sends a request carrying modern per-request protocol metadata
+- **THEN** the server serves that request under the modern revision, without establishing a session
+
+#### Scenario: Both eras are served at once
+
+- **WHEN** a legacy client and a modern client are both talking to the server
+- **THEN** each is served under its own era, and neither affects the other
+
+### Requirement: Legacy Behaviour Is Unchanged
+
+Adding the modern era SHALL NOT change any observable behaviour of any legacy
+revision the server negotiates. A client that works today SHALL continue to
+work with no change on its side.
+
+#### Scenario: An existing client is unaffected
+
+- **WHEN** a client that negotiated a legacy revision before the modern era existed makes any request it made before
+- **THEN** it receives the same response it received before
+
+### Requirement: An Ambiguous Request Is Served As Legacy
+
+When the server cannot determine which era a request belongs to, it SHALL
+serve it as legacy.
+
+This is not a neutral default. Serving a legacy request as modern breaks a
+client that works today and gives it no way to recover. Serving a modern
+request as legacy produces an error the modern client's own detection is
+specified to recognize and fall back from.
+
+#### Scenario: Era cannot be determined
+
+- **WHEN** a request carries neither an `initialize` method nor modern per-request protocol metadata
+- **THEN** the server serves it under the legacy era
+
+### Requirement: The Server Advertises Its Supported Versions
+
+The server SHALL implement a discovery request that reports the protocol
+versions it supports, its identity, and its capabilities, so that a modern
+client MAY learn them before sending any other request.
+
+A client SHALL NOT be required to call it: a modern request naming a version
+the server does not support SHALL be answered with an unsupported-version
+error carrying the list of versions the server does support, so that a client
+that invokes a method directly can retry with a mutually supported version.
+
+#### Scenario: Client discovers up front
+
+- **WHEN** a modern client sends the discovery request
+- **THEN** the response names every protocol version the server supports
+
+#### Scenario: Client invokes a method directly with an unsupported version
+
+- **WHEN** a modern client sends a request naming a protocol version the server does not support
+- **THEN** the response is an unsupported-version error listing the versions the server does support
+
+#### Scenario: Advertised versions are the versions served
+
+- **WHEN** the discovery request reports a protocol version
+- **THEN** a request naming that version is served rather than rejected as unsupported
+
+### Requirement: A Modern Request Carries Its Own Protocol Version
+
+In the modern era the protocol version SHALL be taken from the request, and
+SHALL NOT be read from retained session state. Where the version appears both
+in the request body and in a transport header, the two SHALL agree, and a
+request whose header and body disagree SHALL be rejected.
+
+#### Scenario: Version comes from the request
+
+- **WHEN** two modern requests arrive naming different supported protocol versions
+- **THEN** each is answered according to the version it named
+
+#### Scenario: Header and body disagree
+
+- **WHEN** a modern request declares one protocol version in its transport header and a different one in its body
+- **THEN** the request is rejected rather than served under either
+
+### Requirement: Both Eras Are Served On Every Route That Reaches The Server
+
+Every caller that dispatches HTTP requests into the MCP server SHALL serve
+both eras. Era support SHALL NOT differ between the local route and the remote
+route.
+
+#### Scenario: Modern request over the remote route
+
+- **WHEN** a modern request arrives over the tokenized remote route rather than the local one
+- **THEN** it is served under the modern era, the same as it would be locally

--- a/openspec/changes/add-mcp-dual-era-2026/specs/mcp-server/spec.md
+++ b/openspec/changes/add-mcp-dual-era-2026/specs/mcp-server/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Session Requirements Govern The Legacy Era Only
+
+Every requirement in this capability concerning sessions — how a session
+becomes stateful, the concurrency limit, the total pool bound, the reaping of
+ephemeral sessions, and the rejection of a terminated session — SHALL be read
+as governing the legacy era, in which sessions exist.
+
+The modern era has no sessions for those requirements to govern. Their absence
+there is not a gap in conformance.
+
+#### Scenario: A modern request and the session limits
+
+- **WHEN** the server is serving modern requests
+- **THEN** no session is created for them, and they are not counted against any session limit
+
+#### Scenario: Legacy sessions are still bounded
+
+- **WHEN** legacy clients connect
+- **THEN** every session limit in this capability applies to them exactly as before
+
+### Requirement: List Results Are Returned In A Deterministic Order
+
+`tools/list` SHALL return its entries in an order that is stable across
+process restarts for an unchanged set of tools, so that a client may cache the
+result and so that a repeated listing does not defeat prompt caching.
+
+The order SHALL NOT depend on the iteration order of an unordered container.
+
+#### Scenario: Two runs return the same order
+
+- **WHEN** a client lists tools, the server restarts with the same tools registered, and the client lists tools again
+- **THEN** the two responses carry the tools in the same order
+
+#### Scenario: Order is independent of registration order
+
+- **WHEN** the order in which tools are registered changes but the set of tools does not
+- **THEN** the listing order is unchanged
+
+### Requirement: List And Read Results Carry Cache Guidance
+
+`tools/list`, `resources/list` and `resources/read` SHALL carry a freshness
+hint stating how long the result may be reused, and a scope stating whether
+the result may be cached beyond the requesting caller.
+
+A result whose content depends on the caller's access level SHALL NOT be
+marked cacheable beyond that caller.
+
+#### Scenario: A client caches a tool listing
+
+- **WHEN** a client lists tools
+- **THEN** the response states how long the listing may be reused
+
+#### Scenario: Access-dependent results are not shared
+
+- **WHEN** a listing reflects the caller's access level
+- **THEN** its cache scope does not permit reuse for another caller

--- a/openspec/changes/add-mcp-dual-era-2026/specs/mcp-stateless-requests/spec.md
+++ b/openspec/changes/add-mcp-dual-era-2026/specs/mcp-stateless-requests/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Control Tools Are Rate-Limited In Every Era
+
+Tools in the control and settings categories SHALL be rate-limited in the
+modern era as they are in the legacy era. The limit SHALL be counted against a
+key that does not require retained protocol state, and SHALL be per-caller
+rather than global, so that one caller cannot exhaust another's allowance.
+
+Until such a limit exists, control- and settings-category tools SHALL NOT be
+reachable in the modern era. An unlimited path to the machine's control tools
+is a worse outcome than those tools being unavailable to modern clients.
+
+#### Scenario: A modern caller exceeds the limit
+
+- **WHEN** a modern caller invokes control-category tools beyond the permitted rate
+- **THEN** further control-category calls from that caller are refused
+
+#### Scenario: One caller does not consume another's allowance
+
+- **WHEN** one modern caller has exhausted its allowance
+- **THEN** a different modern caller may still invoke control-category tools
+
+#### Scenario: Control tools before a limit exists
+
+- **WHEN** a modern client invokes a control- or settings-category tool and no session-independent rate limit has been implemented
+- **THEN** the call is refused rather than served without a limit
+
+#### Scenario: Read tools are unaffected
+
+- **WHEN** a modern client invokes a read-category tool
+- **THEN** it is served, whether or not a control-tool rate limit exists
+
+### Requirement: Modern Clients Receive Resource Notifications Without A Session
+
+Resource-update notifications SHALL be available to modern clients through a
+subscription mechanism that does not depend on a session or on a long-lived
+GET stream.
+
+A modern client that has not subscribed SHALL still be able to read every
+resource on request. Absence of notifications SHALL degrade a client to
+polling, not prevent it from working.
+
+#### Scenario: A modern client subscribes
+
+- **WHEN** a modern client opens a subscription and a subscribed resource changes
+- **THEN** the client receives a notification naming the changed resource
+
+#### Scenario: A modern client does not subscribe
+
+- **WHEN** a modern client never opens a subscription
+- **THEN** every resource remains readable on request
+
+#### Scenario: Legacy notifications are unaffected
+
+- **WHEN** a legacy client holds its stream open and a resource changes
+- **THEN** it receives the notification exactly as it did before the modern era existed
+
+### Requirement: A Tool Requiring Confirmation Is Never Silently Ungated
+
+A tool that requires confirmation in the legacy era SHALL NOT be served
+without that confirmation in the modern era. Where the confirmation mechanism
+depends on state the modern era does not have, the tool SHALL be refused with
+an error saying so.
+
+#### Scenario: A confirmation-gated tool is called by a modern client
+
+- **WHEN** a modern client invokes a tool that requires confirmation, and the confirmation mechanism cannot route an answer back to a caller with no session
+- **THEN** the call is refused with an error explaining that the tool is unavailable to this client, rather than executed without confirmation

--- a/openspec/changes/add-mcp-dual-era-2026/tasks.md
+++ b/openspec/changes/add-mcp-dual-era-2026/tasks.md
@@ -1,0 +1,82 @@
+## 1. Era-independent wins, shippable on their own
+
+Neither needs a modern client to exist, and both have a payoff today. Land
+first so the rest is not holding them hostage.
+
+- [ ] 1.1 `McpToolRegistry::listTools` sorts by tool name. The registry is a `QHash` and Qt randomizes the hash seed per process (`qtbase/src/corelib/tools/qhash.cpp:121-127`, `:178`), so the order is stable within a run and different across restarts — the worst shape for a client cache, because nothing looks wrong until two runs are compared
+- [ ] 1.2 Same for `McpResourceRegistry::listResources`
+- [ ] 1.3 Test: list twice across two `McpServer` instances, assert identical order. Must be seen RED — and note that a single-instance test CANNOT fail, because the seed is per process
+- [ ] 1.4 `ttlMs` + `cacheScope` on `tools/list`, `resources/list`, `resources/read`
+- [ ] 1.5 A listing that reflects the caller's access level is NOT `"public"` — 96 tools filtered by `accessLevel` means a shared cache would serve one caller another's tool set
+- [ ] 1.6 Gate both on the negotiated version so legacy clients that pre-date these fields do not receive them
+
+## 2. Era detection
+
+- [ ] 2.1 Add the era discriminator in `handleHttpRequest`, before anything else runs. Decisive signal is the modern-only header set (`Mcp-Method`, `Mcp-Name`) plus `_meta.io.modelcontextprotocol/protocolVersion` in the body
+- [ ] 2.2 `MCP-Protocol-Version` alone is NOT a discriminator — legacy has sent it since 2025-06-18. Write that at the site; it is the mistake this decision exists to prevent
+- [ ] 2.3 Ambiguous → legacy. The failure modes are asymmetric: mis-routing legacy to modern breaks a working client with no recovery, while mis-routing modern to legacy produces the error the modern client's own detection is specified to fall back from
+- [ ] 2.4 Test: every existing legacy shape still routes to legacy — `initialize`, a post-handshake `tools/call`, a notification, a batch array, a bare GET for SSE
+- [ ] 2.5 **The existing `tst_mcpserver_protocol.cpp` and `tst_mcpserver_session.cpp` must pass UNTOUCHED.** A diff to either is evidence the legacy path moved, not that a test needed updating
+
+## 3. Modern request path — read-category only
+
+- [ ] 3.1 Route a modern request to the shared dispatch layer (`handleJsonRpc` and below) without creating a session. Only the envelope forks: version resolution, session lookup, response framing
+- [ ] 3.2 If a fix has to be made in two places, the fork is in the wrong place — say so at the fork
+- [ ] 3.3 Read protocol version per request; reject a request whose header and body disagree (`-32020`)
+- [ ] 3.4 `UnsupportedProtocolVersionError` (`-32022`) carrying `supported` and `requested`
+- [ ] 3.5 Resource-not-found is `-32602` in the modern era; `-32002` stays for legacy. Both correct, per revision
+- [ ] 3.6 **Refuse control- and settings-category tools on the modern path** until section 5 lands. Structural, so the unsafe state cannot be reached by forgetting
+- [ ] 3.7 Tests: a modern read tool works; a modern control tool is refused; header/body mismatch is rejected; an unsupported version returns the supported list
+
+## 4. `server/discover`
+
+- [ ] 4.1 Implement it — a server MUST, a client MAY call it
+- [ ] 4.2 Test BOTH client routes: discovery up front, and inline invocation that hits `-32022` and retries. The second is the likelier one and would be the easier to leave uncovered
+- [ ] 4.3 Assert the advertised list and the served versions are the same list, not two lists that happen to agree today
+
+## 5. Session-independent rate limiting — the gate
+
+- [ ] 5.1 Decide the key. Remote route has a token and is unambiguous; ShotServer's route has the peer address, which collapses a whole LAN behind one NAT to a single key. Decide against real client shapes, not in the abstract (design Open Question)
+- [ ] 5.2 Implement per-caller, not global — one caller must not be able to starve another, which is what the per-session counter was shaped to avoid
+- [ ] 5.3 Open control/settings categories on the modern path only once 5.1-5.2 are done
+- [ ] 5.4 Tests: a caller over the limit is refused; a second caller is unaffected
+- [ ] 5.5 Leave `McpSession::controlCallCount()` alone — legacy still uses it
+
+## 6. Confirmation-gated tools in the modern era
+
+- [ ] 6.1 `m_pendingConfirmation` stores a `sessionId` to route the answer back, and a modern caller has none. Either refuse those tools (defensible — they are the `machine_start_*` family) or give the gate a request-scoped handle
+- [ ] 6.2 Whichever is chosen, a confirmation-gated tool must NEVER be served without confirmation. Refused with an error saying why is acceptable; executed is not
+- [ ] 6.3 Test the refusal explicitly — this is the one place where "not implemented yet" and "silently ungated" look the same from outside
+
+## 7. `subscriptions/listen`
+
+Sequenced last on purpose: it is the only piece needing new socket handling,
+and a modern client without it degrades to polling rather than breaking.
+
+- [ ] 7.1 Long-lived POST stream. ShotServer holds a socket open for SSE on GET today and has not seen this shape — check its socket handling before assuming it transfers
+- [ ] 7.2 Carry the three existing broadcasts (`machine/state`, `profiles/active`, `shots/recent`)
+- [ ] 7.3 Legacy GET stream untouched
+- [ ] 7.4 Do NOT implement stream resumability or `Last-Event-ID` replay — removed outright in this revision, and we already declined it
+
+## 8. Advertise the version
+
+- [ ] 8.1 Add `2026-07-28` to `supportedProtocolVersions()` — **last**. That list is what `server/discover` promises; adding it earlier makes the server lie
+- [ ] 8.2 Confirm the legacy negotiation still picks a legacy version for a legacy client rather than the new highest
+
+## 9. Verify
+
+- [ ] 9.1 Full suite via `mcp__qtcreator__run_tests` (scope `all`) — ask first, Qt Creator is shared
+- [ ] 9.2 Break each fix in turn and confirm its test goes red
+- [ ] 9.3 Live-test over BOTH callers — ShotServer AND `McpRemoteAccess`. The remote route is a separate entry that has been missed before, and a legacy regression there would be invisible to the local one
+- [ ] 9.4 Exercise a real legacy client end to end (Claude Desktop or the claude.ai connector) and confirm nothing changed for it. This is the assertion the whole change rests on
+- [ ] 9.5 Be honest in the PR body that no real MODERN client has exercised any of this — it ships dark, and the test suite is the only evidence. Do not describe it the way the legacy path can now be described
+- [ ] 9.6 Read the `text-invariants.yml` PR run — it gates `src/**` and nothing blocks a merge on it
+
+## 10. Document
+
+- [ ] 10.1 `docs/CLAUDE_MD/MCP_SERVER.md`: which era a client gets and how that is decided, and what a contributor must do to a new tool so it works in both
+- [ ] 10.2 Record that the session machinery is NOT deleted by this change and why — it is legacy's, and legacy stays. Written down so it is not re-litigated every time that code annoys someone
+- [ ] 10.3 Record the answer to "when do we drop legacy": when no client needs it, backed by the revision's twelve-month minimum deprecation windows
+- [ ] 10.4 No wiki manual change — MCP protocol eras are not a user-visible app surface
+- [ ] 10.5 Open the PR, then run `/pr-review-toolkit:review-pr`
+- [ ] 10.6 Archive the change + spec sync as the final commit on the same PR


### PR DESCRIPTION
**Plan only — no implementation.** Landing it so it's on `main` for when we're ready. Deliberately **not archived**: archiving promotes delta specs into `openspec/specs/` as though they were built, and none of this is.

## Why now

MCP revision `2026-07-28` removes protocol-level sessions and the `initialize` handshake outright. Every request carries its own version, identity and capabilities in `_meta`; servers advertise themselves through a new `server/discover` RPC. The spec calls the two worlds **legacy** (`2025-11-25` and earlier) and **modern**, and names a server that speaks both **dual-era**.

Nothing forces the timing — no client speaks it to us yet. This is the plan, written while the spec is fresh.

## The constraint that decides the shape

One row of the compatibility matrix:

| Client | Server | Outcome |
|---|---|---|
| Legacy | **Dual-era** | Works |
| Legacy | Modern-only | **Fails — no recovery** |

The spec is explicit that *"legacy clients have no fall-forward mechanism"*, because the handshake that would have negotiated a fallback is the thing that was removed. So modern is **added beside** legacy, never in place of it, and the legacy half stays for years — backed by the revision's new twelve-month minimum deprecation windows.

## Load-bearing decisions

- **Era is selected per request**, not by a config flag. Both callers (ShotServer and `McpRemoteAccess`) multiplex clients of unknown era over one endpoint.
- **Ambiguous → legacy.** The failure modes aren't symmetric: mis-routing legacy to modern breaks a working client permanently; mis-routing modern to legacy produces exactly the error a modern client's own detection is specified to recover from.
- **The discriminator is the modern-only header set plus `_meta`'s protocol version.** `MCP-Protocol-Version` alone is *not* one — legacy has sent it since 2025-06-18. That mistake is called out at the site it would be made.
- **Rate limiting gates the whole modern path.** `session->controlCallCount()` is the only thing between a client and unbounded `machine_start_*`, and a stateless request has no session to count against. Control and settings tools are therefore **structurally refused** on the modern path until a session-independent limiter exists — task 3.6 blocks, section 5 unblocks. Not left to be remembered.

## Two things the plan is careful not to claim

- **It does not delete the session machinery.** That needs legacy *dropped*, which is years out and a separate decision. Stated as a non-goal so this isn't oversold as a cleanup.
- **It would ship dark.** No client speaks `2026-07-28` to us, so the test suite would be the only evidence — a weaker position than the legacy path now has after #1755's live verification. Task 9.5 says not to describe it the same way.

## Shippable on its own

Section 1 is era-independent: deterministic `tools/list` ordering and cacheable list results (`ttlMs`/`cacheScope`). We fail the ordering SHOULD today for a reason unrelated to versioning — the registry is a `QHash` and Qt randomizes the hash seed per process (`qtbase/src/corelib/tools/qhash.cpp:121-127`), so the order is stable within a run and different across restarts, which is the worst case for a client cache. With 96 tool descriptions re-fetched per connection, the caching half has the most immediate payoff of anything in the revision.

## Contents

`openspec/changes/add-mcp-dual-era-2026/` — proposal, design (six decisions with alternatives rejected), two new capability specs (`mcp-dual-era-protocol`, `mcp-stateless-requests`), an `mcp-server` delta scoping the existing session requirements to the legacy era, and a ten-section tasks file. Validates `--strict`.

No source changes. Nothing on the wire moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
