### PR TITLE
Give the MCP server a version that tracks its tool surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,10 @@ payload, or an estimated `tools/list` over 85 KB. Three rules follow from it:
   server-side from the ARGUMENTS and failing closed on an action it cannot resolve.
 - **Declare a tier** (`McpTierCore` / `McpTierStandard` / `McpTierNiche`). Listing order is
   `(tier, name)`, so a truncating client loses the niche tail rather than an arbitrary ten.
+- **Bump `McpSurfaceVersion`** (`src/mcp/mcpserver.h`) whenever the surface changes. It is
+  `serverInfo.version` — the SURFACE, not the build, since 2.0.2 shipped both a 97-tool and a
+  66-tool server. The budget check fingerprints the tools and fails the PR if one moved without
+  the other. It does not refresh any client's cached list; nothing we can send does.
 - **Long-form prose goes in `resources/ai/tools/<topic>.md`**, served by `get_agent_file(topic)`
   and `decenza://tools/<topic>`. The description keeps only what picks the tool and fills its
   arguments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,8 +244,10 @@ payload, or an estimated `tools/list` over 85 KB. Three rules follow from it:
   `(tier, name)`, so a truncating client loses the niche tail rather than an arbitrary ten.
 - **Bump `McpSurfaceVersion`** (`src/mcp/mcpserver.h`) whenever the surface changes. It is
   `serverInfo.version` — the SURFACE, not the build, since 2.0.2 shipped both a 97-tool and a
-  66-tool server. The budget check fingerprints the tools and fails the PR if one moved without
-  the other. It does not refresh any client's cached list; nothing we can send does.
+  66-tool server. A version that no longer matches what the server serves is a false statement in
+  the handshake, and the clients that key on it can only be correct if we are. The budget check
+  fingerprints the tools and fails the PR if one moved without the other. It does not by itself
+  refresh a cache a client is already holding.
 - **Long-form prose goes in `resources/ai/tools/<topic>.md`**, served by `get_agent_file(topic)`
   and `decenza://tools/<topic>`. The description keeps only what picks the tool and fills its
   arguments.

--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -94,9 +94,15 @@ fingerprints the registered tools and their actions and fails the PR when the su
 without the version moving, printing the fingerprint to paste into `McpSurfaceFingerprint`. So the
 rule is enforced rather than remembered.
 
-**What this does not do is refresh anybody's tool list.** Clients cache the catalogue they fetched
-at `initialize` and refresh only on reconnect — and some not even then. Reported, repeatedly, and
-not by us:
+**Why it must be right, separately from what clients do with it.** `initialize` is where the
+server states what it is. A server whose surface has changed while its version has not is putting
+a false statement on the wire, and a client that keys on the version — today, or under the
+2026-07-28 caching semantics — can only behave correctly if we tell the truth. Pinning `1.0.0`
+forever defeated exactly the clients that would have done the right thing.
+
+**What it does not do on its own is refresh an existing cache.** Clients cache the catalogue they
+fetched at `initialize` and refresh only on reconnect — and some not even then. Reported,
+repeatedly, and not by us:
 
 - Claude Code caches by SERVER NAME and never invalidates; a server that went 5 → 15 tools kept
   showing 5 until the entry was renamed in `.mcp.json`

--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -81,6 +81,45 @@ one tool each, 97 → 66.
 The four limits — 80 tools, 500 chars per tool description, 120 per property description, 85 KB
 estimated payload — live in `LIMITS` at the top of that script, so tightening them is one edit.
 
