### PR TITLE
Correct what the jittered-burst test claims about the real scale

### DIFF
--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -268,8 +268,22 @@ private slots:
     //
     //     2.25  2.92  2.92  2.25  0.04
     //
-    // The last sample of every burst is near zero, which is stop-at-weight going
-    // blind on a regular beat rather than occasionally.
+    // The last sample of every burst is near zero.
+    //
+    // WHAT THIS FIXTURE IS NOT: the Half Decent WiFi scale. Field measurement over
+    // four shots put that feed at 3-8% batched with a deepest burst of 6, i.e.
+    // almost entirely evenly paced, and blind samples at 0-3 per shot out of ~270.
+    // This fixture feeds 100% batched, five-frame bursts back to back — far more
+    // aggressive than any transport measured here. An earlier version of this
+    // comment claimed the oscillation meant stop-at-weight was going blind "on a
+    // regular beat" in the field; the diagnostics added alongside it say otherwise,
+    // and this note is the correction.
+    //
+    // So read the test as arithmetic, not as a report from the machine: it holds a
+    // genuine weakness in how a heavily-batched feed is fitted, against the day a
+    // transport delivers like that. What the real scale does instead is deliver
+    // irregularly — gaps followed by tight runs — which is a different problem the
+    // 65%-fill rule handles badly and which this fixture does not model.
     //
     // What it is NOT: a choice of averaging statistic. The estimate was switched
     // from minimum-of-three to median-of-three specifically to fix this. Measured


### PR DESCRIPTION
Comment-only. No code change.

The `QEXPECT_FAIL` fixture in `cadenceEstimateDoesNotTrackTheLowTail` feeds a 100% batched, five-frame-burst stream, and its comment presented the resulting oscillation as what stop-at-weight does in the field — *"going blind on a regular beat rather than occasionally."*

The diagnostics merged in [#1764](https://github.com/Kulitorum/Decenza/pull/1764) say otherwise. Four shots on the Half Decent WiFi scale:

| | batched | max burst | blind samples | arrivals |
|---|---|---|---|---|
| 12:06 | 8% | 6 | 3 | 286 |
| 10:20 | 3% | 2 | 0 | 290 |
| 10:34 | 3% | 3 | 1 | 261 |
| 10:46 | 4% | 3 | 3 | 264 |

The feed is almost entirely evenly paced, at a steady 10.0/s. What it actually does is arrive **irregularly** — gaps followed by tight runs — which the 65%-fill rule handles badly and which this fixture does not model.

The test keeps its place: the arithmetic weakness it holds is real for any transport that does deliver in heavy bursts. Only the claim about *this* hardware was wrong, and the comment now separates the two.

Closes the loop on the investigation: yields across those four shots were 36.0, 36.7, 36.3, 36.2 against a 36 g target, with actual drip varying 1.23–1.72 g. The residual error is drip scatter, not measurement — so no further code change is warranted, and the short-span escape branch explored during this work has been deleted rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)