### PR TITLE
Stop opening an empty path for iconless MCP resource families

### DIFF
--- a/src/mcp/mcptoolregistry.h
+++ b/src/mcp/mcptoolregistry.h
@@ -114,6 +114,14 @@ namespace McpRegistryHelpers {
     // now returns empty rather than defaulting, so a new resource family cannot
     // silently re-buy the fallback.
     inline QString iconDataUri(const QString& qrcPath) {
+        // An empty path is "this family has no icon" — the documented answer from
+        // iconQrcForResource() below, not a miss to be discovered by opening it.
+        // QFile("").open() takes the filesystem engine and emits
+        // "QFSFileEngine::open: No file name specified" (qtbase/src/corelib/io/
+        // qfsfileengine.cpp:204), once per iconless resource per resources/list —
+        // 15 warning lines per MCP client connect on a shipped build, crowding the
+        // ring buffer that field diagnosis reads.
+        if (qrcPath.isEmpty()) return QString();
         QFile f(qrcPath);
         if (!f.open(QIODevice::ReadOnly)) return QString();
         const QByteArray svg = f.readAll();

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -964,6 +964,38 @@ private slots:
         QVERIFY(sizes.toArray()[0].isString());
     }
 
+    // A resource family with no icon of its own — iconQrcForResource() answers
+    // that with an empty path — must not be discovered by TRYING TO OPEN it.
+    // QFile("").open() takes the filesystem engine and Qt prints
+    // "QFSFileEngine::open: No file name specified"
+    // (qtbase/src/corelib/io/qfsfileengine.cpp:204), once per iconless resource
+    // per resources/list. On the shipped tablet build that is the 15
+    // decenza://tools/<topic> docs resources: 15 warning lines every time an MCP
+    // client connects, in the ring buffer field diagnosis reads. init()'s
+    // failOnWarning() is what asserts the absence — dropping the empty-path guard
+    // in iconDataUri() turns this test red.
+    void iconlessResourceFamilyEmitsNoIconsAndOpensNoFile()
+    {
+        QVERIFY2(McpRegistryHelpers::iconQrcForResource("decenza://tools/debug_get_log").isEmpty(),
+                 "the tool-docs family is expected to map to no icon; if it gained one, "
+                 "this test needs a different iconless URI, not deleting");
+
+        McpServer server;
+        server.resourceRegistry()->registerResource(
+            "decenza://tools/debug_get_log", "debug_get_log documentation",
+            "Long-form documentation for the debug_get_log MCP tool",
+            "application/json", []() -> QJsonObject { return QJsonObject{}; });
+
+        const QString sid = openSession(server, "2025-11-25");
+        auto resp = sendHttp(server, "POST", rpcBody("resources/list", {}, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonArray resources = resp.jsonBody["result"].toObject()["resources"].toArray();
+        QCOMPARE(resources.size(), 1);
+        QVERIFY2(!resources[0].toObject().contains("icons"),
+                 "an iconless family must omit `icons` entirely, not ship an empty array");
+    }
+
     // `structuredContent` is not a field of `ResourceContents` in ANY MCP
     // revision — it exists on `CallToolResult` alone. This used to assert the
     // omission at 2024-11-05 only, which encoded the mistaken premise that it


### PR DESCRIPTION
## What

`McpRegistryHelpers::iconDataUri()` now returns early when handed an empty path, instead of passing it to `QFile`.

## Why

`iconQrcForResource()` answers "this family has no icon" with an empty `QString` — deliberate, and the reason the `decenza://tools/<topic>` docs resources don't re-buy the generic fallback. But `iconsArrayFromQrc()` fed that empty string straight to `QFile`, and an empty filename takes the *filesystem* engine, which warns:

```
QFSFileEngine::open: No file name specified
```

Once per iconless resource, per `resources/list`. There are 15 tool-docs resources, so **every MCP client connect logs a 15-line burst** — plus one at startup, where `registerAllResources()` lists them to count them.

Found in a tablet's debug log (2.0.2, build 3531): over 300 of these lines in the ring buffer, in bursts of 15/60/75/90, sitting between `Registered 66 tools` and `Registered 23 resources`. Nothing breaks — `iconsArrayFromQrc` already returns `{}` on the failed open, so the wire format is correct either way. The cost is the log: this is the buffer field diagnosis reads, and 300 lines of a warning about nothing crowds out history that matters.

The guard goes in `iconDataUri()` rather than at the call site because the empty string is a documented answer from the mapper directly above it, not a miss to be discovered by attempting an open.

## Test

`iconlessResourceFamilyEmitsNoIconsAndOpensNoFile()` in `tst_mcpserver_protocol.cpp` registers a `decenza://tools/*` resource, lists it at 2025-11-25, and asserts the record omits `icons` entirely. `init()`'s `QTest::failOnWarning()` is what asserts the *absence of the warning* — remove the guard and the test goes red. It also pins the premise (`iconQrcForResource` maps that family to nothing), so if the family ever gains an icon the test says to pick a different URI rather than delete itself.

## Not included

The same log carried `UpdateChecker: release "v2.0.2" found but no platform asset available`. That one is reporting something real — Android build [30761183739](https://github.com/Kulitorum/Decenza/actions/runs/30761183739) on tag `v2.0.2` failed on `-Werror,-Wunused-function`, leaving the release advertising a version code with no APK for 44 minutes — so it is deliberately left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)