### PR TITLE
fix(update): stop inventing a build number when release notes lack one

### DIFF
--- a/docs/CLAUDE_MD/CI_CD.md
+++ b/docs/CLAUDE_MD/CI_CD.md
@@ -212,8 +212,8 @@ EOF
 
 ### Auto-Update System
 - **Check interval**: Every 60 minutes (configurable in Settings → Updates)
-- **Version detection**: Compares display version (`X.Y.Z`), then falls back to build number if versions are equal
-- **Build number source**: Parsed from release notes using pattern `Build: XXXX` (or `Build XXXX`)
+- **Version detection**: Compares display version (`X.Y.Z`) first, then build number when the versions are equal. **Equal is the normal case, not the edge case** — the display version rolls, so a dozen builds can ship under one `vX.Y.Z` and each gets its own build number. `v2.0.3` covered builds 3533, 3534 and 3535 in three days. For those, the build number is the only thing that distinguishes a new release from the running one.
+- **Build number source**: Parsed from release notes using pattern `Build: XXXX` (or `Build XXXX`). Notes carrying no such line mean **no build number**, and the check goes blind until the next poll rather than guessing one — there is nowhere else to read it from. The tag and the asset filename both carry the display version (`v2.0.3`, `Decenza_2.0.3.apk`), which has no relation to `versioncode.txt`. Only `android-release.yml` writes the line, so the blind window spans the tag push to that job finishing — once per build, and a release gets many beta builds.
 - **Beta channel**: Users opt-in via Settings → Updates → "Beta updates". Prereleases are only shown to opted-in users.
 - **Platforms**: Android auto-downloads APK; iOS directs to App Store; desktop shows release page
 

--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -475,9 +475,13 @@ Item {
                                 text: {
                                     if (MainController.updateChecker.updateAvailable) {
                                         var betaTag = MainController.updateChecker.latestIsBeta ? " (Beta)" : ""
+                                        // 0 means the release notes state no build number, so there is
+                                        // none to show — printing "(Build 0)" would read as a real one.
+                                        var buildTag = MainController.updateChecker.latestVersionCode > 0
+                                                     ? " (Build " + MainController.updateChecker.latestVersionCode + ")"
+                                                     : ""
                                         var msg = TranslationManager.translate("settings.update.updateavailable", "Update available:") +
-                                               " v" + MainController.updateChecker.latestVersion + betaTag +
-                                               " (Build " + MainController.updateChecker.latestVersionCode + ")"
+                                               " v" + MainController.updateChecker.latestVersion + betaTag + buildTag
                                         // Add platform-specific note for iOS
                                         if (Qt.platform.os === "ios") {
                                             msg += "\n" + TranslationManager.translate("settings.update.appstoreupdate", "Update via App Store")

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -339,15 +339,34 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
     bool wasBeta = m_latestIsBeta;
     m_latestIsBeta = release["prerelease"].toBool();
 
-    // Extract build number from release notes (look for "Build: XXXX" or "Build XXXX")
+    // Extract build number from release notes (look for "Build: XXXX" or "Build XXXX").
+    //
+    // This number, not the display version, is what identifies a release in
+    // practice. The display version rolls: v2.0.3 stayed put across builds 3533,
+    // 3534 and 3535 in three days, so isNewerVersion() below reports "not newer"
+    // for every one of them and the build-number comparison is the ONLY thing
+    // that can see a new build. Treat it as the primary signal that it is.
+    //
+    // Which is why 0 has to mean "this release states no build number" and not a
+    // guess. There is nowhere else to read one from: the tag and the asset
+    // filename both carry the display version (v2.0.3, Decenza_2.0.3.apk), which
+    // has no relation to versioncode.txt. A previous fallback took the tag's
+    // patch component and returned it as a build number, so a field log shows
+    // `latestBuild= 3` for v2.0.3 — and 3 > 3535 is false, so a device on the
+    // rolling version was told it was up to date for the whole window. A wrong
+    // number is worse than none here, because none is filtered by the `> 0` guard
+    // at the comparison and simply leaves the check blind until the next poll.
+    //
+    // The window is bounded — only android-release.yml writes the line, so it
+    // spans the tag push to that job finishing — but it is not rare. A release
+    // gets many beta builds, each a force-pushed tag with its own build number,
+    // so an opted-in beta device passes through this window once per build. See
+    // CI_CD.md.
     int newBuildNumber = 0;
     QRegularExpression buildRe(R"(Build[:\s]+(\d+))", QRegularExpression::CaseInsensitiveOption);
     QRegularExpressionMatch buildMatch = buildRe.match(body);
     if (buildMatch.hasMatch()) {
         newBuildNumber = buildMatch.captured(1).toInt();
-    } else {
-        // Fallback: extract from APK filename pattern (Decenza_X.Y.Z.apk where Z might be build)
-        newBuildNumber = extractBuildNumber(tagName);
     }
 
     // Reset prompt flag when a new release OR a new build of the same tag is
@@ -405,11 +424,13 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
     }
 #endif
 
-    // Check if update is available using display version comparison,
-    // falling back to build number if versions are equal
+    // Compare the display version first, then the build number when the display
+    // versions are equal — which is the ordinary case, not a fallback: many beta
+    // builds ship under one vX.Y.Z and only the build number separates them.
+    // A build number of 0 means the release states none (see above), so the
+    // comparison is skipped rather than run against a guess.
     bool newer = isNewerVersion(m_latestVersion, currentVersion());
     if (!newer && !isNewerVersion(currentVersion(), m_latestVersion) && m_latestBuildNumber > 0) {
-        // Same display version — compare build numbers (strictly greater)
         newer = m_latestBuildNumber > currentVersionCode();
     }
 
@@ -466,17 +487,6 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
             }
         }
     }
