### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 2.0.2 LANGUAGES CXX)
+project(Decenza VERSION 2.0.3 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
Version bump for the 2.0.3 pre-release.

`versioncode.txt` is deliberately untouched — CI bumps it on tag push and commits the new value back to `main`, so a local increment would collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)