### PR TITLE
fix: keep bottom bar action buttons on screen with a long profile name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1352,6 +1352,7 @@ set(QML_FILES
     qml/components/ProfilePreviewPopup.qml
     qml/components/ProfileInfoButton.qml
     qml/components/BottomBar.qml
+    qml/components/BottomBarSubtitle.qml
     qml/components/ThemedIcon.qml
     qml/components/TranslationErrorToast.qml
     qml/components/AccessibleMouseArea.qml

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -23,16 +23,36 @@ Item {
     readonly property color contentColor: Theme.contentColorOn(barColor, Theme.iconColor)
 
     // How much width the title-side content may take before it starts pushing the
-    // action buttons off the end of the bar. Nothing in the row has a minimum width,
-    // so an oversized leftContent does NOT get shrunk by the layout — the buttons are
-    // squeezed to near-zero cells instead and their centred labels paint outside the
-    // bar, which is what a long profile name did on Shot Review / Shot Detail.
-    // Pages bind their leftContent's Layout.maximumWidth to this so the text elides.
-    // No binding loop: nothing here depends on leftContentRow's own width.
-    readonly property real leftContentMaxWidth: Math.max(0,
+    // action buttons off the end of the bar.
+    //
+    // A child of a Qt Quick Layout that is not itself a layout and has no explicit
+    // Layout.fillWidth gets QLayoutPolicy::Fixed — it cannot shrink below its own
+    // preferred width; only nested layouts get Preferred
+    // (qtdeclarative/src/quicklayouts/qquicklayout.cpp:1304-1330, effectiveSizePolicy_helper).
+    // The action buttons are therefore Fixed, so an oversized leftContent does not
+    // squeeze them: the row's minimum sum simply exceeds the bar and the whole row
+    // is laid out past the right edge, which is what a long profile name did on
+    // Shot Review / Shot Detail. Capping leftContent lowers that minimum sum, so
+    // pages bind their leftContent's Layout.maximumWidth to this and the text elides.
+    //
+    // Floored at a couple of characters rather than at 0: Layout.maximumWidth: 0 is a
+    // legal zero-width cell, so the text would vanish outright — no ellipsis, and the
+    // Accessible.name on the collapsed item goes with it. The subtraction can reach
+    // that point because contentRow.implicitWidth counts a fillWidth/WordWrap label
+    // (e.g. the upload-error text on Shot Review) at its full unwrapped width even
+    // though the layout can shrink it. Overflowing by this floor beats disappearing.
+    //
+    // No binding loop: nothing here depends on leftContentRow's own width. A nested
+    // layout's implicitWidth is its engine-preferred size, which already clamps each
+    // child to that child's Layout.maximumWidth (qquicklayout.cpp:1278, boundSize),
+    // so titleRow's term needs no cap of its own — rightTextLabel is a plain Text, so
+    // its raw implicitWidth does. Invisible children are dropped from the engine
+    // entirely (qquicklayout.cpp:883-890, shouldIgnoreItem), hence the gap count.
+    readonly property real leftContentMaxWidth: Math.max(Theme.scaled(48),
         width - titleRow.implicitWidth - contentRow.implicitWidth
-              - (root.rightText !== "" ? Math.min(rightTextLabel.implicitWidth, width * 0.4) : 0)
-              - Theme.chartMarginSmall - Theme.spacingLarge - Theme.spacingMedium * 3)
+              - (rightTextLabel.visible ? Math.min(rightTextLabel.implicitWidth, width * 0.4) : 0)
+              - Theme.chartMarginSmall - Theme.spacingLarge
+              - Theme.spacingMedium * (rightTextLabel.visible ? 4 : 3))
     // Effective fill color, re-exposed for callers that mirror it (e.g.
     // CommunityBrowserPage's "Add to Library" label). The fill lives on the
     // nested bgRect, not this Item root, so alias it back to the public surface.

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -21,6 +21,18 @@ Item {
     // backgrounds became derivable: a light theme with a dark background colour derives
     // iconColor to WHITE while barColor stays the palette's white bar — white on white.
     readonly property color contentColor: Theme.contentColorOn(barColor, Theme.iconColor)
+
+    // How much width the title-side content may take before it starts pushing the
+    // action buttons off the end of the bar. Nothing in the row has a minimum width,
+    // so an oversized leftContent does NOT get shrunk by the layout — the buttons are
+    // squeezed to near-zero cells instead and their centred labels paint outside the
+    // bar, which is what a long profile name did on Shot Review / Shot Detail.
+    // Pages bind their leftContent's Layout.maximumWidth to this so the text elides.
+    // No binding loop: nothing here depends on leftContentRow's own width.
+    readonly property real leftContentMaxWidth: Math.max(0,
+        width - titleRow.implicitWidth - contentRow.implicitWidth
+              - (root.rightText !== "" ? Math.min(rightTextLabel.implicitWidth, width * 0.4) : 0)
+              - Theme.chartMarginSmall - Theme.spacingLarge - Theme.spacingMedium * 3)
     // Effective fill color, re-exposed for callers that mirror it (e.g.
     // CommunityBrowserPage's "Add to Library" label). The fill lives on the
     // nested bgRect, not this Item root, so alias it back to the public surface.
@@ -68,6 +80,7 @@ Item {
         // before the title. (With no back button the row collapses and the outer
         // leftMargin is the only inset.)
         RowLayout {
+            id: titleRow
             spacing: 0
 
             // Back button (square hitbox, full bar height)
@@ -143,6 +156,7 @@ Item {
 
         // Simple right text (alternative to custom content)
         Text {
+            id: rightTextLabel
             visible: root.rightText !== ""
             text: root.rightText
             color: root.contentColor

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -27,8 +27,11 @@ Item {
     //
     // A child of a Qt Quick Layout that is not itself a layout and has no explicit
     // Layout.fillWidth gets QLayoutPolicy::Fixed — it cannot shrink below its own
-    // preferred width; only nested layouts get Preferred
-    // (qtdeclarative/src/quicklayouts/qquicklayout.cpp:1304-1330, effectiveSizePolicy_helper).
+    // preferred width; nested layouts get Preferred unconditionally
+    // (qtdeclarative/src/quicklayouts/qquicklayout.cpp:1304-1332, effectiveSizePolicy_helper).
+    // A non-layout child can also reach Preferred via :1319-1329, but only under
+    // Layout.useDefaultSizePolicy or the app-wide AA_QtQuickUseDefaultSizePolicy
+    // attribute — this app sets neither, so Fixed is what its children get.
     // The action buttons are therefore Fixed, so an oversized leftContent does not
     // squeeze them: the row's minimum sum simply exceeds the bar and the whole row
     // is laid out past the right edge, which is what a long profile name did on
@@ -37,14 +40,16 @@ Item {
     //
     // Floored at a couple of characters rather than at 0: Layout.maximumWidth: 0 is a
     // legal zero-width cell, so the text would vanish outright — no ellipsis, and the
-    // Accessible.name on the collapsed item goes with it. The subtraction can reach
-    // that point because contentRow.implicitWidth counts a fillWidth/WordWrap label
-    // (e.g. the upload-error text on Shot Review) at its full unwrapped width even
-    // though the layout can shrink it. Overflowing by this floor beats disappearing.
+    // Accessible.name on the collapsed item goes with it. Overflowing by this floor
+    // beats disappearing. Note the subtraction over-counts any fillWidth/WordWrap
+    // label in the content slot: the layout can shrink one, but the row still reports
+    // its UNCAPPED implicit width as preferred. Give such a label its own
+    // Layout.maximumWidth (Shot Review's upload status lines do) rather than leaning
+    // on this floor to absorb it.
     //
     // No binding loop: nothing here depends on leftContentRow's own width. A nested
     // layout's implicitWidth is its engine-preferred size, which already clamps each
-    // child to that child's Layout.maximumWidth (qquicklayout.cpp:1278, boundSize),
+    // child to that child's Layout.maximumWidth (qquicklayout.cpp:1279, boundSize),
     // so titleRow's term needs no cap of its own — rightTextLabel is a plain Text, so
     // its raw implicitWidth does. Invisible children are dropped from the engine
     // entirely (qquicklayout.cpp:883-890, shouldIgnoreItem), hence the gap count.

--- a/qml/components/BottomBarSubtitle.qml
+++ b/qml/components/BottomBarSubtitle.qml
@@ -34,12 +34,20 @@ ColumnLayout {
 
     Accessible.role: Accessible.StaticText
     Accessible.name: root.primaryText + (root.secondaryText !== "" ? ", " + root.secondaryText : "")
+    // Both halves are required together — Accessible.focusable alone leaves the item
+    // unreachable by keyboard Tab. Neither page set activeFocusOnTab before this block
+    // was extracted; fixed here rather than carried forward. See ACCESSIBILITY.md.
     Accessible.focusable: true
+    activeFocusOnTab: true
 
     Text {
         text: root.primaryText
         font: Theme.labelFont
-        color: Theme.textColor
+        // The bar's own content colour, not Theme.textColor: under a background preset
+        // textColor is derived from the PAGE while barColor is a different surface, which
+        // is exactly the divergence BottomBar.contentColor exists to absorb. The title one
+        // row over already uses it; both pages had this line reading Theme.textColor.
+        color: root.bar.contentColor
         elide: Text.ElideRight
         Layout.maximumWidth: root._maxTextWidth
         Accessible.ignored: true
@@ -48,7 +56,8 @@ ColumnLayout {
     Text {
         text: root.secondaryText
         font: Theme.captionFont
-        color: Theme.textSecondaryColor
+        // Softened contentColor rather than textSecondaryColor, for the same reason.
+        color: Qt.rgba(root.bar.contentColor.r, root.bar.contentColor.g, root.bar.contentColor.b, 0.7)
         elide: Text.ElideRight
         Layout.maximumWidth: root._maxTextWidth
         Accessible.ignored: true

--- a/qml/components/BottomBarSubtitle.qml
+++ b/qml/components/BottomBarSubtitle.qml
@@ -1,0 +1,56 @@
+import QtQuick
+import QtQuick.Layouts
+import Decenza
+
+// Profile name + date pair that sits in a BottomBar's leftContent slot. It stays
+// visible while the user scrolls, providing context once the page header is
+// off-screen, and reads as a subtitle to the page title — which is why it lives in
+// leftContent (beside the title) rather than in the action slot.
+//
+// Shared by Shot Review and Shot Detail; both had a verbatim copy of this block.
+// Width is capped both by a share of the page and by whatever the bar has left after
+// its title and buttons (see BottomBar.leftContentMaxWidth), so a long profile name
+// elides instead of pushing the action buttons off the right edge.
+ColumnLayout {
+    id: root
+
+    // The bar this sits in — supplies the remaining-width budget.
+    required property BottomBar bar
+    // The page (or any item) whose width sets the proportional cap.
+    required property Item page
+
+    property string primaryText: ""
+    property string secondaryText: ""
+
+    // Share of the page width this may take when the bar has room to spare.
+    property real widthFraction: 0.3
+
+    readonly property real _maxTextWidth:
+        Math.min(root.page.width * root.widthFraction, root.bar.leftContentMaxWidth)
+
+    visible: primaryText !== ""
+    spacing: 0
+    Layout.alignment: Qt.AlignVCenter
+
+    Accessible.role: Accessible.StaticText
+    Accessible.name: root.primaryText + (root.secondaryText !== "" ? ", " + root.secondaryText : "")
+    Accessible.focusable: true
+
+    Text {
+        text: root.primaryText
+        font: Theme.labelFont
+        color: Theme.textColor
+        elide: Text.ElideRight
+        Layout.maximumWidth: root._maxTextWidth
+        Accessible.ignored: true
+    }
+
+    Text {
+        text: root.secondaryText
+        font: Theme.captionFont
+        color: Theme.textSecondaryColor
+        elide: Text.ElideRight
+        Layout.maximumWidth: root._maxTextWidth
+        Accessible.ignored: true
+    }
+}

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2335,33 +2335,11 @@ T.Page {
         title: TranslationManager.translate("postshotreview.title", "Shot Review")
         onBackClicked: postShotReviewPage.handleBack()
 
-        // Profile name + date remain visible while the user scrolls, providing context
-        // when the header is off-screen. It reads as a subtitle to the page title, so
-        // it lives in leftContent and stays beside it.
-        leftContent: ColumnLayout {
-            visible: !!(postShotReviewPage.editShotData.profileName)
-            spacing: 0
-            Layout.alignment: Qt.AlignVCenter
-            Accessible.role: Accessible.StaticText
-            Accessible.name: (postShotReviewPage.editShotData.profileName || "") + (postShotReviewPage.editShotData.dateTime ? ", " + postShotReviewPage.editShotData.dateTime : "")
-            Accessible.focusable: true
-
-            Text {
-                text: postShotReviewPage.editShotData.profileName || ""
-                font: Theme.labelFont
-                color: Theme.textColor
-                elide: Text.ElideRight
-                Layout.maximumWidth: Math.min(postShotReviewPage.width * 0.3, bottomBar.leftContentMaxWidth)
-                Accessible.ignored: true
-            }
-            Text {
-                text: postShotReviewPage.editShotData.dateTime || ""
-                font: Theme.captionFont
-                color: Theme.textSecondaryColor
-                elide: Text.ElideRight
-                Layout.maximumWidth: Math.min(postShotReviewPage.width * 0.3, bottomBar.leftContentMaxWidth)
-                Accessible.ignored: true
-            }
+        leftContent: BottomBarSubtitle {
+            bar: bottomBar
+            page: postShotReviewPage
+            primaryText: postShotReviewPage.editShotData.profileName || ""
+            secondaryText: postShotReviewPage.editShotData.dateTime || ""
         }
 
         // Undo button — edits autosave on every commit point; this reverts the

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2331,6 +2331,7 @@ T.Page {
 
     // Bottom bar (stays visible under keyboard)
     BottomBar {
+        id: bottomBar
         title: TranslationManager.translate("postshotreview.title", "Shot Review")
         onBackClicked: postShotReviewPage.handleBack()
 
@@ -2350,7 +2351,7 @@ T.Page {
                 font: Theme.labelFont
                 color: Theme.textColor
                 elide: Text.ElideRight
-                Layout.maximumWidth: postShotReviewPage.width * 0.3
+                Layout.maximumWidth: Math.min(postShotReviewPage.width * 0.3, bottomBar.leftContentMaxWidth)
                 Accessible.ignored: true
             }
             Text {
@@ -2358,7 +2359,7 @@ T.Page {
                 font: Theme.captionFont
                 color: Theme.textSecondaryColor
                 elide: Text.ElideRight
-                Layout.maximumWidth: postShotReviewPage.width * 0.3
+                Layout.maximumWidth: Math.min(postShotReviewPage.width * 0.3, bottomBar.leftContentMaxWidth)
                 Accessible.ignored: true
             }
         }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2439,6 +2439,12 @@ T.Page {
             font: Theme.labelFont
             wrapMode: Text.WordWrap
             Layout.fillWidth: true
+            // Capped so a long server message doesn't inflate contentRow.implicitWidth
+            // and starve BottomBar.leftContentMaxWidth: a fillWidth child is Preferred
+            // policy, so the layout shrinks it, but its UNCAPPED implicit width is what
+            // the row reports as preferred (qquicklayout.cpp:1279 clamps preferred to
+            // maximum, which is what makes this cap register).
+            Layout.maximumWidth: postShotReviewPage.width * 0.25
         }
 
         Text {
@@ -2448,6 +2454,12 @@ T.Page {
             font: Theme.labelFont
             wrapMode: Text.WordWrap
             Layout.fillWidth: true
+            // Capped so a long server message doesn't inflate contentRow.implicitWidth
+            // and starve BottomBar.leftContentMaxWidth: a fillWidth child is Preferred
+            // policy, so the layout shrinks it, but its UNCAPPED implicit width is what
+            // the row reports as preferred (qquicklayout.cpp:1279 clamps preferred to
+            // maximum, which is what makes this cap register).
+            Layout.maximumWidth: postShotReviewPage.width * 0.25
         }
 
         // AI Advice button - visible when AI is configured and we have shot data

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1592,34 +1592,11 @@ T.Page {
         title: TranslationManager.translate("shotdetail.title", "Shot Detail")
         onBackClicked: AppShell.backRequested()
 
-        // Profile name + date in the bottom bar remain visible while the user scrolls,
-        // providing context when the header is off-screen. It reads as a subtitle to
-        // the page title, so it lives in leftContent and stays beside it.
-        leftContent: ColumnLayout {
-            visible: !!(shotDetailPage.shotData.profileName)
-            spacing: 0
-            Layout.alignment: Qt.AlignVCenter
-            Accessible.role: Accessible.StaticText
-            Accessible.name: (shotDetailPage.shotData.profileName || "") + (shotDetailPage.shotData.dateTime ? ", " + shotDetailPage.shotData.dateTime : "")
-            Accessible.focusable: true
-
-            Text {
-                text: shotDetailPage.shotData.profileName || ""
-                font: Theme.labelFont
-                color: Theme.textColor
-                elide: Text.ElideRight
-                Layout.maximumWidth: Math.min(shotDetailPage.width * 0.3, bottomBar.leftContentMaxWidth)
-                Accessible.ignored: true
-            }
-
-            Text {
-                text: shotDetailPage.shotData.dateTime || ""
-                font: Theme.captionFont
-                color: Theme.textSecondaryColor
-                elide: Text.ElideRight
-                Layout.maximumWidth: Math.min(shotDetailPage.width * 0.3, bottomBar.leftContentMaxWidth)
-                Accessible.ignored: true
-            }
+        leftContent: BottomBarSubtitle {
+            bar: bottomBar
+            page: shotDetailPage
+            primaryText: shotDetailPage.shotData.profileName || ""
+            secondaryText: shotDetailPage.shotData.dateTime || ""
         }
 
         // No upload button here by design: this page is read-only, and the edit icon

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1608,7 +1608,7 @@ T.Page {
                 font: Theme.labelFont
                 color: Theme.textColor
                 elide: Text.ElideRight
-                Layout.maximumWidth: shotDetailPage.width * 0.3
+                Layout.maximumWidth: Math.min(shotDetailPage.width * 0.3, bottomBar.leftContentMaxWidth)
                 Accessible.ignored: true
             }
 
@@ -1617,7 +1617,7 @@ T.Page {
                 font: Theme.captionFont
                 color: Theme.textSecondaryColor
                 elide: Text.ElideRight
-                Layout.maximumWidth: shotDetailPage.width * 0.3
+                Layout.maximumWidth: Math.min(shotDetailPage.width * 0.3, bottomBar.leftContentMaxWidth)
                 Accessible.ignored: true
             }
         }


### PR DESCRIPTION
## Problem

On Shot Review and Shot Detail, a long profile name pushes the bottom-bar action buttons off the right edge of the screen — reported with Undo + Visualizer + AI Advice visible and a profile named `Collin Espresso/6 bar simple bloom 16g Co…`.

## Cause

A child of a Qt Quick Layout that is not itself a layout and has no explicit `Layout.fillWidth` gets `QLayoutPolicy::Fixed` and cannot shrink below its preferred width; nested layouts get `Preferred` (`qtdeclarative/src/quicklayouts/qquicklayout.cpp:1304-1332`). So the action buttons are Fixed — they are never squeezed. The profile name was capped only at `page.width * 0.3`, which is itself a Fixed contribution, and once title + subtitle + buttons exceed the bar the row's minimum sum can't be met and the whole row is laid out past the right edge.

## Fix

`BottomBar` publishes the width actually left over, and the subtitle is capped by it so it elides instead of overflowing the row:

```qml
readonly property real leftContentMaxWidth: Math.max(Theme.scaled(48),
    width - titleRow.implicitWidth - contentRow.implicitWidth
          - (rightTextLabel.visible ? Math.min(rightTextLabel.implicitWidth, width * 0.4) : 0)
          - Theme.chartMarginSmall - Theme.spacingLarge
          - Theme.spacingMedium * (rightTextLabel.visible ? 4 : 3))
```

Details worth knowing:

- **Floored at `Theme.scaled(48)`, not 0.** `Layout.maximumWidth: 0` is a legal zero-width cell — the text would vanish outright, no ellipsis, and the `Accessible.name` on the collapsed item with it.
- **`titleRow` needs no cap of its own** but `rightTextLabel` does: a nested layout's `implicitWidth` is its engine-preferred size, which already clamps each child to that child's `Layout.maximumWidth` (`qquicklayout.cpp:1279`, `boundSize`). `rightTextLabel` is a plain `Text`, whose raw `implicitWidth` is unclamped.
- **Gap count varies with `rightTextLabel.visible`** — invisible children are dropped from the layout engine entirely (`qquicklayout.cpp:883-890`, `shouldIgnoreItem`), so the row has 4 gaps with `rightText` set and 3 without.
- **Shot Review's upload status labels are now capped.** They are `fillWidth` + `WordWrap`, so the layout can shrink them, but `contentRow` still reports their *uncapped* implicit width as preferred — which starved the budget to its floor whenever an upload error was on screen.

## Also in this PR

- **New `qml/components/BottomBarSubtitle.qml`.** The profile-name/date block was duplicated verbatim across both pages; each is now a six-line usage. It takes the bar's `contentColor` rather than `Theme.textColor` — under a background preset `textColor` derives from the page while `barColor` is a different surface, the divergence `BottomBar.contentColor` exists to absorb — and adds `activeFocusOnTab` alongside `Accessible.focusable`, which neither page had.

## Testing

- Build clean; full suite 110 passed / 0 failed locally via Qt Creator.
- Manual check on Shot Review / Shot Detail with a long profile name. No QML test harness in this repo, so the layout behaviour itself is not covered by an automated test.
- `text-invariants.yml` ran on this PR and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
