### PR TITLE
feat(firmware): allow same-version reflash, add flash-path diagnostics

### DIFF
--- a/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
+++ b/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
@@ -67,7 +67,17 @@ Decent's own update CDN, the same host Tcl de1app uses. Two channels:
 
 Decent's own `de1beta` channel is not wired — in practice it has not been updated reliably for a long time and tracks stable. Switching channels via the toggle wipes the local cache so the next check contacts the new endpoint fresh.
 
-**Downgrades are allowed**, matching de1app. If the remote firmware on the selected channel is *older* than what's on the DE1 (e.g. you flip nightly → stable after having flashed a nightly build), the Firmware tab labels the action as "Downgrade now" and shows a yellow strip with both the installed and the available version. `FirmwareUpdater::isDowngrade` exposes this to QML. The three-phase flash procedure is direction-agnostic: it writes whatever's in the cached `.dat`. The equality-only pre-flight guard at the start of Phase 1 only short-circuits when installed == downloaded.
+**There is no version gate at all**, matching de1app — every version check in its `start_firmware_update` (`de1_comms.tcl:884-895`) is commented out, so its button flashes whatever is in `bootfwupdate.dat` regardless of what the machine reports. Decenza does the same and labels the action instead of blocking it:
+
+| Remote vs installed | Button | Strip |
+|---|---|---|
+| Newer | "Update now" | — |
+| Older | "Downgrade now" | yellow: rolls the DE1 back |
+| Same | "Reflash" | yellow: already on this version |
+
+`FirmwareUpdater::isDowngrade` and `::isReflash` expose this to QML; the button's only requirement is `availableVersion > 0` (a check has succeeded). The three-phase flash is direction-agnostic — it writes whatever's in the cached `.dat`.
+
+Re-flashing the same build used to short-circuit to `Succeeded` without writing anything. That made the one case that most needs a flash unreachable: a bank that verified but did not take, leaving the DE1 running the old image while reporting the new build. It is also safe for the same reason a failed update is — the write lands in the inactive bank.
 
 The downloaded file is cached at `QStandardPaths::AppDataLocation/firmware/bootfwupdate.dat` with a sidecar `.meta.json` storing `{etag, version, downloadedAtEpoch}`. A subsequent check returns `304 Not Modified` from the CDN when the ETag hasn't changed, and we don't re-download.
 
@@ -77,7 +87,13 @@ Only `BoardMarker == 0xDE100001` (offset 4 of the 64-byte header) and the on-dis
 
 ## What gets logged
 
-Every state transition, upload-progress heartbeat (every 5 %), and failure goes through `qCDebug`/`qCWarning` with the `decenza.firmware` Qt logging category and the `[firmware]` prefix. Milestone lines carry a `[+MM:SS.ms]` elapsed prefix from the moment `startUpdate` was tapped, so the log trail tells you exactly how long each phase took.
+Every state transition, upload-progress heartbeat (every 5 %), and failure goes through `qCDebug`/`qCWarning` with the `decenza.firmware` Qt logging category and the `[firmware]` prefix.
+
+Three lines exist specifically because the failure they diagnose is invisible without them:
+
+- `[firmware] payload: <n> bytes sha256=… version=… byteCount=… cpuBytes=…` — logged in `loadCachedPayload()`, immediately before the first chunk. `validateFile()` checks only BoardMarker (offset 4) and a size floor, so a `.dat` assembled from two revisions by the cache's Range-resume path passes validation unchanged; the digest is the only thing that catches it. Compare against the CDN file for the active channel.
+- `[firmware] downloadIfNeeded: … existingBytes=… metaVersion=… metaEtag=…` and `using cached file without download: …` — whether we resumed onto an existing file, and whether we skipped the server entirely.
+- `A009 parsed: windowIncrement=… erase=… map=… firstError=…` (`[Firmware]` tag, `de1device.cpp`) — `WindowIncrement` is decoded but not carried on the `fwMapResponse` signal. It is what separates a terminal verify verdict from an in-progress notification: reaprime/decaid accepts a verify response only when `WindowIncrement == 0`, while we accept the first notification of any shape. A non-zero value on the notification that produced "Verification failed at block A.B.C" means that address is a cursor, not a corrupt block. Milestone lines carry a `[+MM:SS.ms]` elapsed prefix from the moment `startUpdate` was tapped, so the log trail tells you exactly how long each phase took.
 
 Example field-report log for a successful update:
 
