### PR TITLE
Stop the app aborting at 1024 descriptors, and stop it getting there (#1773)

### DIFF
--- a/scripts/check_log_markers.py
+++ b/scripts/check_log_markers.py
@@ -97,6 +97,13 @@ COVERED_GLOBS = [
     # has to answer, and it shipped with five hand-typed "[MulticastLock]"
     # prefixes that no registered marker would ever match.
     "src/network/multicastlock.cpp",
+    # Wholly about mDNS/DNS-SD: socket setup, query/retransmit, record parsing,
+    # both backends. Every line is a [Network] line. It carried a hand-typed
+    # "[MdnsResolver]" prefix that the registry never knew about, so a reader
+    # pulling the [Network] story out of a submitted log got everything about the
+    # WiFi scale EXCEPT why its name would not resolve — which is the half that
+    # usually explains the other.
+    "src/network/mdnsresolver.cpp",
     "src/core/settings_hardware.cpp",
     # Wholly about the screensaver: every log line in it is a screensaver line.
     "src/screensaver/screensavervideomanager.cpp",

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -200,6 +200,34 @@ static bool withTempDb(const QString& dbPath, const QString& connPrefix, Work&& 
     const QString connName = connPrefix + QString("_%1")
         .arg(reinterpret_cast<quintptr>(QThread::currentThreadId()), 0, 16);
     bool opened = false;
+    // The removal has to survive `work` throwing. Without this it sat as a plain
+    // statement after the block, so an exception escaping `work` would skip it
+    // and strand the connection — and with it the SQLite file descriptor — for
+    // the life of the process. No caller throws today (there is not one `throw`
+    // in src/), so this is defence against std::bad_alloc and against the first
+    // caller that does, not a fix for a live bug.
+    //
+    // Declared BEFORE the scope that holds `db` so it destructs AFTER it. If a
+    // QSqlDatabase copy is still alive, QSqlDatabasePrivate::invalidateDb warns
+    // "connection is still in use, all queries will cease to work" and calls
+    // disable(), which DELETES the driver (qsqldatabase.cpp:139-147 and 217-223,
+    // Qt 6.11.1). So the descriptor is released either way — what the surviving
+    // copy loses is the ability to run a query, silently. Getting the order right
+    // is about not breaking a live copy, not about leaking the fd.
+    //
+    // What this does NOT cover, so nobody reads it as a descriptor guarantee:
+    //   - Shutdown. removeDatabase() begins with CHECK_QCOREAPPLICATION
+    //     (qsqldatabase.cpp:26-30) and returns after a warning if the
+    //     QCoreApplication is already gone — a storage worker finishing after
+    //     that point removes nothing. This is exception safety, not shutdown
+    //     safety.
+    //   - A copy outliving the call. If `work` stashes the QSqlDatabase or a
+    //     live QSqlQuery, removal drops the dictionary entry while the surviving
+    //     copy keeps the driver and its SQLite handle open.
+    struct ConnectionRemover {
+        QString name;
+        ~ConnectionRemover() { QSqlDatabase::removeDatabase(name); }
+    } remover{connName};
     {
         QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE", connName);
         db.setDatabaseName(dbPath);
@@ -212,7 +240,6 @@ static bool withTempDb(const QString& dbPath, const QString& connPrefix, Work&& 
             work(db);
         }
     }
-    QSqlDatabase::removeDatabase(connName);
     return opened;
 }
 

--- a/src/core/logtags.h
+++ b/src/core/logtags.h
@@ -181,6 +181,17 @@
 #define DECENZA_SUBSYS_LOG_STDERR(marker, tag, msg, qFn) \
     qFn().noquote() << (QString("[" marker "][" tag "] ") + (msg))
 
+// Stream form, for files whose sites interleave several values apiece and would
+// only be made harder to read by composing a QString at each one (mdnsresolver's
+// per-packet traces are the case). Same "[marker][tag] " shape, defined here so
+// it is not re-typed per file — the reason this block exists.
+//
+// It writes stderr only, like DECENZA_SUBSYS_LOG_STDERR: a streamed line has no
+// single QString to hand to logMessage, so a site needing the in-app view wants
+// the statement forms above instead.
+#define DECENZA_SUBSYS_STREAM(marker, tag, qFn) \
+    qFn().noquote() << "[" marker "][" tag "]"
+
 // As above, but `tag` is a runtime QString instead of a literal. Only for a
 // helper that logs on behalf of SEVERAL sources — one whose own class name would
 // be the wrong answer. BLEManager's refractometer tiers are the case: main.cpp

--- a/src/core/networklogging.h
+++ b/src/core/networklogging.h
@@ -73,3 +73,15 @@
     DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_NETWORK, tag, msg, qInfo)
 #define NETWORK_WARN_STDERR(tag, msg) \
     DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_NETWORK, tag, msg, qWarning)
+
+// Stream variants. Same marker and shape as the forms above — the difference is
+// only how the message is composed, so a reader's [Network] search returns all
+// of them together. Use these where a site interleaves several values and a
+// QString would obscure rather than help; prefer the statement forms otherwise.
+// Being in a helper header is also what lets the .cpp using them sit in
+// check_log_markers.py's COVERED_GLOBS: the bare qDebug/qWarning lives here,
+// where the gate expects it, instead of in the file it serves.
+#define NETWORK_DBG_STREAM(tag) \
+    DECENZA_SUBSYS_STREAM(DECENZA_LOG_MARKER_NETWORK, tag, qDebug)
+#define NETWORK_WARN_STREAM(tag) \
+    DECENZA_SUBSYS_STREAM(DECENZA_LOG_MARKER_NETWORK, tag, qWarning)

--- a/src/network/mdnsresolver.cpp
+++ b/src/network/mdnsresolver.cpp
@@ -28,7 +28,6 @@ namespace {
 std::atomic<MdnsResolver::QueryPort> g_queryPort{MdnsResolver::QueryPort::Auto};
 }  // namespace
 
-#include "core/logtags.h"
 
 // ---- This file's log prefix, defined ONCE -------------------------------
 //
