### PR TITLE
fix(visualizer): upload this shot's yield, not the previous shot's

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2237,6 +2237,47 @@ QString MainController::currentHotWaterSpecJson() const {
     return compactJson(o);
 }
 
+ShotMetadata MainController::buildShotMetadataFromSettings() const {
+    // Every field here is sticky DYE state that describes the SETUP — the bean,
+    // the grinder, the bag, the recipe — and is identical for a real shot and a
+    // simulated one. Per-shot measurements (beanWeight, drinkWeight) and
+    // per-shot provenance (yieldMode, yieldAnchorValue) are deliberately absent:
+    // each caller supplies them, so the reasoning about where a weight comes
+    // from stays next to the assignment. A third copy of this block lived in
+    // uploadPendingShot() until that dead method was deleted; centralizing is
+    // what stops the next copy drifting (CLAUDE.md, "Centralize anything
+    // produced at more than one site").
+    ShotMetadata metadata;
+    metadata.beanBrand = m_settings->dye()->dyeBeanBrand();
+    metadata.beanType = m_settings->dye()->dyeBeanType();
+    metadata.roastDate = m_settings->dye()->dyeRoastDate();
+    metadata.roastLevel = m_settings->dye()->dyeRoastLevel();
+    metadata.grinderBrand = m_settings->dye()->dyeGrinderBrand();
+    metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
+    metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
+    metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
+    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
+    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
+    metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
+    metadata.drinkEy = m_settings->dye()->dyeDrinkEy();
+    metadata.espressoNotes = m_settings->dye()->dyeShotNotes();
+    metadata.barista = m_settings->dye()->dyeBarista();
+    metadata.beanBaseJson = m_settings->dye()->dyeBeanBaseData();
+    // Coffee bag snapshot: which bag this shot was pulled with, and the
+    // beans' freeze lifecycle at shot time (bean-bag-inventory).
+    metadata.bagId = m_settings->dye()->activeBagId();
+    metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
+    metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
+    metadata.storageHint = m_settings->dye()->activeBagStorageHint();
+    metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
+    // Recipe provenance (add-recipes): the recipe active at shot time and
+    // the steam spec in effect, so promote-from-shot round-trips the drink.
+    metadata.recipeId = m_settings->dye()->activeRecipeId();
+    metadata.steamJson = currentSteamSpecJson();
+    metadata.hotWaterJson = currentHotWaterSpecJson();
+    return metadata;
+}
+
 void MainController::copyToClipboard(const QString& text) {
     auto* cb = QGuiApplication::clipboard();
     if (cb) {
@@ -3710,10 +3751,11 @@ void MainController::onShotEnded() {
     // Must run before stopCapture() so its debug output is included in the shot log.
     computeAutoFlowCalibration();
 
-    // Capture shot-end epoch now so uploads (including deferred pending uploads) use consistent time.
-    // Held in a local until after the discard branch so a dropped shot doesn't corrupt
-    // m_pendingShotEpoch / m_pendingDebugLog that may still belong to a prior unflushed shot
-    // (uploadPendingShot is gated on m_hasPendingShot, which the discard path doesn't touch).
+    // Shot-end epoch for the visualizer upload. A local captured by value into
+    // the save callback below, alongside duration/finalWeight/metadata/debugLog
+    // — so it describes THIS shot even if another shot ends while the save is
+    // still in flight. It was a member until the dead uploadPendingShot() that
+    // needed it across calls was removed.
     const qint64 pendingShotEpoch = QDateTime::currentSecsSinceEpoch();
 
     // Stop debug logging and get the captured log
@@ -3723,47 +3765,17 @@ void MainController::onShotEnded() {
         debugLog = m_shotDebugLogger->getCapturedLog();
     }
 
-    // Build metadata for history
-    ShotMetadata metadata;
-    metadata.beanBrand = m_settings->dye()->dyeBeanBrand();
-    metadata.beanType = m_settings->dye()->dyeBeanType();
-    metadata.roastDate = m_settings->dye()->dyeRoastDate();
-    metadata.roastLevel = m_settings->dye()->dyeRoastLevel();
-    metadata.grinderBrand = m_settings->dye()->dyeGrinderBrand();
-    metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
-    metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
-    metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
-    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
-    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
+    // Build metadata for history. The sticky DYE fields come from the shared
+    // helper; what follows is what only THIS shot can supply.
+    ShotMetadata metadata = buildShotMetadataFromSettings();
     metadata.beanWeight = m_settings->dye()->dyeBeanWeight();
-    // This shot's measured weight, NOT dyeDrinkWeight(): that setting still
-    // holds the PREVIOUS shot's yield, because it is only updated once this
-    // shot's save callback runs (setDyeDrinkWeight below). The auto-upload is
-    // issued from inside that same callback with this metadata copy, and
-    // VisualizerUploader prefers metadata.drinkWeight over the finalWeight
-    // argument, so the stale value won and every Visualizer upload reported
-    // the previous shot's yield. Fall back to the setting only when no scale
-    // gave us a weight, where the user-entered DYE value is the authority.
-    metadata.drinkWeight = finalWeight > 0 ? finalWeight : m_settings->dye()->dyeDrinkWeight();
-    metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
-    metadata.drinkEy = m_settings->dye()->dyeDrinkEy();
+    // The yield is NOT set here. It reaches the uploader as the finalWeight
+    // argument below — see ShotMetadata in visualizeruploader.h for why the
+    // struct deliberately has no drink-weight field.
+    //
     // No enjoyment: a just-pulled shot has not been tasted, so it saves
     // unrated (ShotMetadata defaults to 0). See settings_dye.h.
-    metadata.espressoNotes = m_settings->dye()->dyeShotNotes();
-    metadata.barista = m_settings->dye()->dyeBarista();
-    metadata.beanBaseJson = m_settings->dye()->dyeBeanBaseData();
-    // Coffee bag snapshot: which bag this shot was pulled with, and the
-    // beans' freeze lifecycle at shot time (bean-bag-inventory).
-    metadata.bagId = m_settings->dye()->activeBagId();
-    metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
-    metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
-    metadata.storageHint = m_settings->dye()->activeBagStorageHint();
-    metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
-    // Recipe provenance (add-recipes): the recipe active at shot time and
-    // the steam spec in effect, so promote-from-shot round-trips the drink.
-    metadata.recipeId = m_settings->dye()->activeRecipeId();
-    metadata.steamJson = currentSteamSpecJson();
-    metadata.hotWaterJson = currentHotWaterSpecJson();
+    //
     // Yield anchor provenance (add-yield-ratio-anchor): what was MEANT,
     // alongside the resolved grams in shotTargetWeight (what ran).
     metadata.yieldMode = shotYieldMode;
@@ -3805,11 +3817,6 @@ void MainController::onShotEnded() {
         }
     }
 
-    // Past the discard gate — commit the pending-shot snapshot used by uploadPendingShot()
-    // and the synchronous visualizer auto-upload below.
-    m_pendingShotEpoch = pendingShotEpoch;
-    m_pendingDebugLog = debugLog;
-
     // Always save shot to local history (async — DB work runs on background thread)
     qDebug() << "[metadata] Saving shot - shotHistory:" << (m_shotHistory ? "exists" : "null")
              << "isReady:" << (m_shotHistory ? m_shotHistory->isReady() : false);
@@ -3824,8 +3831,8 @@ void MainController::onShotEnded() {
 
             // Connect to shotSaved signal for completion (single-shot, auto-disconnects)
             connect(m_shotHistory, &ShotHistoryStorage::shotSaved, this,
-                    [this, finalWeight, shotDateTime, showPostShot,
-                     duration, doseWeight, metadata, debugLog](qint64 shotId) {
+                    [this, finalWeight, shotDateTime, showPostShot, duration,
+                     doseWeight, metadata, debugLog, pendingShotEpoch](qint64 shotId) {
                 m_savingShot = false;
 
                 if (shotId > 0) {
@@ -3854,7 +3861,7 @@ void MainController::onShotEnded() {
                         m_visualizer->uploadShot(
                             m_shotDataModel, m_profileManager->currentProfilePtr(),
                             duration, finalWeight, doseWeight, metadata, debugLog,
-                            m_pendingShotEpoch, shotId);
+                            pendingShotEpoch, shotId);
                     }
 
                     // Set shot date/time for display on metadata page
@@ -3987,91 +3994,14 @@ void MainController::onShotEnded() {
     // persisted to the right row from C++. Do NOT auto-upload here —
     // before save the id is unknown and the upload would orphan.
 
-    // Store pending shot data for later upload (user can re-upload with updated metadata)
     // Note: shotEndedShowMetadata is emitted from the shotSaved callback above,
     // after m_lastSavedShotId is set, so PostShotReviewPage gets a valid shot ID.
-    if (showPostShot) {
-        m_hasPendingShot = true;
-        m_pendingShotDuration = duration;
-        m_pendingShotFinalWeight = finalWeight;
-        m_pendingShotDoseWeight = doseWeight;
+    if (showPostShot)
         qDebug() << "  -> Will show metadata page after shot is saved";
-    }
 
     // Reset extraction flag so that subsequent Steam/HotWater/Flush operations
     // don't incorrectly trigger shot metadata page or upload
     m_extractionStarted = false;
-}
-
-void MainController::uploadPendingShot() {
-    if (!m_hasPendingShot || !m_settings || !m_shotDataModel || !m_visualizer) {
-        qDebug() << "MainController: No pending shot to upload";
-        return;
-    }
-
-    // Build metadata from current settings
-    ShotMetadata metadata;
-    metadata.beanBrand = m_settings->dye()->dyeBeanBrand();
-    metadata.beanType = m_settings->dye()->dyeBeanType();
-    metadata.roastDate = m_settings->dye()->dyeRoastDate();
-    metadata.roastLevel = m_settings->dye()->dyeRoastLevel();
-    metadata.grinderBrand = m_settings->dye()->dyeGrinderBrand();
-    metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
-    metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
-    metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
-    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
-    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
-    metadata.beanWeight = m_settings->dye()->dyeBeanWeight();
-    metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
-    metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
-    metadata.drinkEy = m_settings->dye()->dyeDrinkEy();
-    // Unrated on save — see the espresso path above.
-    metadata.barista = m_settings->dye()->dyeBarista();
-    metadata.beanBaseJson = m_settings->dye()->dyeBeanBaseData();
-    metadata.bagId = m_settings->dye()->activeBagId();
-    metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
-    metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
-    metadata.storageHint = m_settings->dye()->activeBagStorageHint();
-    metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
-    // Recipe provenance (add-recipes): the recipe active at shot time and
-    // the steam spec in effect, so promote-from-shot round-trips the drink.
-    metadata.recipeId = m_settings->dye()->activeRecipeId();
-    metadata.steamJson = currentSteamSpecJson();
-    metadata.hotWaterJson = currentHotWaterSpecJson();
-
-    // Build notes: user notes + AI recommendation (if any)
-    QString notes = m_settings->dye()->dyeShotNotes();
-    if (m_aiManager && !m_aiManager->lastRecommendation().isEmpty()) {
-        QString aiRec = m_aiManager->lastRecommendation();
-        QString provider = m_aiManager->selectedProvider();
-        QString providerName = provider;
-        if (provider == "openai") providerName = "OpenAI GPT-4o";
-        else if (provider == "anthropic") providerName = "Anthropic Claude";
-        else if (provider == "gemini") providerName = "Google Gemini";
-        else if (provider == "ollama") providerName = "Ollama";
-
-        if (!notes.isEmpty()) {
-            notes += "\n\n---\n\n";
-        }
-        notes += aiRec + "\n\n---\nAdvice by " + providerName;
-    }
-    metadata.espressoNotes = notes;
-
-    qDebug() << "MainController: Uploading pending shot with metadata -"
-             << "Profile:" << m_profileManager->currentProfile().title()
-             << "Duration:" << m_pendingShotDuration << "s"
-             << "Bean:" << metadata.beanBrand << metadata.beanType;
-
-    // Manual re-upload of the just-finished shot: by now the shot is
-    // saved and m_lastSavedShotId holds its row id, so the link is
-    // persisted from C++ via uploadSucceededForShot.
-    m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(),
-                             m_pendingShotDuration, m_pendingShotFinalWeight,
-                             m_pendingShotDoseWeight, metadata, m_pendingDebugLog,
-                             m_pendingShotEpoch, m_lastSavedShotId);
-
-    m_hasPendingShot = false;
-    m_pendingDebugLog.clear();
 }
 
 void MainController::generateFakeShotData() {
@@ -4158,11 +4088,10 @@ void MainController::generateFakeShotData() {
     m_shotDataModel->addPhaseMarker(preinfusionEnd, "Extraction", 1, false);
     m_shotDataModel->addPhaseMarker(steadyEnd, "Ending", 3, false);
 
-    // Set up pending shot state
-    m_hasPendingShot = true;
-    m_pendingShotDuration = totalDuration;
-    m_pendingShotFinalWeight = 40.0;
-    m_pendingShotDoseWeight = 18.0;
+    // The simulated shot's weights, read by the save block below. Locals, not
+    // members: nothing outside this call needs them.
+    const double simulatedFinalWeight = 40.0;
+    const double simulatedDoseWeight = 18.0;
 
     qDebug() << "DEV: Generated" << numSamples << "fake samples";
 
@@ -4173,42 +4102,16 @@ void MainController::generateFakeShotData() {
         } else {
             m_savingShot = true;
 
-            ShotMetadata metadata;
-            metadata.beanBrand = m_settings->dye()->dyeBeanBrand();
-            metadata.beanType = m_settings->dye()->dyeBeanType();
-            metadata.roastDate = m_settings->dye()->dyeRoastDate();
-            metadata.roastLevel = m_settings->dye()->dyeRoastLevel();
-            metadata.grinderBrand = m_settings->dye()->dyeGrinderBrand();
-            metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
-            metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
-            metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
-            metadata.equipmentId = m_settings->dye()->activeEquipmentId();
-            metadata.rpm = m_settings->dye()->dyeGrinderRpm();
-            metadata.beanWeight = m_pendingShotDoseWeight;
-            // This shot's weight, not the previous shot's — same reason as the
-            // real espresso path above.
-            metadata.drinkWeight = m_pendingShotFinalWeight;
-            metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
-            metadata.drinkEy = m_settings->dye()->dyeDrinkEy();
-            // Unrated on save — see the espresso path above.
-            metadata.espressoNotes = m_settings->dye()->dyeShotNotes();
-            metadata.barista = m_settings->dye()->dyeBarista();
-            metadata.beanBaseJson = m_settings->dye()->dyeBeanBaseData();
-            metadata.bagId = m_settings->dye()->activeBagId();
-            metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
-            metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
-            metadata.storageHint = m_settings->dye()->activeBagStorageHint();
-            metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
-            metadata.recipeId = m_settings->dye()->activeRecipeId();
-            metadata.steamJson = currentSteamSpecJson();
-            metadata.hotWaterJson = currentHotWaterSpecJson();
+            // Same sticky DYE metadata a real shot records; only the dose is
+            // per-shot here. The yield goes to saveShot() as an argument.
+            ShotMetadata metadata = buildShotMetadataFromSettings();
+            metadata.beanWeight = simulatedDoseWeight;
 
             // Use current profile's temperature and target weight as overrides
             double temperatureOverride = m_profileManager->currentProfile().espressoTemperature();
             double targetWeight = m_profileManager->currentProfile().targetWeight();
 
-            double pendingFinalWeight = m_pendingShotFinalWeight;
-            connect(m_shotHistory, &ShotHistoryStorage::shotSaved, this, [this, pendingFinalWeight](qint64 shotId) {
+            connect(m_shotHistory, &ShotHistoryStorage::shotSaved, this, [this](qint64 shotId) {
                 m_savingShot = false;
 
                 if (shotId > 0) {
@@ -4216,8 +4119,12 @@ void MainController::generateFakeShotData() {
                     m_lastSavedShotId = shotId;
                     emit lastSavedShotIdChanged();
 
-                    // Update drink weight
-                    m_settings->dye()->setDyeDrinkWeight(pendingFinalWeight);
+                    // Deliberately NOT setDyeDrinkWeight() here, unlike the real
+                    // espresso path: this shot's weight is invented, and that
+                    // setting is real persisted user data — written from the
+                    // review page (PostShotReviewPage.qml:844), carried in the
+                    // settings transfer, and readable over MCP. A dev gesture
+                    // should not plant a made-up yield in it.
 
                     // Reset shot-specific metadata for next shot
                     m_settings->dye()->setDyeShotNotes("");
@@ -4231,7 +4138,7 @@ void MainController::generateFakeShotData() {
 
             m_shotHistory->saveShot(
                 m_shotDataModel, m_profileManager->currentProfilePtr(),
-                totalDuration, m_pendingShotFinalWeight, m_pendingShotDoseWeight,
+                totalDuration, simulatedFinalWeight, simulatedDoseWeight,
                 metadata, "[Simulated shot]",
                 temperatureOverride, targetWeight);
         }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -3736,7 +3736,15 @@ void MainController::onShotEnded() {
     metadata.equipmentId = m_settings->dye()->activeEquipmentId();
     metadata.rpm = m_settings->dye()->dyeGrinderRpm();
     metadata.beanWeight = m_settings->dye()->dyeBeanWeight();
-    metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
+    // This shot's measured weight, NOT dyeDrinkWeight(): that setting still
+    // holds the PREVIOUS shot's yield, because it is only updated once this
+    // shot's save callback runs (setDyeDrinkWeight below). The auto-upload is
+    // issued from inside that same callback with this metadata copy, and
+    // VisualizerUploader prefers metadata.drinkWeight over the finalWeight
+    // argument, so the stale value won and every Visualizer upload reported
+    // the previous shot's yield. Fall back to the setting only when no scale
+    // gave us a weight, where the user-entered DYE value is the authority.
+    metadata.drinkWeight = finalWeight > 0 ? finalWeight : m_settings->dye()->dyeDrinkWeight();
     metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
     metadata.drinkEy = m_settings->dye()->dyeDrinkEy();
     // No enjoyment: a just-pulled shot has not been tasted, so it saves
@@ -4177,7 +4185,9 @@ void MainController::generateFakeShotData() {
             metadata.equipmentId = m_settings->dye()->activeEquipmentId();
             metadata.rpm = m_settings->dye()->dyeGrinderRpm();
             metadata.beanWeight = m_pendingShotDoseWeight;
-            metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
+            // This shot's weight, not the previous shot's — same reason as the
+            // real espresso path above.
+            metadata.drinkWeight = m_pendingShotFinalWeight;
             metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
             metadata.drinkEy = m_settings->dye()->dyeDrinkEy();
             // Unrated on save — see the espresso path above.

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -342,6 +342,10 @@ public:
     // every saved shot and used by the composer to prefill promote-from-shot.
     QString currentHotWaterSpecJson() const;
 
+    // Sticky DYE metadata shared by the real and simulated shot-save paths.
+    // Callers add the per-shot fields (weights, yield provenance) themselves.
+    ShotMetadata buildShotMetadataFromSettings() const;
+
     // Clipboard
     Q_INVOKABLE void copyToClipboard(const QString& text);
     Q_INVOKABLE QString pasteFromClipboard() const;
@@ -440,9 +444,6 @@ public slots:
     void onEspressoCycleStarted();
     void onShotEnded();
     void onScaleWeightChanged(double weight);  // Called by scale weight updates
-
-    // DYE: upload pending shot with current metadata from Settings
-    Q_INVOKABLE void uploadPendingShot();
 
     // Developer mode: generate fake shot data for testing UI
     Q_INVOKABLE void generateFakeShotData();
@@ -672,13 +673,6 @@ private:
 
     QTimer m_heaterTweaksTimer;  // Debounce slider changes before sending MMR writes
 
-    // DYE: pending shot data for delayed upload
-    bool m_hasPendingShot = false;
-    double m_pendingShotDuration = 0;
-    double m_pendingShotFinalWeight = 0;
-    double m_pendingShotDoseWeight = 0;
-    qint64 m_pendingShotEpoch = 0;
-    QString m_pendingDebugLog;
     qint64 m_lastSavedShotId = 0;  // ID of most recently saved shot (for post-shot review)
     bool m_savingShot = false;     // Guard against overlapping async saves
 

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -33,6 +33,18 @@ class EquipmentStorage;
 // which is exactly what stopped being true for enjoyment once a *setting* fed
 // it. If anything ever feeds those fields automatically, they become this bug.
 //
+// dyeDrinkWeight is the field that already failed that test, and it is worth
+// naming here rather than leaving the list looking complete. It is written
+// automatically after every shot (setDyeDrinkWeight in MainController's save
+// callback), so it always holds a yield belonging to some earlier shot. It was
+// read at metadata-build time and shipped to Visualizer, which reported the
+// PREVIOUS shot's yield while the app displayed the correct one. The fix was
+// not to reset it more carefully but to stop a per-shot measurement travelling
+// through sticky state at all: ShotMetadata no longer carries a drink weight,
+// and the yield reaches the uploader only as an explicit argument. The setting
+// survives because the review page and MCP still legitimately read and write
+// it — but nothing on a save path may read it again.
+//
 // Bean model (bean-bag-inventory): the active coffee bag IS the bean state.
 // The dye/* QSettings keys act as a synchronous write-through cache of the
 // active bag — selecting a bag copies its fields in (applyActiveBag), and

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -962,10 +962,17 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
     }
     meta["grinder"] = grinder;
 
-    // Weights
+    // Weights. beanWeight keeps its metadata-first resolution: the dose is
+    // user-entered (dyeBeanWeight) and the doseWeight argument is a fallback
+    // the caller derives from the profile when that setting is unset, so the
+    // two genuinely differ.
     double beanWeight = metadata.beanWeight > 0 ? metadata.beanWeight : doseWeight;
-    // Use user-entered weight first, then scale weight, then app's flow-integrated volume (ml ≈ g for espresso)
-    double drinkWeight = metadata.drinkWeight > 0 ? metadata.drinkWeight : finalWeight;
+    // The yield takes the measured argument directly. ShotMetadata carries no
+    // drink weight: it used to, and preferring that field over this argument
+    // is what let a sticky setting holding the PREVIOUS shot's yield reach
+    // Visualizer while the app showed the right number. A per-shot measurement
+    // has one source, and it is this parameter.
+    double drinkWeight = finalWeight;
     if (drinkWeight <= 0) {
         const auto& wdData = shotData->waterDispensedData();
         if (!wdData.isEmpty())

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -38,7 +38,11 @@ struct ShotMetadata {
     qint64 equipmentId = 0; // Equipment package (add-equipment-packages); 0 = none
     qint64 rpm = 0;         // Grinder rpm dial-in; 0 = unset
     double beanWeight = 0;  // Dose weight in grams
-    double drinkWeight = 0; // Output weight in grams
+    // No drinkWeight here on purpose. The yield is a per-shot MEASUREMENT, and
+    // it already travels as an explicit argument to uploadShot()/buildShotJson().
+    // Carrying a second copy in this struct — which is otherwise sticky setup
+    // state that outlives a shot — is what let the previous shot's yield reach
+    // Visualizer. One source only.
     double drinkTds = 0;
     double drinkEy = 0;
     int espressoEnjoyment = 0;  // 0-100
@@ -348,7 +352,7 @@ private:
     QString m_lastShotUrl;
     // The local shots.id the in-flight upload is for; emitted with
     // uploadSucceededForShot. A single member suffices because callers
-    // (MainController shot-end, manual re-upload, history re-upload) are
+    // (MainController shot-end, history re-upload) are
     // mutually exclusive in practice and never issue overlapping
     // uploads. NOTE: m_uploading is a UI state flag, NOT a concurrency
     // guard — nothing rejects a second uploadShot() while one is in


### PR DESCRIPTION
## Reported

Two users, one root cause.

**Report 1** — a shot the app correctly shows as 15.0 g → 45.4 g appears on Visualizer as 15.0 g → 60.1 g. 60.1 g was the *previous* shot's yield. The uploaded weight lags one shot behind.

**Report 2** — adding notes to an already-uploaded shot and re-uploading fixes the displayed weight, but the shot's metadata still reads back the previous shot's number.

## Cause

`MainController::onShotEnded()` copied `ShotMetadata::drinkWeight` from the sticky DYE setting `dyeDrinkWeight()`. That setting is only updated to *this* shot's weight inside the save callback — and the Visualizer auto-upload fires from that same callback, eleven lines earlier, carrying metadata built before the shot was saved. `buildShotJson` then preferred `metadata.drinkWeight` over the measured `finalWeight` argument it was also handed, so the stale value won.

Swapping recipes is not the trigger — it only makes the wrong number visible, because consecutive yields then differ. Someone pulling the same yield every time would never notice.

The local database was never affected: `saveShot()` ignores that field and stores the measured `finalWeight`. That is why the app showed the right number and Visualizer did not.

Report 2 is the same bug with its display half repaired. Re-upload is a PATCH built from the stored row, so the displayed weight corrects itself; the original uploaded `.shot` blob keeps the stale number in `app.data.settings.drink_weight`, and that blob is what an AI reading the shot back sees.

## Fix

`ShotMetadata` no longer carries a drink weight at all.

The yield is a per-shot **measurement** and already travels as an explicit argument to `uploadShot()`/`buildShotJson()`. Carrying a second copy inside a struct that is otherwise sticky *setup* state — bean, grinder, bag, recipe — is what let one shot's yield reach Visualizer under another shot's name. `buildShotJson` now reads its `finalWeight` argument directly, and the bug is structurally unavailable rather than corrected at one call site.

`beanWeight` deliberately keeps its metadata-first resolution. The dose setting and the `doseWeight` argument genuinely differ — the caller derives a profile fallback for it — so that ternary does real work.

An intermediate version of this branch fixed only the assignment, keeping `finalWeight > 0 ? finalWeight : dyeDrinkWeight()`. Review caught that the fallback reinstated the stale value whenever `finalWeight` was 0, and — by making the field non-zero — also suppressed the uploader's own flow-integrated fallback. Its comment was wrong twice over besides. That history is in the commits.

## Also in this PR

All downstream of the same investigation:

- **Deleted `MainController::uploadPendingShot()`** — `Q_INVOKABLE`, no caller anywhere, wired to QML twice historically and unwired for good in `4f578544`. It carried its own copy of the metadata block and the same stale read. Three review agents mistook it for the live manual re-upload path and reasoned from that, which is the cost of leaving it. Its members go with it; the shot-end epoch becomes a by-value lambda capture like every other value the save callback uses.
- **Extracted `buildShotMetadataFromSettings()`** — 23 sticky DYE assignments were duplicated across the real and simulated shot paths, with a third copy in the deleted method.
- **The dev simulated-shot gesture no longer calls `setDyeDrinkWeight()`** — it was planting an invented 40 g in real persisted user data.
- **Recorded the miss in `settings_dye.h`** — that comment already stated the test a sticky DYE field must pass ("if anything ever feeds those fields automatically, they become this bug") and listed the tolerated fields without naming `dyeDrinkWeight`, which fails it on every shot. The list read as complete when it was not.

## User-visible effect

Automatic uploads report the shot just pulled. When no weight source produces a number, the upload carries the flow-integrated volume or no weight field, instead of the previous shot's yield stated as fact.

Shots already uploaded keep the stale value inside their original blob. Re-uploading fixes what Visualizer displays but not that embedded copy — no migration, consistent with #1573's precedent for the identical bug shape on `dyeEspressoEnjoyment`.

No wiki manual entry: this restores intended behaviour rather than adding or changing a feature.

## Testing

Build clean, full suite green locally through Qt Creator: 110 passed, 0 failed, 0 warnings.

No new test. The changed logic is an ordering/ownership property of `MainController::onShotEnded()`, which has no test harness — standing one up needs BLE, settings and storage. `buildShotJson` is private with no testing seam, unlike its `public static` siblings. Called out rather than papered over with a test that asserts something easier. The structural fix is what prevents recurrence here: the field a stale value travelled through no longer exists.

Neither report has a GitHub issue, so this closes nothing.