@@ -124,7 +140,7 @@ The firmware module ships with **63 unit tests** across:
 - `tst_firmwareheader` (12) — `.dat` file header parser + on-disk validator
 - `tst_firmwareassetcachehelpers` (12) — sidecar JSON round-trip, Range-header computation
 - `tst_de1device_firmware` (13) — `DE1Device::writeFWMapRequest` / `writeFirmwareChunk` (bypasses MMR dedupe cache), `fwMapResponse` signal
-- `tst_firmwareupdater` (13) — full state-machine flows: happy path, erase timeout, disconnect during upload, verify failure, precondition refused, race guard, dismiss, retry restart, verify-disconnect retroactive success + grace timeout
+- `tst_firmwareupdater` (13) — full state-machine flows: happy path, erase timeout, disconnect during upload, verify failure, precondition refused, same-version re-flash still flashes, dismiss, retry restart, verify-disconnect retroactive success + grace timeout
 
 Build with `-DBUILD_TESTS=ON` and run individual binaries from `build/<config>/tests/Debug/`.
 

--- a/qml/pages/settings/SettingsFirmwareTab.qml
+++ b/qml/pages/settings/SettingsFirmwareTab.qml
@@ -115,13 +115,27 @@ Item {
                 AccessibleButton {
                     Layout.preferredWidth: Theme.scaled(140)
                     Layout.preferredHeight: Theme.scaled(40)
-                    text: firmwareTab.fw && firmwareTab.fw.isDowngrade
-                          ? TranslationManager.translate(
-                                "firmware.tab.downgradeNow", "Downgrade now")
-                          : TranslationManager.translate(
+                    text: {
+                        if (!firmwareTab.fw) return TranslationManager.translate(
                                 "firmware.tab.updateNow", "Update now")
+                        if (firmwareTab.fw.isDowngrade)
+                            return TranslationManager.translate(
+                                "firmware.tab.downgradeNow", "Downgrade now")
+                        if (firmwareTab.fw.isReflash)
+                            return TranslationManager.translate(
+                                "firmware.tab.reflashNow", "Reflash")
+                        return TranslationManager.translate(
+                                "firmware.tab.updateNow", "Update now")
+                    }
                     accessibleName: text
-                    enabled: firmwareTab.fw && firmwareTab.fw.updateAvailable && !firmwareTab.isWorking && !firmwareTab.fw.isSimulated
+                    // No version gate — matches de1app, which flashes whatever
+                    // is in bootfwupdate.dat regardless of the installed
+                    // build. Same-build re-flash is warned about in the strip
+                    // below, not blocked: it is the only recovery for a bank
+                    // that verified but did not take. The requirement is a
+                    // known remote version (i.e. a check has succeeded), not a
+                    // newer one.
+                    enabled: firmwareTab.fw && firmwareTab.fw.availableVersion > 0 && !firmwareTab.isWorking && !firmwareTab.fw.isSimulated
                     onClicked: if (firmwareTab.fw) firmwareTab.fw.startUpdate()
                 }
             }
@@ -135,7 +149,9 @@ Item {
         Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: Theme.scaled(70)
-            visible: firmwareTab.fw && firmwareTab.fw.updateAvailable && firmwareTab.fw.isDowngrade
+            visible: firmwareTab.fw
+                     && ((firmwareTab.fw.updateAvailable && firmwareTab.fw.isDowngrade)
+                         || firmwareTab.fw.isReflash)
             color: Theme.cardBackgroundColor
             radius: Theme.cardRadius
             border.color: Theme.warningColor
@@ -150,22 +166,34 @@ Item {
                     Layout.fillWidth: true
                     spacing: Theme.scaled(2)
 
-                    Tr {
-                        key: "firmware.tab.downgradeHeader"
-                        fallback: "This is a downgrade"
+                    Text {
+                        text: firmwareTab.fw && firmwareTab.fw.isReflash
+                              ? TranslationManager.translate(
+                                    "firmware.tab.reflashHeader",
+                                    "Already on this version")
+                              : TranslationManager.translate(
+                                    "firmware.tab.downgradeHeader",
+                                    "This is a downgrade")
                         color: Theme.warningColor
                         font.pixelSize: Theme.scaled(14)
                         font.bold: true
                     }
                     Text {
                         Layout.fillWidth: true
-                        text: TranslationManager.translate(
-                                  "firmware.tab.downgradeDetail",
-                                  "Installed v%1 → available v%2. " +
-                                  "Flashing will roll the DE1 back. " +
-                                  "Continue only if you know why.")
-                              .arg(firmwareTab.fw && firmwareTab.fw.installedVersion > 0 ? firmwareTab.fw.installedVersion : "—")
-                              .arg(firmwareTab.fw ? firmwareTab.fw.availableVersion : "—")
+                        text: firmwareTab.fw && firmwareTab.fw.isReflash
+                              ? TranslationManager.translate(
+                                    "firmware.tab.reflashDetail",
+                                    "The DE1 already reports v%1. " +
+                                    "Flashing it again takes the full upload time " +
+                                    "and is only useful if the last update did not take.")
+                                .arg(firmwareTab.fw.availableVersion)
+                              : TranslationManager.translate(
+                                    "firmware.tab.downgradeDetail",
+                                    "Installed v%1 → available v%2. " +
+                                    "Flashing will roll the DE1 back. " +
+                                    "Continue only if you know why.")
+                                .arg(firmwareTab.fw && firmwareTab.fw.installedVersion > 0 ? firmwareTab.fw.installedVersion : "—")
+                                .arg(firmwareTab.fw ? firmwareTab.fw.availableVersion : "—")
                         color: Theme.textColor
                         font.pixelSize: Theme.scaled(12)
                         wrapMode: Text.Wrap

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -304,6 +304,21 @@ void DE1Device::onTransportDataReceived(const QBluetoothUuid& uuid, const QByteA
         FW_LOG(QStringLiteral("A009 notify: %1").arg(QString::fromLatin1(data.toHex(' '))));
         auto parsed = DE1::Firmware::parseFWMapNotification(data);
         if (parsed) {
+            // WindowIncrement is decoded but not carried on fwMapResponse, so
+            // it is logged here. It is the field that separates a terminal
+            // verify verdict from an in-progress notification: reaprime/decaid
+            // only accepts a verify response when WindowIncrement == 0, while
+            // we accept the first notification of any shape. If a failing
+            // update logs a non-zero value on the line that produced
+            // "Verification failed", the address in that message is a cursor,
+            // not a corrupt block.
+            FW_LOG(QStringLiteral("A009 parsed: windowIncrement=%1 erase=%2 map=%3 firstError=%4")
+                       .arg(parsed->windowIncrement)
+                       .arg(parsed->fwToErase)
+                       .arg(parsed->fwToMap)
+                       .arg(QString::fromLatin1(
+                           QByteArray(reinterpret_cast<const char*>(parsed->firstError.data()), 3)
+                               .toHex(' '))));
             emit fwMapResponse(parsed->fwToErase, parsed->fwToMap,
                                QByteArray(reinterpret_cast<const char*>(parsed->firstError.data()), 3));
         } else {

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -1,5 +1,6 @@
 #include "controllers/firmwareupdater.h"
 
+#include <QCryptographicHash>
 #include <QDebug>
 #include <QFile>
 #include <QLoggingCategory>
@@ -484,6 +485,10 @@ void FirmwareUpdater::onCheckFinished(FirmwareAssetCache::CheckResult result) {
         (result.kind == FirmwareAssetCache::CheckResult::Newer ||
          result.kind == FirmwareAssetCache::CheckResult::Older);
     m_isDowngrade = (result.kind == FirmwareAssetCache::CheckResult::Older);
+    // Same build is not an "update available" — the banner stays quiet — but
+    // it is still flashable, so the QML labels and warns off this flag rather
+    // than off updateAvailable.
+    m_isReflash   = (result.kind == FirmwareAssetCache::CheckResult::Same);
     if (offersFlash) {
         // The dismissed-version pin applies to both directions: once the
         // user hides the banner for a given remote version, don't re-open
@@ -505,6 +510,7 @@ void FirmwareUpdater::onCheckFinished(FirmwareAssetCache::CheckResult result) {
                                                                                 : "Error")
         << " updateAvailable=" << m_updateAvailable
         << " isDowngrade=" << m_isDowngrade
+        << " isReflash=" << m_isReflash
         << (result.errorDetail.isEmpty() ? QString() : QStringLiteral(" err=") + result.errorDetail);
     emit availabilityChanged();
     setState(State::Idle);
@@ -515,20 +521,19 @@ void FirmwareUpdater::onDownloadFinished(QString path, Header header) {
     Q_UNUSED(header);
     if (m_state != State::Downloading) return;
 
-    // Race guard: re-read installed version. If it *equals* the cached
-    // header's version, there's nothing to do — short-circuit to Succeeded.
-    // A strict mismatch (newer *or* older) proceeds: de1app allows
-    // downgrades (matching channel swap: nightly → stable), so we only
-    // bail on true equality, not on "installed >= available".
+    // No version gate. de1app has none either — every version check in
+    // start_firmware_update (de1_comms.tcl:884-895) is commented out, so its
+    // update button flashes whatever is in bootfwupdate.dat regardless of
+    // what the machine reports. This used to short-circuit an equal version
+    // to Succeeded without writing anything, which made the one case that
+    // most needs a flash — a bank that verified but did not take, so the DE1
+    // still runs the old image while reporting the new build — unreachable
+    // from the UI. Re-flashing the same build is safe for the same reason a
+    // failed update is: the write lands in the inactive bank and the active
+    // one is untouched until verify passes. The UI warns instead of blocking.
     const uint32_t currentInstalled = m_installedVersionProvider
         ? m_installedVersionProvider() : m_installedVersion;
     m_installedVersion = currentInstalled;
-    if (currentInstalled == header.version) {
-        m_updateAvailable = false;
-        emit availabilityChanged();
-        setState(State::Succeeded);
-        return;
-    }
 
     m_availableVersion = header.version;
     setState(State::Ready);
@@ -642,6 +647,23 @@ void FirmwareUpdater::loadCachedPayload() {
         return;
     }
     m_firmwareBytes = f.readAll();
+
+    // Fingerprint what we are about to write to flash. FirmwareHeader's
+    // validateFile() only checks BoardMarker (offset 4) and a size floor, so
+    // a file assembled from two different revisions — which the cache's
+    // Range-resume path can produce — passes validation unchanged. A digest
+    // is the only thing that distinguishes the bytes we meant to flash from
+    // the bytes we have. Compare against the CDN file for the active channel.
+    const QByteArray digest =
+        QCryptographicHash::hash(m_firmwareBytes, QCryptographicHash::Sha256).toHex();
+    auto header = DE1::Firmware::parseHeader(m_firmwareBytes);
+    qCDebug(firmwareLog).noquote()
+        << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+        << "[firmware] payload:" << m_firmwareBytes.size() << "bytes sha256="
+        << QString::fromLatin1(digest)
+        << "version=" << (header ? header->version : 0)
+        << "byteCount=" << (header ? header->byteCount : 0)
+        << "cpuBytes=" << (header ? header->cpuBytes : 0);
 }
 
 void FirmwareUpdater::onChunkPumpTick() {

--- a/src/controllers/firmwareupdater.h
+++ b/src/controllers/firmwareupdater.h
@@ -39,6 +39,7 @@ class FirmwareUpdater : public QObject {
     Q_PROPERTY(QString stateText READ stateText NOTIFY stateChanged)
     Q_PROPERTY(bool updateAvailable READ updateAvailable NOTIFY availabilityChanged)
     Q_PROPERTY(bool isDowngrade READ isDowngrade NOTIFY availabilityChanged)
+    Q_PROPERTY(bool isReflash READ isReflash NOTIFY availabilityChanged)
     // True while wired to the DE1 simulator (no real BLE). The check,
     // download, and version surfaces still run so the page is usable;
     // only the flash itself is blocked.
@@ -117,6 +118,12 @@ public:
     // Mirrors de1app's "Firmware downgrade available" affordance: the user
     // is allowed to flash it, but the UI should label it as a downgrade.
     bool isDowngrade() const { return m_isDowngrade; }
+    // True when the available firmware is the *same build* as what's
+    // installed. Flashing is still permitted — de1app has no version gate at
+    // all (every check in start_firmware_update is commented out), and a
+    // re-flash is the only way to recover a bank that verified but did not
+    // take. The UI warns rather than disabling the button.
+    bool isReflash() const { return m_isReflash; }
     bool isSimulated() const;
     bool isFlashing() const {
         return m_state == State::Erasing ||
@@ -184,6 +191,7 @@ private:
     State       m_state            = State::Idle;
     bool        m_updateAvailable  = false;
     bool        m_isDowngrade      = false;
+    bool        m_isReflash        = false;
     uint32_t    m_availableVersion = 0;
     uint32_t    m_installedVersion = 0;
     double      m_progress         = 0.0;

--- a/src/core/firmwareassetcache.cpp
+++ b/src/core/firmwareassetcache.cpp
@@ -291,10 +291,23 @@ void FirmwareAssetCache::downloadIfNeeded() {
     // If we already have a validated file matching the sidecar version,
     // skip the download entirely — the caller can use cachedPath/cachedHeader.
     QFileInfo info(cachePath());
+    qCDebug(firmwareLog) << "[firmware] downloadIfNeeded: channel="
+                         << currentUrl() << "existingBytes="
+                         << (info.exists() ? info.size() : 0)
+                         << "metaVersion=" << m_meta.version
+                         << "metaEtag=" << m_meta.etag;
     if (info.exists()) {
         auto header = cachedHeader();
         if (header && header->boardMarker == BOARD_MARKER &&
             info.size() >= qint64(header->byteCount) + HEADER_SIZE) {
+            // Short-circuit: the on-disk file is *accepted without contacting
+            // the server*. Nothing here proves it came from the channel we are
+            // now on — only that its first 64 bytes parse and it is long
+            // enough. Log the version we are about to hand back so a mismatch
+            // against the UI's "Available:" is visible in the trail.
+            qCDebug(firmwareLog) << "[firmware] using cached file without "
+                                    "download: version=" << header->version
+                                 << "size=" << info.size();
             emit downloadFinished(cachePath(), *header);
             return;
         }

--- a/tests/tst_firmwareupdater.cpp
+++ b/tests/tst_firmwareupdater.cpp
@@ -20,7 +20,7 @@
 // test runs in < 100 ms instead of the real 45-second flash.
 //
 // This file starts with the happy path only (§4a); error-path tests
-// (disconnect, timeout, verify failure, precondition, race guard) land
+// (disconnect, timeout, verify failure, precondition, same-version) land
 // in §4b, and retry/dismiss/verify-retroactive-success semantics in §4c.
 
 namespace {
@@ -186,22 +186,29 @@ private slots:
         QVERIFY(!sawFirmwareWrite);
     }
 
-    void raceGuardAlreadyUpdated_jumpsToSucceeded() {
+    void sameVersion_stillFlashes() {
         Fixture f;
-        // Installed version already equals what the file contains.
+        // Installed version already equals what the file contains. This used
+        // to short-circuit to Succeeded without writing anything, which made
+        // the case that most needs a flash — a bank that verified but did not
+        // take, so the DE1 reports the new build while running the old one —
+        // unreachable. de1app has no version gate at all (every check in
+        // start_firmware_update is commented out); we match it and warn in the
+        // UI instead. The flash must actually start.
         f.updater.setInstalledVersionProvider([]{ return 1352u; });
         writeCachedBlob(&f.updater, &f.cache, makeFirmwareBlob(1352));
         f.updater.startUpdate();
 
-        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Succeeded);
-        // Race guard fired before any BLE write: no erase, no chunks.
+        QTRY_VERIFY(f.updater.state() != FirmwareUpdater::State::Downloading);
+        QVERIFY(f.updater.state() != FirmwareUpdater::State::Succeeded);
+
         bool sawEraseReq = false;
         for (const auto& w : f.transport.writes) {
             if (w.first == DE1::Characteristic::FW_MAP_REQUEST) {
                 sawEraseReq = true; break;
             }
         }
-        QVERIFY(!sawEraseReq);
+        QVERIFY(sawEraseReq);
     }
 
     // ===== §4b+: firmware-flash MMR-write guard =====


### PR DESCRIPTION
## Why

Two users report the DE1 firmware update failing at the **identical** point: `Verification failed at block 0.72.0` — FirstError bytes `00 48 00`, address `0x4800`, chunk 1152 of 28992. One on an Android tablet, one on an iPad, both on the nightly channel going to v1352.

An identical offset across two different BLE stacks rules out every timing explanation — queue drops, write-retry loss, erase overlap, per-platform pacing — all of which land somewhere different on each run. That leaves the bytes we flash or the way we read the verify response, and **neither is visible in a submitted log today**.

The firmware file itself is exonerated. Downloaded both channels and compared against the image `decaid` bundles:

| | bytes | sha256 | Version |
|---|---|---|---|
| `de1plus` (stable) | 456,704 | `eef43473…39c6` | 1333 |
| `de1nightly` | 463,872 | `d9433b85…2927` | **1352** |
| decaid `assets/firmware/de1/de1-1352.bin` | 463,872 | `d9433b85…2927` | 1352 |

Byte-for-byte identical, header parses clean both sides (BoardMarker `0xDE100001`, ByteCount 461,824, CpuBytes 298,592 — matching decaid's manifest exactly).

## Diagnostics

- **`loadCachedPayload()` logs size, sha256 and parsed header fields** of the exact bytes about to be written. `FirmwareHeader::validateFile()` checks only BoardMarker at offset 4 and a size floor, so a `.dat` assembled from two revisions passes validation unchanged — and `downloadIfNeeded()` can produce one, since it byte-range resumes onto whatever is on disk with no ETag check that the partial came from the same revision. A digest is the only thing that catches it.
- **`downloadIfNeeded()` logs** existing on-disk size, sidecar version/ETag, and whether the cached file was accepted without contacting the server at all.
- **`de1device` logs `WindowIncrement`** on every parsed A009 notification. It is decoded and then dropped on the way to `fwMapResponse`, which is why no existing log can tell a terminal verify verdict from an in-progress notification. reaprime/decaid accepts a verify response only when `WindowIncrement == 0`; we accept the first notification of any shape and report its FirstError as a corrupt block. **If the failing notification carries a non-zero WindowIncrement, `0x4800` is a cursor, not corruption.**

## Same-version reflash

Testing any of this needs a machine already on v1352 to be able to flash v1352, which was impossible: `onDownloadFinished` short-circuited an equal version straight to `Succeeded` without writing anything, and the QML button gated on `updateAvailable`, false for `Same`.

Both removed. **de1app has no version gate either** — every check in `start_firmware_update` (`de1_comms.tcl:884-895`) is commented out, so its button flashes whatever is in `bootfwupdate.dat` regardless of what the machine reports. The button now requires only that a check has succeeded:

| Remote vs installed | Button | Strip |
|---|---|---|
| Newer | Update now | — |
| Older | Downgrade now | yellow: rolls the DE1 back |
| Same | Reflash | yellow: already on this version |

Beyond making this testable, the short-circuit made the one case that most needs a flash unreachable: a bank that verified but did not take, leaving the DE1 running the old image while reporting the new build. Re-flashing is safe for the same reason a failed update is — the write lands in the inactive bank, and the active one is untouched until verify passes.

## Notes

- This PR **fixes nothing**. It is instrumentation plus the ability to re-test. The next step is a real flash on a machine that reproduces; the log then points at either the WindowIncrement misread (fix: adopt decaid's predicate) or the digest (fix: the Range-resume hole in `downloadIfNeeded()`).
- `raceGuardAlreadyUpdated_jumpsToSucceeded` asserted the removed behaviour and is inverted to `sameVersion_stillFlashes`.
- `docs/CLAUDE_MD/FIRMWARE_UPDATE.md` updated. **Wiki manual not yet updated** — it needs the Reflash row.
- Local build and test suite have **not** been run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)