-}
-
-int UpdateChecker::extractBuildNumber(const QString& version) const
-{
-    // Match patterns like "v1.0.123" or "1.0.123"
-    QRegularExpression re(R"((\d+)\.(\d+)\.(\d+))");
-    QRegularExpressionMatch match = re.match(version);
-    if (match.hasMatch()) {
-        return match.captured(3).toInt();
-    }
-    return 0;
 }
 
 bool UpdateChecker::isNewerVersion(const QString& latest, const QString& current) const

--- a/src/core/updatechecker.h
+++ b/src/core/updatechecker.h
@@ -157,7 +157,6 @@ private:
     void parseReleaseInfo(const QByteArray& data);
     void startDownload();
     bool installApk(const QString& apkPath);
-    int extractBuildNumber(const QString& version) const;
     bool isNewerVersion(const QString& latest, const QString& current) const;
 
     // Translate a user-visible string via the injected TranslationManager,

--- a/tests/tst_updatechecker.cpp
+++ b/tests/tst_updatechecker.cpp
@@ -52,6 +52,7 @@ private slots:
     void releaseInfoRequestDropsConnectionImmediately();
     void releaseInfoRequestCarriesGithubHeaders();
     void theCheckPathIssuesTheSharedRequest();
+    void notesWithoutABuildNumberYieldNoBuildNumber();
 
 private:
     // UpdateChecker's constructor dereferences Settings::app() to read
@@ -115,6 +116,63 @@ void tst_UpdateChecker::theCheckPathIssuesTheSharedRequest()
     // QTEST_MAIN as well as guiless, both tried. Re-inlining THAT site would slip
     // past this suite; it is one line calling the same helper, and the attribute
     // assertions above still pin what the helper produces.