+### The server version identifies the SURFACE, not the build
+
+`initialize` returns `serverInfo.version` — `McpSurfaceVersion` in `src/mcp/mcpserver.h` — plus
+`serverInfo.appVersion`, which carries the build. They are separate facts and neither substitutes
+for the other: **2.0.2 shipped both a 97-tool server and a 66-tool one**, so a version that
+followed the app version would have read identically across the change that halved the list.
+
+**Bump `McpSurfaceVersion` whenever the tool surface changes** — a tool added, removed or renamed,
+an action added to a merged tool, an argument whose meaning changes. `check_mcp_tool_budget.py`
+fingerprints the registered tools and their actions and fails the PR when the surface moves
+without the version moving, printing the fingerprint to paste into `McpSurfaceFingerprint`. So the
+rule is enforced rather than remembered.
+
+**What this does not do is refresh anybody's tool list.** Clients cache the catalogue they fetched
+at `initialize` and refresh only on reconnect — and some not even then. Reported, repeatedly, and
+not by us:
+
+- Claude Code caches by SERVER NAME and never invalidates; a server that went 5 → 15 tools kept
+  showing 5 until the entry was renamed in `.mcp.json`
+  ([claude-code#40025](https://github.com/anthropics/claude-code/issues/40025)).
+- claude.ai keeps the list through disconnect/reconnect and even delete-and-re-add
+  ([claude-ai-mcp#137](https://github.com/anthropics/claude-ai-mcp/issues/137),
+  [claude-code#38324](https://github.com/anthropics/claude-code/issues/38324)).
+- Codex fails to invalidate on an explicit `tools/list_changed`
+  ([codex#33266](https://github.com/openai/codex/issues/33266)).
+
+Observed here: after this app dropped to 66 tools, ChatGPT still reported 97 across a manual
+disconnect and reconnect.
+
+This server declares no `tools.listChanged` and should not: tools are registered once at startup
+and never change while the app runs, so the notification could never fire. The version's job is
+narrower and still worth having — it makes a stale session **visible**, which is otherwise only
+inferable by counting tools.
+
+The actual fix is protocol-level. MCP 2026-07-28 adds `ttlMs` and `cacheScope` to list results
+precisely because clients cache catalogues; adopting it here is real work (that revision also
+makes the core stateless, and this server is session-based with held responses for in-app
+confirmation), and whether the clients honour the hints is unverified.
+
 ### Adding a tool
 
 1. **Does it belong to a noun that already has a tool?** Add an action to that tool, not a new

--- a/scripts/check_mcp_tool_budget.py
+++ b/scripts/check_mcp_tool_budget.py
@@ -31,6 +31,7 @@ Usage: python3 scripts/check_mcp_tool_budget.py [--verbose]
 Exit code 1 on any violation.
 """
 
+import hashlib
 import re
 import sys
 from pathlib import Path
@@ -79,6 +80,17 @@ PROPERTY_DESCRIPTION = re.compile(r'\{"description", ((?:"(?:[^"\\]|\\.)*"\s*)+)
 ACTION_BUILDER = re.compile(r'(?:sync|async)Action\(\s*"([a-z_0-9]+)",\s*"([a-z_]+)"')
 ACTION_TOOL_START = re.compile(r'const QVector<McpToolAction>\s+(\w+)\s*\{')
 VALID_CATEGORIES = {"read", "control", "settings"}
+# `serverInfo.version` and the surface it was recorded against, both in mcpserver.h.
+# A client caches the tool list it fetched at initialize and refreshes only on
+# reconnect, so a surface that moves without the version moving leaves no way to tell
+# a stale session from a live one — which is exactly how a connector came to report
+# 97 tools against a server that registers 66.
+SURFACE_VERSION = re.compile(r'McpSurfaceVersion\s*=\s*"([^"]+)"')
+SURFACE_FINGERPRINT = re.compile(r'McpSurfaceFingerprint\s*=\s*"([^"]+)"')
+# Which QVector<McpToolAction> belongs to which tool, so the fingerprint is keyed by
+# the tool NAME rather than by a local variable a rename would churn.
+ACTION_TOOL_BINDING = re.compile(
+    r'registerActionTool\(\s*\n?\s*"([a-z_0-9]+)",.*?\n\s*(\w+)\)?[,;]', re.S)
 # McpServer's name-keyed confirmation list, for the tools that are not merged. A name
 # left here after its tool became a verb of a merged tool is dead text that reads like
 # a live rule — and the next reader trusts it.
@@ -96,6 +108,12 @@ def literal_text(source: str) -> str:
     """Join C++ adjacent string literals into the text the compiler would produce."""
     parts = re.findall(r'"((?:[^"\\]|\\.)*)"', source)
     return "".join(parts).replace('\\"', '"').replace("\\n", "\n")
+
+
+def header_sources(repo_root: Path) -> str:
+    """All tool sources concatenated — for patterns that span a registration."""
+    return "\n".join(p.read_text(encoding="utf-8")
+                     for glob in TOOLS_GLOBS for p in sorted(repo_root.glob(glob)))
 
 
 def scan(repo_root: Path):
@@ -132,6 +150,22 @@ def scan(repo_root: Path):
             actions.append((family, match.group(1), match.group(2), rel, line))
 
     return tools, properties, data_uris, actions
+
+
+def surface_fingerprint(tools, actions, bindings) -> str:
+    """A stable digest of what a client would see in `tools/list`.
+
+    Tool names, plus each merged tool's action names keyed by the TOOL — not by the
+    C++ variable holding the vector, which a rename would churn for no reason. Not
+    the descriptions: prose is edited constantly and a client's cached LIST is what
+    goes stale, not its wording.
+    """
+    by_tool = {}
+    for family, action, _category, _path, _line in actions:
+        by_tool.setdefault(bindings.get(family, family), set()).add(action)
+    lines = sorted(name for name, _d, _p, _l, _c in tools)
+    lines += [f"{tool}:{','.join(sorted(verbs))}" for tool, verbs in sorted(by_tool.items())]
+    return hashlib.sha256("\n".join(lines).encode()).hexdigest()[:12]
 
 
 def estimate_payload_bytes(tools, properties) -> int:
@@ -251,6 +285,21 @@ def main() -> int:
                     f"not exist."
                 )
 
+    header = (repo_root / "src/mcp/mcpserver.h").read_text(encoding="utf-8")
+    bindings = {var: tool for tool, var in ACTION_TOOL_BINDING.findall(header_sources(repo_root))}
+    fingerprint = surface_fingerprint(tools, actions, bindings)
+    recorded = SURFACE_FINGERPRINT.search(header)
+    version = SURFACE_VERSION.search(header)
+    if not recorded or not version:
+        violations.append("src/mcp/mcpserver.h: McpSurfaceVersion / McpSurfaceFingerprint not found")
+    elif recorded.group(1) != fingerprint:
+        violations.append(
+            f"src/mcp/mcpserver.h: the tool surface changed but McpSurfaceVersion is still "
+            f"\"{version.group(1)}\". Bump it and set McpSurfaceFingerprint to \"{fingerprint}\". "
+            f"A client caches the tool list from initialize and refreshes only on reconnect, so "
+            f"without a version change there is nothing to tell a stale session from a live one."
+        )
+
     payload = estimate_payload_bytes(tools, properties)
     if payload > LIMITS["max_payload_bytes"]:
         violations.append(
@@ -262,7 +311,8 @@ def main() -> int:
         print(
             f"MCP tool budget: {len(tools)} tools, "
             f"{sum(len(d) for _, d, _, _, _ in tools)} description chars, "
-            f"~{payload / 1024:.1f} KB estimated tools/list payload"
+            f"~{payload / 1024:.1f} KB estimated tools/list payload, "
+            f"surface {fingerprint}"
         )
 
     if not violations:

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -1,4 +1,5 @@
 #include "mcpserver.h"
+#include "version.h"
 #include "mcpsession.h"
 #include "mcptoolregistry.h"
 #include "mcpresourceregistry.h"
@@ -1082,7 +1083,12 @@ QJsonObject McpServer::handleInitialize(const QJsonObject& params, McpSession* s
 
     QJsonObject serverInfo;
     serverInfo["name"] = "Decenza MCP Server";
-    serverInfo["version"] = "1.0.0";
+    // The app version identifies the BUILD; this identifies the SURFACE. Both are
+    // needed and neither substitutes for the other: 2.0.2 shipped both a 97-tool and
+    // a 66-tool server, so a client that reported the app version would have looked
+    // identical across the change that halved its tool list.
+    serverInfo["version"] = QString::fromLatin1(McpSurfaceVersion);
+    serverInfo["appVersion"] = QStringLiteral(VERSION_STRING);
 
     // Negotiate protocol version — accept what the client requests if we support it,
     // otherwise return our preferred version (the first entry).

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -47,13 +47,20 @@ struct PendingConfirmation {
 // one, and a client reporting the app version would have shown the same string for
 // both. `serverInfo.appVersion` carries the build alongside it.
 //
-// What this does and does not buy: a client caches the tool list it fetched at
-// initialize and only refreshes on RECONNECT — this server declares no
-// `tools.listChanged` and could not usefully send one, since tools are registered
-// once at startup and never change while the app runs. So the version does not
-// invalidate anything by itself. What it does is make a stale session VISIBLE: a
-// connector still showing 1.0.0 is talking to a session that predates the merge,
-// which otherwise can only be inferred by counting tools.
+// This is a correctness obligation before it is anything else. The handshake is
+// where a server states what it is, and a server whose surface has changed while
+// its version has not is making a false statement on the wire — independently of
+// whether any particular client acts on it. A client that DOES key on the version
+// (today, or under the 2026-07-28 caching semantics) can only behave correctly if
+// we tell it the truth; pinning "1.0.0" forever defeated exactly those clients.
+//
+// It does not, on its own, invalidate an existing cache: a client caches the tool
+// list it fetched at initialize and refreshes only on RECONNECT, some not even
+// then. This server declares no `tools.listChanged` and could not usefully send
+// one, since tools are registered once at startup and never change while the app
+// runs. The useful side effect is that a stale session becomes VISIBLE — a
+// connector still reporting an old version is talking to a session that predates
+// the change, which otherwise can only be inferred by counting tools.
 //
 // scripts/check_mcp_tool_budget.py fingerprints the registered tools and their
 // actions and fails the PR if the surface moved without this string moving, so the

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -39,6 +39,30 @@ struct PendingConfirmation {
     QString protocolVersion = QStringLiteral("2024-11-05");  // captured at request time; default to legacy gating so a missed assignment never silently emits 2025-spec fields
 };
 
+// The MCP server's own version, reported as `serverInfo.version` at initialize.
+//
+// BUMP THIS WHENEVER THE TOOL SURFACE CHANGES — a tool added, removed or renamed, an
+// action added to a merged tool, an argument that changes meaning. It is not the app
+// version and does not follow it: 2.0.2 shipped a 97-tool server and then a 66-tool
+// one, and a client reporting the app version would have shown the same string for
+// both. `serverInfo.appVersion` carries the build alongside it.
+//
+// What this does and does not buy: a client caches the tool list it fetched at
+// initialize and only refreshes on RECONNECT — this server declares no
+// `tools.listChanged` and could not usefully send one, since tools are registered
+// once at startup and never change while the app runs. So the version does not
+// invalidate anything by itself. What it does is make a stale session VISIBLE: a
+// connector still showing 1.0.0 is talking to a session that predates the merge,
+// which otherwise can only be inferred by counting tools.
+//
+// scripts/check_mcp_tool_budget.py fingerprints the registered tools and their
+// actions and fails the PR if the surface moved without this string moving, so the
+// rule above is enforced rather than remembered.
+inline constexpr const char* McpSurfaceVersion = "1.0.1";
+// Fingerprint of the tool surface this version was recorded against. Update it in
+// the same edit as the version; the check prints the value to paste.
+inline constexpr const char* McpSurfaceFingerprint = "8ada4d203b66";
+
 class McpServer : public QObject {
     Q_OBJECT
     Q_PROPERTY(int activeSessionCount READ activeSessionCount NOTIFY activeSessionCountChanged)

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -18,6 +18,7 @@
 #include <QPair>
 
 #include "mcp/mcpserver.h"
+#include "version.h"
 #include "mcp/mcpsession.h"
 #include "mcp/mcptoolregistry.h"
 #include "mcp/mcpresourceregistry.h"
@@ -205,6 +206,34 @@ private slots:
         QCOMPARE(resp.statusCode, 200);
         const QString got = resp.jsonBody["result"].toObject()["protocolVersion"].toString();
         QCOMPARE(got, expected);
+    }
+
+    // `serverInfo.version` identifies the tool SURFACE, not the build, and the two
+    // are genuinely different facts: 2.0.2 shipped both a 97-tool server and a
+    // 66-tool one, so a version that followed the app would have read identically
+    // across the change that halved the list. Clients cache the catalogue they
+    // fetched at initialize and refresh only on reconnect (some not even then), so
+    // this string is what makes a stale session diagnosable at a glance.
+    //
+    // Asserting it against the constant rather than a literal is the point: the
+    // literal is what it was for the server's whole life, and a hand-typed one here
+    // would let the two drift apart while both looked right.
+    void initializeReportsSurfaceVersionAndAppVersion()
+    {
+        McpServer server;
+        QJsonObject params{
+            {"protocolVersion", "2025-11-25"},
+            {"capabilities", QJsonObject{}},
+            {"clientInfo", QJsonObject{{"name", "tst"}, {"version", "1"}}}};
+        auto resp = sendHttp(server, "POST", rpcBody("initialize", params));
+
+        const QJsonObject info = resp.jsonBody["result"].toObject()["serverInfo"].toObject();
+        QCOMPARE(info["name"].toString(), QString("Decenza MCP Server"));
+        QCOMPARE(info["version"].toString(), QString::fromLatin1(McpSurfaceVersion));
+        QCOMPARE(info["appVersion"].toString(), QString(VERSION_STRING));
+        QVERIFY2(info["version"].toString() != info["appVersion"].toString()
+                     || QString::fromLatin1(McpSurfaceVersion) == QString(VERSION_STRING),
+                 "surface version and app version are separate facts");
     }
 
     // The server-level `instructions` field (#1162) was introduced in MCP


### PR DESCRIPTION
## Why

`serverInfo.version` has been the literal `"1.0.0"` since the server was written. `initialize` is where a server states what it is, so a server whose surface has changed while its version has not is **putting a false statement on the wire** — regardless of what any particular client does with it. And the clients that do key on the version, today or under the 2026-07-28 caching semantics, can only behave correctly if we are telling the truth; pinning `1.0.0` forever defeated exactly those.

Not abstract: **2.0.2 shipped a 97-tool server and then a 66-tool one**, so a version that followed the app version would have read identically across the change that halved the list.

## What changes

- `McpSurfaceVersion` (`src/mcp/mcpserver.h`), now `1.0.1`, reported as `serverInfo.version`. `serverInfo.appVersion` carries the build alongside it.
- **Bump it whenever the surface changes** — a tool added, removed or renamed, an action added to a merged tool, an argument whose meaning changes.
- Enforced, not remembered: `check_mcp_tool_budget.py` fingerprints the registered tools and their actions and fails the PR when the surface moved without the version, printing the fingerprint to paste into `McpSurfaceFingerprint`. Verified by renaming a `scale_timer` action and watching it demand the bump.
- Test asserts `serverInfo` against the constants rather than literals, so the two cannot drift apart while both look right.

The fingerprint covers tool and action **names**, not description text — descriptions are edited constantly and a version that moves on every wording fix stops carrying information.

## What it does not do

It does not, on its own, invalidate a cache a client is already holding. Clients cache the catalogue they fetched at `initialize` and refresh only on reconnect — several not even then:

- Claude Code caches by **server name** and never invalidates; a server that went 5 → 15 tools kept showing 5 until the entry was renamed in `.mcp.json` ([claude-code#40025](https://github.com/anthropics/claude-code/issues/40025))
- claude.ai keeps the list through disconnect/reconnect and even delete-and-re-add ([claude-ai-mcp#137](https://github.com/anthropics/claude-ai-mcp/issues/137), [claude-code#38324](https://github.com/anthropics/claude-code/issues/38324))
- Codex fails to invalidate on an explicit `tools/list_changed` ([codex#33266](https://github.com/openai/codex/issues/33266))

Observed here: after this app dropped to 66 tools, ChatGPT still reported 97 across a manual disconnect and reconnect.

This server declares no `tools.listChanged` and should not — tools are registered once at startup and never change while the app runs, so it could never fire. The useful side effect of an honest version is that a stale session becomes **visible**, which otherwise can only be inferred by counting tools.

The protocol-level fix for the caching is 2026-07-28's `ttlMs` / `cacheScope` on list results. Adopting that revision is real work — it also makes the core stateless, and this server is session-based with held responses for in-app confirmation — and whether the clients honour the hints is unverified.

## Verification

- Full suite: **110 passed, 0 failed**
- All six `text-invariants` checks pass, including the extended budget check

🤖 Generated with [Claude Code](https://claude.com/claude-code)