### PR TITLE
fix(mdns): define the log macros outside the !Q_OS_IOS guard

### DIFF
--- a/src/network/mdnsresolver.cpp
+++ b/src/network/mdnsresolver.cpp
@@ -28,9 +28,6 @@ namespace {
 std::atomic<MdnsResolver::QueryPort> g_queryPort{MdnsResolver::QueryPort::Auto};
 }  // namespace
 
-#ifndef Q_OS_IOS
-
-#include "multicastlock.h"
 #include "core/logtags.h"
 
 // ---- This file's log prefix, defined ONCE -------------------------------
@@ -49,6 +46,11 @@ std::atomic<MdnsResolver::QueryPort> g_queryPort{MdnsResolver::QueryPort::Auto};
 // definition, and a marker the registry declares — holds either way.
 #define MDNS_DBG  qDebug().noquote()   << "[" DECENZA_LOG_MARKER_NETWORK "][MdnsResolver]"
 #define MDNS_WARN qWarning().noquote() << "[" DECENZA_LOG_MARKER_NETWORK "][MdnsResolver]"
+
+#ifndef Q_OS_IOS
+
+#include "multicastlock.h"
+
 
 #include <QHostAddress>
 #include <QElapsedTimer>


### PR DESCRIPTION
The v2.0.3 iOS build failed with 10 `use of undeclared identifier 'MDNS_DBG' / 'MDNS_WARN'` errors.

The macro definitions sat inside the `#ifndef Q_OS_IOS` block that ends at the mjansson implementation, but the Bonjour section below it — which **is** compiled on iOS — uses them throughout. macOS cannot catch this: `Q_OS_IOS` is false there, so the local build defines the macros and compiles both sections.

Definitions and the `logtags.h` include they need now sit above the guard.

Version stays at 2.0.3 — rolling beta, so the tag gets re-pointed at the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)