@@ -38,14 +37,202 @@ std::atomic<MdnsResolver::QueryPort> g_queryPort{MdnsResolver::QueryPort::Auto};
 // registered marker got ZERO hits for the resolver — while this subsystem is
 // diagnosed almost entirely from submitted logs.
 //
-// These emit the registered [Network] marker plus a tag naming this file, which
-// is what networklogging.h's helpers do. The streaming form is kept rather than
-// the (tag, QString) helpers because these sites interleave 2-8 values apiece and
-// several are per-packet traces; composing a QString at each would reflow the
-// file for no gain in what a reader sees. The property that matters — one
-// definition, and a marker the registry declares — holds either way.
-#define MDNS_DBG  qDebug().noquote()   << "[" DECENZA_LOG_MARKER_NETWORK "][MdnsResolver]"
-#define MDNS_WARN qWarning().noquote() << "[" DECENZA_LOG_MARKER_NETWORK "][MdnsResolver]"
+// These emit the registered [Network] marker plus a tag naming this file. The
+// streaming form is kept rather than the (tag, QString) helpers because these
+// sites interleave 2-8 values apiece and several are per-packet traces;
+// composing a QString at each would reflow the file for no gain in what a reader
+// sees.
+//
+// They ALIAS networklogging.h's stream helpers rather than spelling the
+// "[marker][tag] " shape out again — that shape has one definition, in
+// logtags.h, and copying a body to specialize it is the drift the whole
+// convention exists to stop. Aliasing also puts the bare qDebug/qWarning in a
+// helper header rather than in this file, which is what lets this file sit in
+// check_log_markers.py's COVERED_GLOBS: a future bare qDebug here now fails the
+// gate instead of quietly leaving the [Network] story a line short.
+#define MDNS_DBG  NETWORK_DBG_STREAM("MdnsResolver")
+#define MDNS_WARN NETWORK_WARN_STREAM("MdnsResolver")
+
+#include "core/networklogging.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QMap>
+#include <QStringList>
+
+#include <cerrno>
+#ifdef Q_OS_WIN
+#include <winsock2.h>
+#else
+#include <poll.h>
+#endif
+
+namespace {
+
+// Wait until `fd` is readable, or `timeoutMs` elapses.
+// Returns >0 readable, 0 timed out, <0 error with errno set.
+//
+// poll(), never select(). select()'s fd_set is a fixed FD_SETSIZE-bit (1024)
+// bitmap indexed by descriptor NUMBER, so FD_SET() on a descriptor >= 1024
+// writes past the end of it. Android's bionic catches that and abort()s the
+// process — issue #1773: the app had 1024 descriptors open after ~96 h uptime,
+// discovery's four mDNS sockets therefore came back as fds 1024-1027, and the
+// first FD_SET killed it. bionic's check is UNCONDITIONAL, not gated on
+// _FORTIFY_SOURCE (the NDK sysroot's sys/select.h defines FD_SET as
+// __FD_SET_chk and says "Use <poll.h> instead"), so every Android build aborts.
+// Elsewhere it is worse rather than better: glibc only checks under
+// _FORTIFY_SOURCE and Apple's libc not at all, so an unfortified build corrupts
+// the stack silently. poll() takes the descriptor as a plain int, no ceiling.
+//
+// A high descriptor number is a symptom worth chasing separately; this only
+// makes it survivable.
+//
+// The two families also report descriptor FAULTS differently, which is why this
+// normalises rather than forwarding poll()'s return. POLLERR/POLLHUP/POLLNVAL
+// are output-only: the kernel raises them in `revents` whether or not they were
+// requested, and poll() counts that descriptor as ready. So an INVALID fd comes
+// back as ret == 1 with POLLNVAL where select() returned -1/EBADF — forwarded
+// raw, every caller's `ret < 0` arm goes unreachable, the browse reports an
+// empty network instead of an aborted one, and the resolve loop spins at 100%
+// for its whole deadline calling recvfrom() on a dead socket. Mapping POLLNVAL
+// back to -1 restores what select() did.
+//
+// POLLERR and POLLHUP are mapped the same way, which is deliberately STRICTER
+// than select() was — it reported both as readable. On unconnected UDP
+// multicast sockets neither is expected, and a socket in either state has
+// nothing left to give these loops.
+int waitReadable(int fd, int timeoutMs)
+{
+#ifdef Q_OS_WIN
+    WSAPOLLFD pfd;
+    pfd.fd = static_cast<SOCKET>(fd);
+    pfd.events = POLLRDNORM;
+#else
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+#endif
+    pfd.revents = 0;
+
+#ifdef Q_OS_WIN
+    const int ret = WSAPoll(&pfd, 1, timeoutMs);
+    if (ret < 0) {
+        // WSAPoll reports through WSAGetLastError(), not errno, so a caller
+        // reading errno would otherwise see a stale value. WSAEINTR is a
+        // different NUMBER from EINTR (10004 vs 4), so translate it rather than
+        // leaving the callers' `errno == EINTR` retry permanently false.
+        const int wsaErr = WSAGetLastError();
+        errno = (wsaErr == WSAEINTR) ? EINTR : wsaErr;
+        return -1;
+    }
+#else
+    const int ret = poll(&pfd, 1, timeoutMs);
+    if (ret < 0)
+        return -1;   // errno already set
+#endif
+
+    // Only a fault with NO readable data is an error: POLLHUP can arrive
+    // alongside pending data, and that data is still worth reading.
+#ifdef Q_OS_WIN
+    const bool readable = (pfd.revents & (POLLRDNORM | POLLRDBAND)) != 0;
+#else
+    const bool readable = (pfd.revents & POLLIN) != 0;
+#endif
+    if (ret > 0 && !readable && (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+        errno = (pfd.revents & POLLNVAL) ? EBADF : EIO;
+        return -1;
+    }
+    return ret;
+}
+
+// Report what the process is holding descriptors on, but ONLY when a freshly
+// opened socket comes back with an alarmingly high number.
+//
+// POSIX hands out the lowest-numbered UNUSED descriptor, so a socket coming back
+// as fd N proves 0..N-1 are all in use — a lower bound on the count, not a
+// high-water mark. (With holes, from a partly reclaimed leak, a fresh socket can
+// come back low while the process still holds many high ones, so this can
+// under-report; it cannot over-report.) A lower bound is what diagnosed #1773:
+// the log read `sock= 1024` moments before the abort. What the number could not
+// say is WHAT held the other thousand, and on a user's device there is no second
+// chance to ask — the only channel back is the debug log attached to the crash
+// report.
+//
+// This matters more now than it did before, not less. The poll() change above
+// removes the abort, which also removes the alarm — a descriptor leak that used
+// to announce itself with a crash will otherwise go quiet and resurface as
+// sockets and files failing to open, much further from its cause.
+//
+// Costs nothing in the normal case: below the threshold this reads no directory
+// and formats no string.
+//
+// Linux/Android only, and the guard is around the WHOLE function rather than
+// just the /proc walk. The lowest-free-descriptor premise is POSIX; Windows does
+// not make it — mdns.h hands back `(int)socket(...)`, a kernel HANDLE allocated
+// in multiples of four and unrelated to how many descriptors are held, so a Qt
+// app with a few hundred open would clear the threshold immediately and warn on
+// every resolve about a condition that does not exist. macOS/iOS do return low
+// fds but cannot produce the breakdown, so a warning there would have no reader.
+#if defined(Q_OS_LINUX) || defined(Q_OS_ANDROID)
+void reportFdPressureIfHigh(int fd, const char* what)
+{
+    // Half of FD_SETSIZE. Well clear of anything normal (the app sits in the low
+    // tens) and still a wide margin before the 1024 that used to be fatal, so
+    // the report lands in the log BEFORE the situation is critical.
+    constexpr int kFdWarnThreshold = 512;
+    if (fd < kFdWarnThreshold)
+        return;
+
+    // Group by kind, not by individual entry: 900 lines of "socket:[12345]" is
+    // unreadable in a submitted log, while "socket=890, anon_inode=12" names the
+    // culprit's shape in one line. Sockets then point at the servers and
+    // clients; anon_inode at event loops and timers; a /data path at files.
+    QMap<QString, int> byKind;
+    QDir fdDir(QStringLiteral("/proc/self/fd"));
+    // Every entry is a symlink to a socket/pipe/anon_inode/file, so ask for all
+    // entry types and System — a QDir::Files filter matches almost none of them.
+    const QStringList entries = fdDir.entryList(QDir::AllEntries | QDir::System | QDir::NoDotAndDotDot);
+    if (entries.isEmpty()) {
+        // Empty is never a true answer — we hold at least the socket that
+        // triggered this. entryList() returns {} on failure and reports nothing,
+        // and the failure it hits here is EMFILE on the opendir: reading
+        // /proc/self/fd costs a descriptor, and the condition being reported is
+        // the process running out of them. "0 descriptors" next to "opened fd
+        // 1020" would read as a broken report on the one shot we get.
+        MDNS_WARN << "HIGH FD PRESSURE:" << what << "opened fd" << fd
+                  << "— /proc/self/fd unreadable, no breakdown available";
+        return;
+    }
+    for (const QString& entry : entries) {
+        QString kind = QFileInfo(fdDir.filePath(entry)).symLinkTarget();
+        const qsizetype colon = kind.indexOf(':');
+        if (colon > 0)
+            kind = kind.left(colon);          // socket:[123] -> socket
+        else if (kind.startsWith('/'))
+            kind = QFileInfo(kind).path();    // /data/user/0/... -> its directory
+        if (kind.isEmpty())
+            kind = QStringLiteral("(unknown)");
+        byKind[kind] += 1;
+    }
+
+    QStringList parts;
+    for (auto it = byKind.cbegin(); it != byKind.cend(); ++it)
+        parts << QStringLiteral("%1=%2").arg(it.key()).arg(it.value());
+
+    // entries.size() includes the descriptor entryList() itself held while
+    // scanning, so it reads one high. Not worth correcting for — it is an
+    // order-of-magnitude signal, and saying so beats a silently-off-by-one number.
+    MDNS_WARN << "HIGH FD PRESSURE:" << what << "opened fd" << fd
+              << "— process holds ~" << entries.size()
+              << "descriptors:" << parts.join(QStringLiteral(", "));
+}
+#else
+// Everywhere else the descriptor number carries no information about pressure,
+// so there is nothing honest to report. Inline and empty — the calls compile away.
+inline void reportFdPressureIfHigh(int, const char*) {}
+#endif
+
+}  // namespace
 
 #ifndef Q_OS_IOS
 
@@ -380,6 +567,10 @@ int openQuerySocket(int* boundPortOut)
     if (sock < 0)
         return -1;
 
+    // One report point for both backends' query sockets, since #1772 gave them a
+    // shared opener.
+    reportFdPressureIfHigh(sock, "mDNS query socket");
+
     // Report the port the kernel gave us, not the one we asked for: those differ
     // whenever the 5353 bind failed, and that difference is the whole diagnostic.
     if (boundPortOut) {
@@ -474,16 +665,18 @@ QString resolveHostname(const QString& hostname, int timeoutMs,
         if (remaining <= 0) break;
         const int slice = qMin(remaining, kRetransmitMs);
 
-        fd_set readfds;
-        FD_ZERO(&readfds);
-        FD_SET(sock, &readfds);
-        struct timeval tv;
-        tv.tv_sec = slice / 1000;
-        tv.tv_usec = (slice % 1000) * 1000;
-
-        int ret = select(sock + 1, &readfds, nullptr, nullptr, &tv);
+        int ret = waitReadable(sock, slice);
         if (ret < 0) {
             if (errno == EINTR) continue;
+            // Say which kind of failure this was. Falling through silently lands
+            // in the summary block below as "records=0", whose documented meaning
+            // is "no multicast responses reached our socket at all
+            // (interface/multicast-lock/routing problem)" — filing a descriptor
+            // fault as a network fault, in the one place written to stop exactly
+            // that misattribution. The browse loop already logs its copy.
+            MDNS_WARN << "resolve wait failed for" << hostname << "errno=" << errno;
+            if (stats && stats->error.isEmpty())
+                stats->error = QString("wait on socket failed (errno %1) — resolve aborted early").arg(errno);
             break;
         }
         if (ret == 0) continue;  // slice elapsed with no data — retransmit
@@ -628,22 +821,15 @@ QVector<ServiceInstance> browseServiceMjansson(const QString& serviceType, int t
         if (remaining <= 0) break;
         const int slice = qMin(remaining, kRetransmitMs);
 
-        fd_set readfds;
-        FD_ZERO(&readfds);
-        FD_SET(sock, &readfds);
-        struct timeval tv;
-        tv.tv_sec = slice / 1000;
-        tv.tv_usec = (slice % 1000) * 1000;
-
-        int ret = select(sock + 1, &readfds, nullptr, nullptr, &tv);
+        int ret = waitReadable(sock, slice);
         if (ret < 0) {
             if (errno == EINTR) continue;
             // Anything else (EBADF, EINVAL, ENOMEM) aborts the browse. Without
             // recording it the summary is indistinguishable from an empty
             // network, which is the exact confusion BrowseStats exists to stop.
-            MDNS_WARN << "browse select() failed errno=" << errno;
+            MDNS_WARN << "browse wait failed errno=" << errno;
             if (stats && stats->error.isEmpty())
-                stats->error = QString("select() failed (errno %1) — browse aborted early").arg(errno);
+                stats->error = QString("wait on socket failed (errno %1) — browse aborted early").arg(errno);
             break;
         }
         if (ret == 0) continue;
@@ -735,7 +921,6 @@ QVector<ServiceInstance> browseServiceMjansson(const QString& serviceType, int t
 
 #include <dns_sd.h>
 #include <arpa/inet.h>
-#include <sys/select.h>
 
 #include <cerrno>
 
@@ -1012,6 +1197,10 @@ QVector<ServiceInstance> browseServiceBonjour(const QString& serviceType, int ti
         if (stats)
             stats->error = QStringLiteral("DNSServiceRefSockFD returned no usable socket");
     }
+    // A no-op here: this block only compiles on Apple platforms, where
+    // reportFdPressureIfHigh is the empty stub. Kept so the site does not read as
+    // an oversight if a non-Apple Bonjour backend ever exists.
+    reportFdPressureIfHigh(fd, "Bonjour browse connection");
     QDeadlineTimer deadline(timeoutMs);
 
     // Stay subscribed for the whole window rather than taking an early snapshot.
@@ -1026,27 +1215,21 @@ QVector<ServiceInstance> browseServiceBonjour(const QString& serviceType, int ti
         const qint64 remaining = deadline.remainingTime();
         if (remaining <= 0) break;
 
-        fd_set readfds;
-        FD_ZERO(&readfds);
-        FD_SET(fd, &readfds);
         // Wait in slices, not for the whole remaining deadline. `cancel` is only
-        // read at the top of this loop, and on a quiet LAN nothing wakes
-        // select() — so a full-deadline timeout meant a cancelled browse stayed
+        // read at the top of this loop, and on a quiet LAN nothing wakes the
+        // wait — so a full-deadline timeout meant a cancelled browse stayed
         // parked for up to 15 s, holding the QThreadPool thread that
         // ~QCoreApplication's unconditional waitForDone() then blocks on. That
         // is exactly the hang the cancel flag exists to prevent. The mjansson
         // loop already slices (kRetransmitMs) for the same reason.
         const qint64 slice = qMin<qint64>(remaining, kCancelPollMs);
-        struct timeval tv;
-        tv.tv_sec = static_cast<time_t>(slice / 1000);
-        tv.tv_usec = static_cast<suseconds_t>((slice % 1000) * 1000);
 
-        const int ret = select(fd + 1, &readfds, nullptr, nullptr, &tv);
+        const int ret = waitReadable(fd, static_cast<int>(slice));
         if (ret < 0) {
             if (errno == EINTR) continue;
-            MDNS_WARN << "browse select() failed errno=" << errno;
+            MDNS_WARN << "browse wait failed errno=" << errno;
             if (stats && stats->error.isEmpty())
-                stats->error = QString("select() failed (errno %1) — browse aborted early").arg(errno);
+                stats->error = QString("wait on socket failed (errno %1) — browse aborted early").arg(errno);
             break;
         }
         if (ret == 0) continue;

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -374,20 +374,61 @@ void ShotServer::setSettings(Settings* settings)
     }
 }
 
-// Precondition: no socket in `clients` has an entry in m_keepAliveTimers.
-// This is enforced at each SSE registration site by either calling take() on
-// the map, or by routing the request such that sendResponse/resetKeepAliveTimer
-// is never called. Current sites:
-//   /api/theme/subscribe  — see handleRequest(), "m_sseThemeClients.insert" (calls take())
-//   /api/layout/events    — see handleRequest(), "m_sseLayoutClients.insert" (calls take())
-//   /mcp (SSE GET)        — bypasses sendResponse entirely; McpServer manages its own
-//                           m_sseClients list and ShotServer never inserts a timer
-// If a new SSE endpoint is added that goes through sendResponse without calling
-// take(), this function will call deleteLater() on the socket while its timer
-// lambda still holds a raw pointer to it — causing use-after-free when the timer
-// fires. This static function has no access to m_keepAliveTimers, so callers
-// must maintain the invariant.
-static void broadcastSseEvent(QSet<QTcpSocket*>& clients, const QByteArray& event)
+// Retire one socket: clear it out of every container that can hold it, then
+// close and delete it. See the header for why this cannot be left to
+// onDisconnected() firing — close() does not always emit disconnected(), and the
+// states where it does not are precisely the ones the dead-client checks look
+// for.
+//
+// Idempotent: every removal is a no-op on an absent key, close() on a closed
+// socket does nothing, and Qt collapses repeated deleteLater() into one event.
+// So a call that DOES synchronously re-enter through onDisconnected() is safe.
+void ShotServer::retireSocket(QTcpSocket* socket)
+{
+    if (!socket)
+        return;
+
+    m_clients.remove(socket);
+    m_sseLayoutClients.remove(socket);
+    m_sseThemeClients.remove(socket);
+    m_uploadProgressLog.remove(socket);
+
+    // The timer is a child of `socket` and dies with it; stopping it here keeps
+    // its lambda from firing in the window before deleteLater() runs. Taking it
+    // out of the map is what stops stop() from dereferencing a freed pointer.
+    if (QTimer* t = m_keepAliveTimers.take(socket))
+        t->stop();
+
+    cleanupPendingRequest(socket);
+    m_pendingRequests.remove(socket);
+
+    QList<int> staleLibraryRequests;
+    for (auto it = m_pendingLibraryRequests.begin(); it != m_pendingLibraryRequests.end(); ++it) {
+        if (it.value().socket == socket || it.value().socket.isNull()) {
+            qDebug() << "ShotServer: Cleaning up pending library request" << it.key() << "- socket disconnected";
+            invalidateLibraryRequest(it.value());
+            staleLibraryRequests.append(it.key());
+        }
+    }
+    for (int id : staleLibraryRequests)
+        m_pendingLibraryRequests.remove(id);
+
+    socket->close();
+    socket->deleteLater();
+
+    // Report the recovery, once, with what the silence cost. A limit that was
+    // hit and cleared is a different story from one still being hit, and without
+    // this the log shows only the "limit reached" line — indistinguishable from
+    // a server still refusing everyone.
+    if (m_atConnectionLimit && m_clients.size() < MAX_CONNECTIONS) {
+        m_atConnectionLimit = false;
+        qWarning() << "ShotServer: below connection limit again after refusing"
+                   << m_refusedConnections << "connection(s)";
+        m_refusedConnections = 0;
+    }
+}
+
+void ShotServer::broadcastSseEvent(QSet<QTcpSocket*>& clients, const QByteArray& event)
 {
     QList<QTcpSocket*> dead;
     for (QTcpSocket* client : clients) {
@@ -397,11 +438,14 @@ static void broadcastSseEvent(QSet<QTcpSocket*>& clients, const QByteArray& even
         }
         client->flush();
     }
-    for (QTcpSocket* s : dead) {
-        clients.remove(s);
-        s->close();
-        s->deleteLater();
-    }
+    // A member, not the static free function this used to be. That version could
+    // not reach m_keepAliveTimers, so it carried a precondition its callers had
+    // to uphold by hand ("no socket in `clients` has a keep-alive timer") — and
+    // any new SSE endpoint that went through sendResponse would have broken it
+    // silently, deleting a socket whose timer lambda still held a raw pointer.
+    // retireSocket() enforces it instead of documenting it.
+    for (QTcpSocket* s : dead)
+        retireSocket(s);
 }
 
 void ShotServer::onLayoutChanged()
@@ -545,25 +589,27 @@ void ShotServer::stop()
         // which could destroy timers; clearing the map first avoids dangling pointers.
         for (QTimer* t : std::as_const(m_keepAliveTimers))
             t->stop();
+        // m_clients holds every accepted socket, so it is the superset of the SSE
+        // sets and m_pendingRequests — one pass retires the lot. Iterate a COPY:
+        // retireSocket() mutates m_clients, and close() inside it can re-enter
+        // through onDisconnected().
+        //
+        // This is what closes in-flight upload sockets, which matters beyond
+        // tidiness: an APK or media upload socket that survives stop() still has
+        // its QSocketNotifier around when Android takes over for the
+        // PackageInstaller handover (#865).
+        const auto clients = m_clients;
+        for (QTcpSocket* s : clients)
+            retireSocket(s);
+        // Defensive: retireSocket has emptied all of these for every socket it
+        // saw. Anything left is a pointer that was never in m_clients, which
+        // would be a bug elsewhere — drop it rather than carry it into the next
+        // start().
         m_keepAliveTimers.clear();
-        // Copy sets before closing — s->close() can synchronously trigger
-        // onDisconnected() which calls m_sseLayoutClients.remove() during iteration.
-        auto layoutCopy = m_sseLayoutClients;
         m_sseLayoutClients.clear();
-        for (QTcpSocket* s : layoutCopy) s->close();
-        auto themeCopy = m_sseThemeClients;
         m_sseThemeClients.clear();
-        for (QTcpSocket* s : themeCopy) s->close();
-        // Close in-flight HTTP request sockets too. Without this an APK or
-        // media upload socket survives stop() and its QSocketNotifier
-        // is still around when Android takes over for the PackageInstaller
-        // handover (#865). cleanupPendingRequest must run before the hash
-        // is cleared because it early-returns on missing entries; matches
-        // the destructor pattern.
-        const auto pendingSockets = m_pendingRequests.keys();
-        for (QTcpSocket* s : pendingSockets) cleanupPendingRequest(s);
         m_pendingRequests.clear();
-        for (QTcpSocket* s : pendingSockets) s->close();
+        m_clients.clear();
         m_server->close();
         delete m_server;
         m_server = nullptr;
@@ -577,8 +623,71 @@ void ShotServer::onNewConnection()
 {
     while (m_server->hasPendingConnections()) {
         QTcpSocket* socket = m_server->nextPendingConnection();
+
+        // Fail closed above the ceiling. Dropping the newest arrival keeps the
+        // clients already being served, which is the opposite of what running
+        // out of descriptors does — that takes down BLE, the database and
+        // everything else in the process along with the web server.
+        if (m_clients.size() >= MAX_CONNECTIONS) {
+            // Answer, don't just hang up. A bare close reaches the browser as
+            // ERR_EMPTY_RESPONSE, which is byte-identical to the app being dead,
+            // the wrong port, or a bad certificate — and whoever hits this is far
+            // more likely to be the owner on their phone than anything hostile.
+            //
+            // Written straight to the socket rather than through sendResponse():
+            // that arms a keep-alive timer keyed on the socket, and this socket
+            // is deliberately never wired to onDisconnected, so the entry would
+            // outlive it. flush() normally pushes a body this small straight into
+            // the kernel buffer, leaving close() nothing to drain — a peer that
+            // never reads and has a full receive window instead gets a truncated
+            // 503, which is an acceptable answer to give a client that is not
+            // listening.
+            const QByteArray body =
+                "Decenza is already serving its maximum number of connections. "
+                "Close other tabs or devices and try again in a moment.\n";
+            socket->write("HTTP/1.1 503 Service Unavailable\r\n"
+                          "Content-Type: text/plain\r\n"
+                          "Retry-After: 5\r\n"
+                          "Connection: close\r\n"
+                          "Content-Length: " + QByteArray::number(body.size()) + "\r\n"
+                          "\r\n" + body);
+            socket->flush();
+            socket->close();
+            socket->deleteLater();
+
+            // Log the TRANSITION, not the event. One warning per refusal is one
+            // warning per SYN on a path an attacker controls, and the debug log
+            // is a bounded ring buffer that crash reports carry — flooding it
+            // would evict the fd-pressure evidence this same change adds, which
+            // is the diagnostic losing to the denial of service in the one
+            // buffer they share.
+            ++m_refusedConnections;
+            if (!m_atConnectionLimit) {
+                m_atConnectionLimit = true;
+                qWarning() << "ShotServer: connection limit reached ("
+                           << MAX_CONNECTIONS << ") — refusing new clients, most recent from"
+                           << socket->peerAddress().toString();
+            }
+            continue;
+        }
+        m_clients.insert(socket);
+
         connect(socket, &QTcpSocket::readyRead, this, &ShotServer::onReadyRead);
         connect(socket, &QTcpSocket::disconnected, this, &ShotServer::onDisconnected);
+        // Start the idle clock HERE, not at the first readyRead. A peer that
+        // connects and then sends nothing was previously tracked nowhere: no
+        // m_pendingRequests entry (created on first read), no keep-alive timer
+        // (created when a response is sent), not in either SSE set — so
+        // onCleanupTimerTick's stale sweep could not see it and the descriptor
+        // was held until the peer closed, which a vanished peer never does. On a
+        // LAN where this server advertises itself over mDNS that is a steady
+        // trickle (scanners, browser pre-connects, discovery agents), and the fd
+        // count only goes up. Registering at accept puts such a socket under
+        // SILENT_TIMEOUT_MS — 30 s, not the 5-minute CONNECTION_TIMEOUT_MS, which
+        // is reserved for sockets with a request actually in flight (see the
+        // two-deadline check in onCleanupTimerTick). onReadyRead reuses this
+        // same entry.
+        m_pendingRequests[socket].lastActivity.start();
         emit clientConnected(socket->peerAddress().toString());
     }
 }
@@ -847,34 +956,7 @@ void ShotServer::onReadyRead()
 
 void ShotServer::onDisconnected()
 {
-    QTcpSocket* socket = qobject_cast<QTcpSocket*>(sender());
-    if (socket) {
-        m_sseLayoutClients.remove(socket);
-        m_sseThemeClients.remove(socket);
-        // Stop the keep-alive timer if one is active. The timer is a child of
-        // `socket` and will be destroyed with it when deleteLater() processes —
-        // no explicit delete needed. Stopping it here prevents the timeout lambda
-        // from firing in the window between now and socket destruction.
-        if (QTimer* t = m_keepAliveTimers.take(socket))
-            t->stop();
-        cleanupPendingRequest(socket);
-        m_pendingRequests.remove(socket);
-
-        // Clean up any pending library requests for this socket (or already-destroyed sockets)
-        QList<int> toRemove;
-        for (auto it = m_pendingLibraryRequests.begin(); it != m_pendingLibraryRequests.end(); ++it) {
-            if (it.value().socket == socket || it.value().socket.isNull()) {
-                qDebug() << "ShotServer: Cleaning up pending library request" << it.key() << "- socket disconnected";
-                invalidateLibraryRequest(it.value());
-                toRemove.append(it.key());
-            }
-        }
-        for (int id : toRemove) {
-            m_pendingLibraryRequests.remove(id);
-        }
-
-        socket->deleteLater();
-    }
+    retireSocket(qobject_cast<QTcpSocket*>(sender()));
 }
 
 void ShotServer::invalidateLibraryRequest(PendingLibraryRequest& req)
@@ -964,49 +1046,38 @@ void ShotServer::onCleanupTimerTick()
 
     QList<QTcpSocket*> staleConnections;
     for (auto it = m_pendingRequests.begin(); it != m_pendingRequests.end(); ++it) {
-        if (it.value().lastActivity.isValid() &&
-            it.value().lastActivity.elapsed() > CONNECTION_TIMEOUT_MS) {
+        if (!it.value().lastActivity.isValid())
+            continue;
+        // Two deadlines, because "connected and said nothing" and "halfway
+        // through a 400 MB upload" are not the same client. Giving a socket that
+        // has never sent a byte the full five minutes means 64 of them wedge the
+        // server for five minutes, and the wedge is what every real user then
+        // meets as a 503. A client with a request in flight keeps the long
+        // deadline it needs.
+        const bool sentNothing = it.value().headerData.isEmpty() && it.value().headerEnd < 0;
+        const int deadline = sentNothing ? SILENT_TIMEOUT_MS : CONNECTION_TIMEOUT_MS;
+        if (it.value().lastActivity.elapsed() > deadline)
             staleConnections.append(it.key());
-        }
     }
 
     for (QTcpSocket* socket : staleConnections) {
         QString addr = (socket->state() != QAbstractSocket::UnconnectedState)
             ? socket->peerAddress().toString() : "unknown";
         qWarning() << "ShotServer: Cleaning up stale connection from" << addr;
-        // Remove the keep-alive timer from the map before scheduling deletion.
-        // If disconnected() doesn't fire synchronously from close(), the socket
-        // and its child timer will be destroyed by deleteLater() while the pointer
-        // still sits in m_keepAliveTimers — causing a dangling-pointer crash in stop().
-        if (QTimer* t = m_keepAliveTimers.take(socket))
-            t->stop();
-        cleanupPendingRequest(socket);
-        m_pendingRequests.remove(socket);
-        socket->close();
-        socket->deleteLater();
+        retireSocket(socket);
     }
 
-    // SSE clients are long-lived and never appear in m_pendingRequests, so the
-    // stale-connection loop above won't catch them. Probe each client with an SSE
-    // keepalive comment every 30 s to detect silently-dropped connections.
-    // Inlined rather than delegating to broadcastSseEvent() so we can defensively
-    // call m_keepAliveTimers.take() before deleteLater() — the static helper has
-    // no access to the map and cannot enforce the no-timer-in-map invariant itself.
-    for (QSet<QTcpSocket*>* clientSet : {&m_sseLayoutClients, &m_sseThemeClients}) {
-        QList<QTcpSocket*> dead;
-        for (QTcpSocket* c : *clientSet) {
-            if (c->state() != QAbstractSocket::ConnectedState || c->write(": keepalive\n\n") == -1)
-                dead.append(c);
-            else
-                c->flush();
-        }
-        for (QTcpSocket* c : dead) {
-            clientSet->remove(c);
-            if (QTimer* t = m_keepAliveTimers.take(c)) t->stop();
-            c->close();
-            c->deleteLater();
-        }
-    }
+    // Once subscribed, SSE clients no longer appear in m_pendingRequests — their
+    // entry is removed before handleRequest() runs — so the stale-connection loop
+    // above won't catch them. Probe each client with an SSE
+    // keepalive comment every 30 s to detect silently-dropped connections — which
+    // is exactly what broadcastSseEvent does, so send the probe through it rather
+    // than keeping a second copy of the write-flush-retire loop here. (This used
+    // to be inlined because the old static helper could not reach
+    // m_keepAliveTimers; now that both go through retireSocket, the reason is
+    // gone and the copies can only drift.)
+    broadcastSseEvent(m_sseLayoutClients, ": keepalive\n\n");
+    broadcastSseEvent(m_sseThemeClients, ": keepalive\n\n");
 
     // MCP SSE clients live in McpServer's set; have it run its own probe so
     // silently-dropped MCP connections are detected on the same 30 s cadence.

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -347,6 +347,25 @@ private:
     void invalidateLibraryRequest(PendingLibraryRequest& req);
     void completeLibraryRequest(int reqId, const QJsonObject& resp);
     void cancelAllLibraryRequests();
+    // The ONE way a socket leaves this class. Every container that can hold a
+    // socket pointer is cleared here, then the socket is closed and deleted.
+    //
+    // It has to be one function because close() is NOT guaranteed to emit
+    // disconnected(). Three paths in qabstractsocket.cpp (Qt 6.11.1) skip it:
+    // close() on an UnconnectedState socket skips the disconnectFromHost() call
+    // entirely (:2650-2659); disconnectFromHost() returns early whenever write
+    // data is still pending (:2718-2725); and in ConnectingState/HostLookupState
+    // it sets pendingClose and returns (:2683-2689). The dead-client checks
+    // select for sockets in exactly those states — so a site that close()s,
+    // deleteLater()s and trusts onDisconnected() to do the bookkeeping leaves
+    // dangling pointers behind. Each call site used to maintain that bookkeeping
+    // by hand and they had already drifted apart.
+    //
+    // "Every container" means every one in THIS class. McpServer keeps its own
+    // SSE client list over the same sockets (McpServer::m_sseClients); that is
+    // safe without help here only because it holds QPointers.
+    void retireSocket(QTcpSocket* socket);
+    void broadcastSseEvent(QSet<QTcpSocket*>& clients, const QByteArray& event);
     QTimer* m_cleanupTimer = nullptr;
     int m_port = 8888;
     int m_activeMediaUploads = 0;
@@ -356,6 +375,16 @@ private:
     QSet<QTcpSocket*> m_sseLayoutClients;  // SSE connections for layout change notifications
     QSet<QTcpSocket*> m_sseThemeClients;   // SSE connections for theme change notifications
     QHash<QTcpSocket*, QTimer*> m_keepAliveTimers;  // Idle timers for keep-alive connections
+    // Every accepted socket, for the whole time it is alive. The other
+    // containers above each hold a SUBSET once the connection has taken a shape
+    // (mid-request, subscribed to SSE, idle between keep-alive requests), so
+    // none of them can answer "how many clients are connected right now" — which
+    // is what MAX_CONNECTIONS is enforced against. (m_pendingRequests now also
+    // gets an entry at accept, before any of those shapes is known; it is
+    // removed again the moment a request completes.)
+    QSet<QTcpSocket*> m_clients;
+    bool m_atConnectionLimit = false;   // true between hitting MAX_CONNECTIONS and dropping below it
+    int m_refusedConnections = 0;       // refusals since the limit was last hit, reported on recovery
 
     // TLS state
     QSslCertificate m_sslCert;
@@ -367,7 +396,28 @@ private:
     static constexpr qint64 MAX_UPLOAD_SIZE = 500 * 1024 * 1024;   // 500 MB max per file
     static constexpr int MAX_CONCURRENT_UPLOADS = 2;               // Limit concurrent media uploads
     static constexpr int CONNECTION_TIMEOUT_MS = 300000;           // 5 minute timeout
+    // Ceiling on simultaneously accepted clients. Not a throughput limit — it is
+    // the backstop for an unauthenticated listener bound to QHostAddress::Any and
+    // advertised over mDNS, which anything on the LAN can open a socket to
+    // without sending a byte.
+    //
+    // NOT the Tailscale Funnel path, which an earlier draft of this comment
+    // claimed: the only Funnel config in the tree points at McpRemoteAccess's
+    // loopback listener on remoteMcpPort (mcptunnel_tsnet.cpp, started from
+    // McpRemoteAccess::startTunnel), never at this server's port. No
+    // Funnel-originated socket reaches m_clients.
+    //
+    // 64 is well above real use (a browser opens ~6 per host, plus the
+    // layout/theme/MCP SSE streams, times a few devices) and far below any
+    // descriptor limit.
+    static constexpr int MAX_CONNECTIONS = 64;
     static constexpr int KEEPALIVE_TIMEOUT_S = 30;                 // Close idle keep-alive connections after 30s
+    // Deadline for a socket that has sent nothing at all since being accepted.
+    // Deliberately the same as KEEPALIVE_TIMEOUT_S: a browser that pre-connects
+    // and then idles is treated the same before its first request as after its
+    // last one, and it simply reconnects. CONNECTION_TIMEOUT_MS above stays for
+    // anything with a request actually in flight.
+    static constexpr int SILENT_TIMEOUT_MS = KEEPALIVE_TIMEOUT_S * 1000;
     static constexpr int DISCOVERY_PORT = 8889;                    // UDP port for device discovery
     static constexpr int SESSION_LIFETIME_DAYS = 90;               // Auth session cookie lifetime
 };


### PR DESCRIPTION
Fixes #1773 — SIGABRT on an Android 15 tablet four days into a session, `FORTIFY: FD_SET: file descriptor 1027 >= FD_SETSIZE 1024`, inside `MdnsResolver::resolveHostname`.

## 1. `select()` cannot be used at all

Its `fd_set` is a fixed 1024-bit bitmap **indexed by descriptor number**, so `FD_SET()` on a descriptor >= `FD_SETSIZE` writes past the end of it. bionic's check is unconditional (the NDK header defines `FD_SET` as `__FD_SET_chk` and says "Use `<poll.h>` instead") and aborts; glibc only checks under `_FORTIFY_SOURCE` and Apple's libc not at all, so elsewhere it corrupts the stack silently. The log shows the four discovery sockets coming back as fds 1024-1027 moments before the abort.

All three loops now go through one `waitReadable()` helper on `poll()` / `WSAPoll`. It **normalises descriptor faults back to `-1`**: `poll()` reports `POLLNVAL` as a *ready* descriptor (`ret > 0`) where `select()` returned `-1`/`EBADF`, so a naive conversion leaves every caller's error arm unreachable — the browse reporting an empty network instead of an aborted one, and the resolve loop spinning at 100% for its full deadline calling `recvfrom()` on a dead socket. That matters here specifically: this ships to a process just shown to run out of descriptors.

## 2. Nothing should have been holding 1024 descriptors

`ShotServer` registered an accepted socket **nowhere** until its first `readyRead` — no `m_pendingRequests` entry, no keep-alive timer, no SSE-set membership — so the stale sweep could not see it and the descriptor was held until the peer closed, which a peer that has gone away never does. The server binds `QHostAddress::Any` and advertises over mDNS, so on a normal LAN that is a steady trickle from scanners, browser pre-connects and discovery agents.

- Idle clock starts at accept, with a separate **30 s** deadline for a socket that has sent nothing at all. The 5-minute deadline stays for requests in flight — otherwise 64 silent sockets wedge the server for five minutes.
- `MAX_CONNECTIONS = 64` fails closed, answering with a **503 + Retry-After** rather than a bare close (`ERR_EMPTY_RESPONSE` is indistinguishable from the app being dead or the port being wrong).
- The refusal logs the **transition**, not the event. One warning per refusal is one per SYN; the debug log is a bounded ring buffer that crash reports carry, so a flood would evict the fd evidence this same PR adds.

`McpRemoteAccess` already did accept-time registration, an idle reaper and a cap; this brings the LAN-facing server to the same standard.

## 3. Socket teardown is now one function

`retireSocket()` clears every container, then closes and deletes. `close()` is **not** guaranteed to emit `disconnected()` — three paths in `qabstractsocket.cpp` skip it (unconnected socket, pending write data, connecting/host-lookup), and those are exactly the states the dead-client checks select for. Each call site maintained that bookkeeping by hand and had already drifted; `broadcastSseEvent` was a file-static that couldn't reach `m_keepAliveTimers` at all, so it carried a precondition its callers upheld manually. It's a member now, and the SSE keepalive probe calls it instead of keeping a second copy of the same loop.

## 4. Removing the abort also removes the alarm

A descriptor leak that used to announce itself with a crash would now go quiet and resurface as sockets and files failing to open, far from the cause. A socket returning a number >= 512 logs one warning with `/proc/self/fd` grouped by kind — `socket=890, anon_inode=12` — naming the culprit's shape. A new descriptor is the lowest free one, so its number is a **lower bound** on how many are open; enough to catch this. Linux/Android only — on Windows the value is a kernel handle allocated in multiples of four and carries no such meaning.

This is the only diagnostic channel that reaches a user's device. No external fd tool does, and **LeakSanitizer tracks heap allocations only and cannot see a descriptor leak** — the nightly ASan job would never have flagged this.

`mdnsresolver.cpp` now logs through `NETWORK_*_STDERR` under the registered `[Network]` marker instead of a hand-typed `[MdnsResolver]` prefix, and is listed in `COVERED_GLOBS`. Pulling the `[Network]` story out of a submitted log previously returned everything about the WiFi scale except why its name would not resolve.

## Also

`withTempDb()` is exception-safe: `removeDatabase()` ran as a plain statement after the work block, so a throw escaping the callback would skip it. Scope guard now, declared before the `QSqlDatabase` so destruction order stays right.

## Correction to an earlier revision of this description

An earlier version claimed Tailscale Funnel exposed this server to the public internet and used that as the rationale for the cap. **That is wrong.** The only Funnel config in the tree points at `McpRemoteAccess`'s loopback listener on `remoteMcpPort`, never at port 8888, and no Funnel-originated socket reaches `m_clients`. The exposure is LAN-wide, which is enough to justify the limits but is a different argument. The comments have been corrected to say so, including a note recording the wrong claim so it isn't re-derived.

## Testing

Full suite via Qt Creator: **110 passed, 0 failed, 0 skipped**. Build clean (the one warning is the pre-existing `__eh_frame` linker note). `check_log_markers.py`, `check_test_source_duplication.py` and `check_mcp_tool_budget.py` all pass.

No new tests: the crash needs 1024 live descriptors, the sweep needs a 30 s/5 min timer, and the fd report needs `/proc`. I'd rather say that than add tests that cannot fail.

## Review

Three agents reviewed this; their findings are folded in. The `m_clients` dangling-pointer defect (would have made the server refuse *every* connection for the life of the process once 64 SSE clients died silently), the `POLLNVAL` conversion bug, the "0 descriptors" false report when `opendir` hits `EMFILE`, the unbounded refusal logging, and the Funnel misattribution above all came from that pass.

## Unrelated bug found in libtailscale, not fixed here

`listener.m[connFd] = netConn.RemoteAddr()` (tailscale.go:370) is written per accepted connection and never deleted — the nearby `delete(conns.m, fdC)` is a different map. `connFd` is closed moments later, so the numbers get reused and `TsnetGetRemoteAddr` can return a previous connection's address. Unbounded map growth plus misattribution. Does not affect us (we only use the funnel path, never `tailscale_listen`/`accept`), but worth filing against the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)