+}
+
+void tst_UpdateChecker::notesWithoutABuildNumberYieldNoBuildNumber()
+{
+    // The build number is what identifies a release: the display version rolls,
+    // so many builds ship under one vX.Y.Z and only the build number separates
+    // them. CI publishes the release before it writes "Build: NNNN" into the
+    // notes, so this no-build-number shape is served to every polling device for
+    // that window. The old code read the tag's patch component and reported it as
+    // the build number — `latestBuild= 3` for v2.0.3 in the field log quoted in
+    // UpdateChecker::parseReleaseInfo. Devices on the rolling version compare
+    // that against their own version code (3 > 3535 is false) and are told they
+    // are up to date, which is the one answer that cannot self-correct into a
+    // download.
+    //
+    // The tag deliberately carries a nonzero patch (.7): the defect is invisible
+    // against a .0 tag, and the app's own version — whatever it is when this runs
+    // — may well be one.
+    Settings settings;
+    QNetworkAccessManager nam;
+    UpdateChecker checker(&nam, &settings);
+
+    // Assets are present and platform-appropriate on purpose: an assetless
+    // release is a different branch that qWarns, and init()'s failOnWarning()
+    // would fail this test for the wrong reason on Android and macOS builds.
+    const QByteArray releases = R"([{
+        "tag_name": "v9.9.7",
+        "draft": false,
+        "prerelease": false,
+        "body": "Notes that do not state a build number.",
+        "assets": [
+            {"name": "Decenza_9.9.7.apk", "browser_download_url": "https://example.invalid/a.apk"},
+            {"name": "Decenza_9.9.7.dmg", "browser_download_url": "https://example.invalid/a.dmg"}
+        ]
+    }])";
+
+    checker.parseReleaseInfo(releases);
+
+    QCOMPARE(checker.latestVersion(), QStringLiteral("9.9.7"));
+    QCOMPARE(checker.latestVersionCode(), 0);
+
+    // And the number IS read when the notes carry one, so the assertion above
+    // cannot be satisfied by never parsing at all.
+    const QByteArray withBuild = R"([{
+        "tag_name": "v9.9.7",
+        "draft": false,
+        "prerelease": false,
+        "body": "Changes here.\nBuild: 4242\n",
+        "assets": [
+            {"name": "Decenza_9.9.7.apk", "browser_download_url": "https://example.invalid/a.apk"},
+            {"name": "Decenza_9.9.7.dmg", "browser_download_url": "https://example.invalid/a.dmg"}
+        ]
+    }])";
+
+    checker.parseReleaseInfo(withBuild);
+
+    QCOMPARE(checker.latestVersionCode(), 4242);
 }
 
 QTEST_GUILESS_MAIN(tst_UpdateChecker)


### PR DESCRIPTION
## The defect

`UpdateChecker` fell back to `extractBuildNumber(tagName)` whenever a release's notes carried no `Build: NNNN` line. That helper returned the tag's **patch component** — a display-version digit with no relation to `versioncode.txt`. For `v2.0.3` it returned `3`.

Found in a field log from the tablet (2.0.3, build 3534):

```
UpdateChecker: release "v2.0.3" found but no platform asset available
UpdateChecker: current= "2.0.2" build= 3531 latest= "2.0.3" latestBuild= 3 newer= true tag= "v2.0.3"
```

## Why it matters more than it looks

The equal-display-version comparison is the **operative** one, not a fallback. The display version rolls: `v2.0.3` covered builds 3533, 3534 and 3535 in three days, and a release gets many beta builds. For all of them `isNewerVersion()` says "not newer" and the build number is the only thing that can see a new build.

So a device on the rolling version compares the invented `3` against its own version code — `3 > 3535` is false — and is told it is **up to date** when it isn't.

Only `android-release.yml` writes the `Build:` line, so every polling device passes through a window where the release exists and the line does not. Once per build.

## The fix

There is nowhere else to read a build number from — the tag and the asset filename both carry the display version (`v2.0.3`, `Decenza_2.0.3.apk`). So report none. `0` is filtered by the existing `m_latestBuildNumber > 0` guard, which leaves the check blind for that window rather than asserting a false "up to date"; the next hourly poll resolves it. A wrong number is worse than none.

`extractBuildNumber()` had this as its only caller and is deleted rather than made to return 0.

Also in this change:
- Settings → Updates suppresses `(Build 0)` instead of printing a build number that does not exist.
- Corrected the `CI_CD.md` and in-code descriptions, which called the build number a fallback for when versions are equal. Equal is the ordinary case, and the build number is what identifies a release.

## Not changed

During the blind window the app still says "You're up to date" to a device that isn't — same as before this change, which reached that message via a fake number instead of a missing one. Distinguishing "no newer build" from "can't tell yet" needs a separate UI state and is a feature, not part of this fix.

## Verification

- Full suite **110/110**, 0 warnings (`run_tests` scope `all`).
- qmllint **232/232 clean** with the patched macOS binary, `CustomItem.qml` included.
- New test watched failing before it was kept: asserting the old value reported `Actual (checker.latestVersionCode()): 0` against `Expected (7): 7`, proving the slot executes and the assertion discriminates. It uses a `.7` patch deliberately — a `.0` tag would have passed against the old code too.
- Test slot added to the existing `tst_updatechecker.cpp` rather than a new file, so it costs milliseconds of build rather than ~1.4 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)