### PR TITLE
fix(firmware): wait 10s post-erase everywhere, gate on notifications, detect spliced downloads

### DIFF
--- a/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
+++ b/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
@@ -21,9 +21,12 @@ Two buttons:
 
 **Expect ~15–20 minutes on Android** — not 45 seconds. Android BLE write-with-response is serialised at ~30 ms per ACK; 28,992 chunks at that rate is ~16 minutes of upload alone. On desktop platforms BLE is faster (macOS/Linux can hit closer to 2–3 minutes), but the Android tablet is the common case.
 
-- **Phase 1 — Erase**: `FWMapRequest(erase=1, map=1)` sent on characteristic `A009`. DE1 erases the inactive flash bank. Modern firmware sends a single erase-complete notification (`fwToErase=0`). We then wait a fixed 10 s (Android) / 1 s (elsewhere) per de1app's convention before starting the chunk pump.
+- **Phase 0 — Sleep**: the DE1 is put to sleep before the erase command. An awake machine runs its heaters, PID and refill logic for the ~18 minutes a flash takes, on the same MCU that is erasing and programming flash. reaprime/decaid does this; de1app has the line and leaves it commented out. It has to happen *before* `setFirmwareFlashInProgress(true)` — `goToSleep()` carries its own guard check and is dropped once the flash is engaged.
+- **Phase 1 — Erase**: `FWMapRequest(erase=1, map=1)` sent on characteristic `A009`. DE1 erases the inactive flash bank. Modern firmware sends a single erase-complete notification (`fwToErase=0`). The chunk pump starts as soon as that notification lands, with a 10 s fallback on every platform if it never does. Measured at +1.31 s on a DE1+/PCB 1.3, so the notification is the normal path and the timer is the exception. Matches reaprime/decaid; de1app gates on nothing and always waits the fixed 10 s.
 - **Phase 2 — Upload**: 28,992 sequential 20-byte packets streamed to characteristic `A006`. Each packet is `[len=16][addr24 BE][16-byte payload]`. Length byte is 16 (`0x10`) — same format as MMR writes which use length 4. Address is 24-bit **big-endian**. ACK-driven progress so the bar tracks bytes on the wire, not bytes in the BLE queue.
 - **Phase 3 — Verify**: `FWMapRequest(erase=0, map=1, FirstError=FF,FF,FF)` on `A009`. DE1 verifies the inactive bank and replies with a 3-byte `FirstError`. `{0xFF, 0xFF, 0xFD}` = success; anything else = the byte offset of the first corrupt block.
+
+  **Only a notification with `WindowIncrement == 0` and `fwToMap == 1` is a verdict.** Anything else is the bootloader talking mid-scan and its `FirstError` is a cursor, so reading it as a corrupt-block address turns normal progress into a permanent-looking failure that survives Retry. We keep waiting; the 60 s verify timeout is the backstop. reaprime/decaid filters on exactly these two fields.
 - On success, the DE1 remaps the inactive bank as active. It does **not** auto-reboot in practice — on every captured flash (upgrade and downgrade) the machine keeps running the old firmware until the user flips its power switch. Decenza prompts for a power-cycle immediately after verify (see `FirmwareUpdater::AwaitingReboot`) and its auto-reconnect logic re-establishes BLE once the DE1 comes back up on the new firmware.
 
 ### BLE subscription timing (matters)
@@ -83,7 +86,15 @@ The downloaded file is cached at `QStandardPaths::AppDataLocation/firmware/bootf
 
 ## What's validated client-side
 
-Only `BoardMarker == 0xDE100001` (offset 4 of the 64-byte header) and the on-disk file size is at least `ByteCount + 64`. The header's `CheckSum` / `DCSum` / `HeaderChecksum` fields use algorithms that aren't currently documented anywhere we can verify; the DE1's own verify-phase response is the authoritative correctness check. Kal Freese's working Python updater skips these too. A `TODO(firmware-crc)` marker in `FirmwareAssetCache` documents where client-side checksum validation would plug in once Decent confirms the algorithms.
+`validateFile()` checks `BoardMarker == 0xDE100001` (offset 4), a file-size floor of `ByteCount + 64`, and a set of structural invariants adopted from reaprime/decaid's `FirmwareValidator`: `ByteCount` non-zero, `0 < CpuBytes <= ByteCount`, the reserved word at offset 20 zero, `CheckSum`/`DCSum`/`HeaderChecksum` all non-zero, and the IV not all-zero. Failing any of the latter gives `Validation::MalformedHeader`.
+
+**Why the structural checks are not busywork:** BoardMarker is identical in every DE1 image ever published and sits in the first 16 bytes, so BoardMarker-plus-a-size-floor accepts a file **spliced from two revisions** — which the cache's `Range:` resume can produce by appending a new revision's tail onto an old revision's body. The result has the right total length and a valid-looking header, and the corruption is only discovered by the DE1 at the end of a ~18-minute flash.
+
+The splice itself is caught by `versionMatchesMeta()`: the sidecar records the Version the server reported for the ETag this channel is currently serving (read via the 64-byte Range GET during the availability check), and a cached or downloaded file whose header disagrees is discarded rather than flashed. A resume is now only attempted when the on-disk bytes are `Truncated` **and** their Version matches — i.e. a genuine interrupted download of this same revision.
+
+The `CheckSum` / `DCSum` / `HeaderChecksum` **algorithms** remain undocumented, so we can only assert they are populated, not recompute them; the DE1's own verify-phase response is still the authoritative correctness check. Kal Freese's working Python updater skips them too. A `TODO(firmware-crc)` marker in `FirmwareAssetCache` documents where real checksum validation would plug in once Decent confirms the algorithms.
+
+Note that synthetic test blobs must populate these fields — `makeFirmwareBlob()` / `makeValidHeader()` in the tests do, and a header built with bare zeros is *supposed* to be rejected.
 
 ## What gets logged
 
@@ -127,20 +138,20 @@ When the DE1 simulator is active (`DE1Device::simulationMode() == true`), the fi
 ## Cross-platform notes
 
 - **All platforms** Decenza supports get the same flow: Windows, macOS, Linux, Android, iOS.
-- **Android** uses a 10 s post-erase wait (vs. 1 s elsewhere) to give the Android BLE stack room to drain the queue between erase and the first chunk write — `de1app`'s historical workaround for an Android-specific race.
+- **The post-erase wait is 10 s on every platform.** It used to be 10 s on Android and 1 s elsewhere, and this file used to justify that as "`de1app`'s historical workaround for an Android-specific race" — a rationale nothing in de1app supports. de1app branches on `$::has_bluetooth`, not on platform (`de1_comms.tcl:941-947`); its 1 s arm is the no-BLE dry run, sitting a few lines below the block that fakes the connection handles because no machine is attached. Every real flash it performs waits 10 s. We read `has_bluetooth` as "is Android" and gave iOS, macOS, Windows and Linux the no-machine timing. A captured DE1+/PCB 1.3 flash reported erase-complete at **1.31 s**, so the 1 s arm was also simply too short — the chunk pump would have started mid-erase.
 - **Android BLE throughput** is the main user-visible bottleneck. Typical ~30 ms per write-with-response ACK means 28,992 chunks ≈ 15 minutes. Not a bug, just the OS's GATT per-connection-event budget.
 - **iOS** has the strictest BLE pacing of any platform; if you see chunk-pump stalls on iOS, the chunk-pump interval (`setChunkPumpIntervalMs`) is tunable via the `FirmwareUpdater` constructor injection.
 - **Computer sleep doesn't affect Android tablet uploads.** If you're debugging via `adb logcat` from a laptop and the laptop sleeps, the logcat connection drops but the tablet and the BLE session keep running. We confirmed this by accident during real-hardware testing — upload completed and DE1 rebooted to the new firmware while the PC was asleep.
 
 ## Testing without a real DE1
 
-The firmware module ships with **63 unit tests** across:
+The firmware module ships with **75 unit tests** across:
 
 - `tst_firmwarepackets` (13) — packet builder byte layouts (FWMapRequest, firmware chunk, parser)
-- `tst_firmwareheader` (12) — `.dat` file header parser + on-disk validator
+- `tst_firmwareheader` (21) — `.dat` file header parser + on-disk validator, including the seven malformed-header shapes and the reserved-field check
 - `tst_firmwareassetcachehelpers` (12) — sidecar JSON round-trip, Range-header computation
-- `tst_de1device_firmware` (13) — `DE1Device::writeFWMapRequest` / `writeFirmwareChunk` (bypasses MMR dedupe cache), `fwMapResponse` signal
-- `tst_firmwareupdater` (13) — full state-machine flows: happy path, erase timeout, disconnect during upload, verify failure, precondition refused, same-version re-flash still flashes, dismiss, retry restart, verify-disconnect retroactive success + grace timeout
+- `tst_de1device_firmware` (14) — `DE1Device::writeFWMapRequest` / `writeFirmwareChunk` (bypasses MMR dedupe cache), `fwMapResponse` signal including `WindowIncrement`
+- `tst_firmwareupdater` (16) — full state-machine flows: happy path, erase-complete notification starts the upload ahead of the fallback timer, "still erasing" does not, a non-terminal verify notification is ignored rather than reported as failure, erase timeout, disconnect during upload, verify failure, precondition refused, same-version re-flash still flashes, dismiss, retry restart, verify-disconnect retroactive success + grace timeout
 
 Build with `-DBUILD_TESTS=ON` and run individual binaries from `build/<config>/tests/Debug/`.
 
@@ -163,7 +174,9 @@ Eight non-obvious bugs surfaced only after trying a real flash. Worth reading be
 
 1. **Byte 0 of a chunk packet is a length field (`16`/`0x10`), not a magic "firmware opcode"**. Same field as MMR writes (`0x04` for 4-byte values). Fooled the initial research agent because `16 == 0x10` coincidentally.
 2. **Chunk address is big-endian.** Little-endian chunks land at byte-swapped addresses, get rejected by the bootloader, and some of those swapped addresses hit peripheral registers — we saw the DE1's pumps fire mid-upload as a result. Matches `make_U24P0` in `de1app/binary.tcl` and Kal Freese's `struct.pack(">BBH", …)`.
-3. **Modern firmware sends one erase notification, not two.** `de1app`'s spec mentions a "while erasing" notification followed by "erase complete", but this firmware (v1333+) skips the first. Don't gate progression on the two-notification dance — de1app itself just waits a fixed 10 s/1 s.
+3. **Modern firmware sends one erase notification, not two.** `de1app`'s spec mentions a "while erasing" notification followed by "erase complete", but this firmware (v1333+) skips the first. Don't gate progression on the two-notification *dance* — but do gate it on the single completion notification, with the fixed wait as fallback. `fwToErase=1` means "still erasing" and must not be mistaken for completion.
+
+   **Don't test `FirstError` on the erase-complete notification either — the DE1 echoes back whatever you sent.** We send `0,0,0` on the erase request and the completion notification carries `0,0,0`; decaid sends `0xFF,0xFF,0xFF` and asserts `0xFF,0xFF,0xFF` comes back. Both are reading their own outbound bytes. Only `fwToErase`/`fwToMap` carry machine state here. (Verify is different: we send `FF FF FF` and success comes back as `FF FF FD`, so that one is a real response.)
 4. **A009 notifications must be re-subscribed right before verify.** The heavy upload-write burst invalidates the CCCD state on Android. Match `de1app/de1_comms.tcl:962`'s ordering exactly.
 5. **`writeComplete` subscription must be deferred past `BleTransport` attach.** At `MainController` construction time, `DE1Device::transport()` is still null. A constructor-time subscribe silently no-ops. Defer the `connect(transport, writeComplete, ...)` call to the first point we know the transport is alive (e.g. `beginUploadPhase`).
 6. **Queue depth ≠ wire depth.** `BleTransport::queueCommand` enqueues immediately but BLE drains at ACK speed. Progress-from-queued-count jumps to 90 % in seconds and hangs; progress-from-ACK-count tracks the wire and is what the user should see.

--- a/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
+++ b/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
@@ -26,12 +26,14 @@ Two buttons:
 - **Phase 2 — Upload**: 28,992 sequential 20-byte packets streamed to characteristic `A006`. Each packet is `[len=16][addr24 BE][16-byte payload]`. Length byte is 16 (`0x10`) — same format as MMR writes which use length 4. Address is 24-bit **big-endian**. ACK-driven progress so the bar tracks bytes on the wire, not bytes in the BLE queue.
 - **Phase 3 — Verify**: `FWMapRequest(erase=0, map=1, FirstError=FF,FF,FF)` on `A009`. DE1 verifies the inactive bank and replies with a 3-byte `FirstError`. `{0xFF, 0xFF, 0xFD}` = success; anything else = the byte offset of the first corrupt block.
 
-  **Only a notification with `WindowIncrement == 0` and `fwToMap == 1` is a verdict.** Anything else is the bootloader talking mid-scan and its `FirstError` is a cursor, so reading it as a corrupt-block address turns normal progress into a permanent-looking failure that survives Retry. We keep waiting; the 60 s verify timeout is the backstop. reaprime/decaid filters on exactly these two fields.
+  **A notification is a verdict only when `WindowIncrement == 0`, `fwToErase == 0`, `fwToMap == 1` *and* `FirstError != FF FF FF`.** Anything else is the bootloader talking mid-scan, and its `FirstError` is a cursor rather than a corrupt-block address — reading it as one turns normal progress into a permanent-looking failure that survives Retry. We keep waiting; the 60 s verify timeout is the backstop. This is reaprime/decaid's `_isTerminalVerificationResponse` (`unified_de1.firmware.dart:142-147`).
+
+  **The `FirstError != FF FF FF` condition is the one that is easy to drop.** `FF FF FF` is the bootloader's "no error found" value *and* what we write into the verify request, which the DE1 echoes — so an in-progress notification carries it with `WindowIncrement == 0` and `fwToMap == 1`, passing any filter built on the other three conditions, comparing unequal to `FF FF FD`, and reporting `Verification failed at block 255.255.255` on a flash that was still verifying. Success is `FF FF FD`; a real failure carries a real address; `FF FF FF` is neither.
 - On success, the DE1 remaps the inactive bank as active. It does **not** auto-reboot in practice — on every captured flash (upgrade and downgrade) the machine keeps running the old firmware until the user flips its power switch. Decenza prompts for a power-cycle immediately after verify (see `FirmwareUpdater::AwaitingReboot`) and its auto-reconnect logic re-establishes BLE once the DE1 comes back up on the new firmware.
 
 ### BLE subscription timing (matters)
 
-The FWMapRequest (A009) CCCD subscription is enabled **right before verify** — *not* at the start of erase. This matches `de1app/de1_comms.tcl:962`. The heavy upload-write burst appears to invalidate the A009 subscription on Android, so a re-subscribe immediately before the verify request is required for the verify response to reach the app.
+The FWMapRequest (A009) CCCD subscription is enabled **right before verify** — *not* at the start of erase. This matches `de1app/de1_comms.tcl:991`. The heavy upload-write burst appears to invalidate the A009 subscription on Android, so a re-subscribe immediately before the verify request is required for the verify response to reach the app.
 
 ## Safety: dual-bank flash
 
@@ -138,20 +140,20 @@ When the DE1 simulator is active (`DE1Device::simulationMode() == true`), the fi
 ## Cross-platform notes
 
 - **All platforms** Decenza supports get the same flow: Windows, macOS, Linux, Android, iOS.
-- **The post-erase wait is 10 s on every platform.** It used to be 10 s on Android and 1 s elsewhere, and this file used to justify that as "`de1app`'s historical workaround for an Android-specific race" — a rationale nothing in de1app supports. de1app branches on `$::has_bluetooth`, not on platform (`de1_comms.tcl:941-947`); its 1 s arm is the no-BLE dry run, sitting a few lines below the block that fakes the connection handles because no machine is attached. Every real flash it performs waits 10 s. We read `has_bluetooth` as "is Android" and gave iOS, macOS, Windows and Linux the no-machine timing. A captured DE1+/PCB 1.3 flash reported erase-complete at **1.31 s**, so the 1 s arm was also simply too short — the chunk pump would have started mid-erase.
+- **The post-erase wait is 10 s on every platform.** It used to be 10 s on Android and 1 s elsewhere, and this file used to justify that as "`de1app`'s historical workaround for an Android-specific race" — a rationale nothing in de1app supports. de1app branches on `$::has_bluetooth`, not on platform (`de1_comms.tcl:940-950`); its 1 s arm is the no-BLE dry run, sitting a few lines below the block that fakes the connection handles because no machine is attached. Every real flash it performs waits 10 s. We read `has_bluetooth` as "is Android" and gave iOS, macOS, Windows and Linux the no-machine timing. A captured DE1+/PCB 1.3 flash reported erase-complete at **1.31 s**, so the 1 s arm was also simply too short — the chunk pump would have started mid-erase.
 - **Android BLE throughput** is the main user-visible bottleneck. Typical ~30 ms per write-with-response ACK means 28,992 chunks ≈ 15 minutes. Not a bug, just the OS's GATT per-connection-event budget.
 - **iOS** has the strictest BLE pacing of any platform; if you see chunk-pump stalls on iOS, the chunk-pump interval (`setChunkPumpIntervalMs`) is tunable via the `FirmwareUpdater` constructor injection.
 - **Computer sleep doesn't affect Android tablet uploads.** If you're debugging via `adb logcat` from a laptop and the laptop sleeps, the logcat connection drops but the tablet and the BLE session keep running. We confirmed this by accident during real-hardware testing — upload completed and DE1 rebooted to the new firmware while the PC was asleep.
 
 ## Testing without a real DE1
 
-The firmware module ships with **75 unit tests** across:
+Five suites cover the firmware module. **No counts here on purpose** — the numbers this section used to carry were hand-maintained, drifted every time a test was added, and were twice internally inconsistent (a stated total that did not match the sum of its own per-suite figures). A data-driven test also contributes one slot and N reported cases, so there is no single number that is right for both readings. `ctest -R firmware` is the source of truth.
 
-- `tst_firmwarepackets` (13) — packet builder byte layouts (FWMapRequest, firmware chunk, parser)
-- `tst_firmwareheader` (21) — `.dat` file header parser + on-disk validator, including the seven malformed-header shapes and the reserved-field check
-- `tst_firmwareassetcachehelpers` (12) — sidecar JSON round-trip, Range-header computation
-- `tst_de1device_firmware` (14) — `DE1Device::writeFWMapRequest` / `writeFirmwareChunk` (bypasses MMR dedupe cache), `fwMapResponse` signal including `WindowIncrement`
-- `tst_firmwareupdater` (16) — full state-machine flows: happy path, erase-complete notification starts the upload ahead of the fallback timer, "still erasing" does not, a non-terminal verify notification is ignored rather than reported as failure, erase timeout, disconnect during upload, verify failure, precondition refused, same-version re-flash still flashes, dismiss, retry restart, verify-disconnect retroactive success + grace timeout
+- `tst_firmwarepackets` — packet builder byte layouts (FWMapRequest, firmware chunk, parser)
+- `tst_firmwareheader` — `.dat` header parser and on-disk validator: BoardMarker, the size floor and ceiling, and the malformed-header shapes (`_data()` table)
+- `tst_firmwareassetcachehelpers` — sidecar JSON round-trip, Range-header computation
+- `tst_de1device_firmware` — `DE1Device::writeFWMapRequest` / `writeFirmwareChunk` (bypasses MMR dedupe cache), `fwMapResponse` signal including `WindowIncrement`
+- `tst_firmwareupdater` — full state-machine flows: happy path; sleep precedes the erase request; the erase-complete notification starts the upload ahead of the fallback timer; "still erasing" does not; a non-terminal verify notification is ignored rather than reported as failure; erase timeout; disconnect during upload; verify failure; precondition refused; same-version re-flash still flashes; dismiss; retry restart; verify-disconnect retroactive success and grace timeout
 
 Build with `-DBUILD_TESTS=ON` and run individual binaries from `build/<config>/tests/Debug/`.
 
@@ -177,7 +179,7 @@ Eight non-obvious bugs surfaced only after trying a real flash. Worth reading be
 3. **Modern firmware sends one erase notification, not two.** `de1app`'s spec mentions a "while erasing" notification followed by "erase complete", but this firmware (v1333+) skips the first. Don't gate progression on the two-notification *dance* — but do gate it on the single completion notification, with the fixed wait as fallback. `fwToErase=1` means "still erasing" and must not be mistaken for completion.
 
    **Don't test `FirstError` on the erase-complete notification either — the DE1 echoes back whatever you sent.** We send `0,0,0` on the erase request and the completion notification carries `0,0,0`; decaid sends `0xFF,0xFF,0xFF` and asserts `0xFF,0xFF,0xFF` comes back. Both are reading their own outbound bytes. Only `fwToErase`/`fwToMap` carry machine state here. (Verify is different: we send `FF FF FF` and success comes back as `FF FF FD`, so that one is a real response.)
-4. **A009 notifications must be re-subscribed right before verify.** The heavy upload-write burst invalidates the CCCD state on Android. Match `de1app/de1_comms.tcl:962`'s ordering exactly.
+4. **A009 notifications must be re-subscribed right before verify.** The heavy upload-write burst invalidates the CCCD state on Android. Match `de1app/de1_comms.tcl:991`'s ordering exactly.
 5. **`writeComplete` subscription must be deferred past `BleTransport` attach.** At `MainController` construction time, `DE1Device::transport()` is still null. A constructor-time subscribe silently no-ops. Defer the `connect(transport, writeComplete, ...)` call to the first point we know the transport is alive (e.g. `beginUploadPhase`).
 6. **Queue depth ≠ wire depth.** `BleTransport::queueCommand` enqueues immediately but BLE drains at ACK speed. Progress-from-queued-count jumps to 90 % in seconds and hangs; progress-from-ACK-count tracks the wire and is what the user should see.
 7. **Verify timeouts need to be generous.** 10 s is too tight; 60 s works. Bootloader verification of the entire 453 KB image plus signature/checksum takes real time.

--- a/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
+++ b/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
@@ -153,7 +153,7 @@ Five suites cover the firmware module. **No counts here on purpose** — the num
 - `tst_firmwareheader` — `.dat` header parser and on-disk validator: BoardMarker, the size floor and ceiling, and the malformed-header shapes (`_data()` table)
 - `tst_firmwareassetcachehelpers` — sidecar JSON round-trip, Range-header computation
 - `tst_de1device_firmware` — `DE1Device::writeFWMapRequest` / `writeFirmwareChunk` (bypasses MMR dedupe cache), `fwMapResponse` signal including `WindowIncrement`
-- `tst_firmwareupdater` — full state-machine flows: happy path; sleep precedes the erase request; the erase-complete notification starts the upload ahead of the fallback timer; "still erasing" does not; a non-terminal verify notification is ignored rather than reported as failure; erase timeout; disconnect during upload; verify failure; precondition refused; same-version re-flash still flashes; dismiss; retry restart; verify-disconnect retroactive success and grace timeout
+- `tst_firmwareupdater` — full state-machine flows: happy path; sleep precedes the erase request; the erase-complete notification starts the upload ahead of the fallback timer; "still erasing" does not, and neither does one arriving before the erase request's own write ACK; a non-terminal verify notification is ignored rather than reported as failure; erase timeout; disconnect during upload; verify failure; precondition refused; same-version re-flash still flashes; dismiss; retry restart; verify-disconnect retroactive success and grace timeout
 
 Build with `-DBUILD_TESTS=ON` and run individual binaries from `build/<config>/tests/Debug/`.
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -304,14 +304,6 @@ void DE1Device::onTransportDataReceived(const QBluetoothUuid& uuid, const QByteA
         FW_LOG(QStringLiteral("A009 notify: %1").arg(QString::fromLatin1(data.toHex(' '))));
         auto parsed = DE1::Firmware::parseFWMapNotification(data);
         if (parsed) {
-            // WindowIncrement is decoded but not carried on fwMapResponse, so
-            // it is logged here. It is the field that separates a terminal
-            // verify verdict from an in-progress notification: reaprime/decaid
-            // only accepts a verify response when WindowIncrement == 0, while
-            // we accept the first notification of any shape. If a failing
-            // update logs a non-zero value on the line that produced
-            // "Verification failed", the address in that message is a cursor,
-            // not a corrupt block.
             FW_LOG(QStringLiteral("A009 parsed: windowIncrement=%1 erase=%2 map=%3 firstError=%4")
                        .arg(parsed->windowIncrement)
                        .arg(parsed->fwToErase)
@@ -319,7 +311,7 @@ void DE1Device::onTransportDataReceived(const QBluetoothUuid& uuid, const QByteA
                        .arg(QString::fromLatin1(
                            QByteArray(reinterpret_cast<const char*>(parsed->firstError.data()), 3)
                                .toHex(' '))));
-            emit fwMapResponse(parsed->fwToErase, parsed->fwToMap,
+            emit fwMapResponse(parsed->windowIncrement, parsed->fwToErase, parsed->fwToMap,
                                QByteArray(reinterpret_cast<const char*>(parsed->firstError.data()), 3));
         } else {
             FW_WARN(QStringLiteral("A009 notify too short to parse: %1 bytes").arg(data.size()));

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1194,11 +1194,11 @@ void DE1Device::skipToNextFrame() {
     requestState(DE1::State::SkipToNext);
 }
 
-void DE1Device::goToSleep() {
+bool DE1Device::goToSleep() {
 #ifdef DECENZA_SIMULATOR
     if (m_simulationMode && m_simulator) {
         m_simulator->goToSleep();
-        return;
+        return true;
     }
 #endif
 
@@ -1208,7 +1208,7 @@ void DE1Device::goToSleep() {
     // REQUESTED_STATE and would otherwise bypass it.
     if (m_firmwareFlashInProgress) {
         DEVICE_WARN(QStringLiteral("Sleep requested during firmware flash, dropping"));
-        return;
+        return false;
     }
 
     // If a profile upload is in progress, defer sleep until it completes.
@@ -1216,10 +1216,10 @@ void DE1Device::goToSleep() {
         DEVICE_LOG(QStringLiteral("Sleep requested during profile upload, deferring until "
                                   "upload completes"));
         m_sleepPendingAfterUpload = true;
-        return;
+        return false;
     }
 
-    if (!m_transport) return;
+    if (!m_transport) return false;
     // Clear pending commands - sleep takes priority. Only drop the MMR
     // cache if something was actually queued — an empty queue means the
     // cache still matches what we've sent. Avoids a spurious re-send of
@@ -1233,6 +1233,7 @@ void DE1Device::goToSleep() {
     // Send sleep command directly (don't queue it)
     QByteArray data(1, static_cast<char>(DE1::State::Sleep));
     m_transport->writeUrgent(DE1::Characteristic::REQUESTED_STATE, data);
+    return true;
 }
 
 void DE1Device::wakeUp() {

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -351,8 +351,13 @@ signals:
     // Phase 1 the DE1 emits two notifications: first with fwToErase=1
     // (erase in progress), then fwToErase=0 (erase complete). Phase 3 emits
     // one notification whose firstError == {0xFF,0xFF,0xFD} on success.
-    void fwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
-                       QByteArray firstError);
+    //
+    // windowIncrement is carried because it is what separates a terminal
+    // response from an in-progress one. A verify notification with a
+    // non-zero WindowIncrement is not a verdict, and reading its FirstError
+    // as a corrupt-block address turns progress into a reported failure.
+    void fwMapResponse(uint16_t windowIncrement, uint8_t fwToErase,
+                       uint8_t fwToMap, QByteArray firstError);
     // Emitted after the DE1 reports its stored ShotSettings (either from our
     // initial read on connect or from an indication after a write). Values
     // are the DE1's current targets; 0 means the heater/setting is off.

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -207,7 +207,13 @@ public slots:
     void stopOperationUrgent(qint64 sawTriggerMs);  // Includes SAW trigger timestamp for latency tracing
     void requestIdle();           // Hard stop (requests Idle state, triggers steam purge)
     void skipToNextFrame();   // Skip to next profile frame during extraction (0x0E)
-    void goToSleep();
+    // Returns true when the sleep command actually reached the transport.
+    // False means it was dropped or deferred (flash in progress, profile
+    // upload in flight, no transport) — callers that need the machine
+    // genuinely asleep must check, not assume. Deliberately not [[nodiscard]]:
+    // most callers are fire-and-forget UI actions where a deferred sleep is
+    // fine, and only the firmware flash cares.
+    bool goToSleep();
     void wakeUp();
 
     // Profile upload
@@ -347,15 +353,19 @@ signals:
     void heaterVoltageChanged();
 
     // Firmware-update response from the DE1 (A009 notification). Carries
-    // the parsed fwToErase/fwToMap flags and the 3-byte FirstError. During
-    // Phase 1 the DE1 emits two notifications: first with fwToErase=1
-    // (erase in progress), then fwToErase=0 (erase complete). Phase 3 emits
-    // one notification whose firstError == {0xFF,0xFF,0xFD} on success.
+    // the parsed WindowIncrement, fwToErase/fwToMap flags and the 3-byte
+    // FirstError. de1app's spec describes two Phase 1 notifications —
+    // fwToErase=1 (erase in progress) then fwToErase=0 (erase complete) —
+    // but v1333+ sends only the completion one. Phase 3 emits a notification
+    // whose firstError == {0xFF,0xFF,0xFD} on success.
     //
-    // windowIncrement is carried because it is what separates a terminal
-    // response from an in-progress one. A verify notification with a
-    // non-zero WindowIncrement is not a verdict, and reading its FirstError
-    // as a corrupt-block address turns progress into a reported failure.
+    // windowIncrement is carried because it is part of what separates a
+    // terminal response from an in-progress one. It is not sufficient alone:
+    // FirstError == {0xFF,0xFF,0xFF} is the bootloader's "no error found"
+    // value and also what the caller writes into the request, so it comes
+    // back on in-progress notifications that are otherwise shaped exactly
+    // like a verdict. See FirmwareUpdater::onFwMapResponse for the full
+    // predicate.
     void fwMapResponse(uint16_t windowIncrement, uint8_t fwToErase,
                        uint8_t fwToMap, QByteArray firstError);
     // Emitted after the DE1 reports its stored ShotSettings (either from our

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -26,7 +26,7 @@ namespace {
 //
 // This was 10 s on Android and 1 s everywhere else, sourced from de1app —
 // but de1app branches on `$::has_bluetooth`, not on platform
-// (de1_comms.tcl:941-947). Its 1 s arm is the no-BLE dry run, a few lines
+// (de1_comms.tcl:940-950). Its 1 s arm is the no-BLE dry run, a few lines
 // below the block that fakes the connection handles because no machine is
 // attached; every real flash it performs waits 10 s regardless of OS. We
 // read that as "Android vs everything else", so iOS, macOS, Windows and
@@ -107,7 +107,7 @@ FirmwareUpdater::FirmwareUpdater(DE1Device* device, FirmwareAssetCache* cache,
                 this, &FirmwareUpdater::onDeviceFirmwareVersionChanged);
         connect(m_device, &DE1Device::simulationModeChanged,
                 this, &FirmwareUpdater::isSimulatedChanged);
-        // The writeComplete subscription is deferred to beginUploadPhase —
+        // The writeComplete subscription is deferred to beginErasePhase —
         // at construction time m_device->transport() is still null (the
         // BLE transport is attached later, when the user connects the DE1),
         // so a connect here would silently no-op and we'd never receive
@@ -570,20 +570,45 @@ void FirmwareUpdater::beginErasePhase() {
         return;
     }
     m_eraseInProgressSeen = false;
+    m_eraseRequestAcked   = false;
+
+    // Subscribe to write ACKs before the erase request goes out, so its own
+    // ACK is observed. Deferred until beginUploadPhase() originally, which
+    // was late enough that the erase phase had no way to tell a notification
+    // caused by this erase from one left over from a previous phase.
+    // Qt::UniqueConnection so retries don't stack handlers.
+    if (auto* t = m_device->transport()) {
+        connect(t, &DE1Transport::writeComplete,
+                this, &FirmwareUpdater::onFirmwareWriteAcked,
+                Qt::UniqueConnection);
+    }
 
     // Put the machine to sleep first. An awake DE1 runs its heaters, PID and
     // refill logic for the ~18 minutes this takes, on the same MCU that is
     // erasing and programming flash. reaprime/decaid requests sleep before
     // erase for this reason; de1app has the line but leaves it commented out.
-    // Preconditions already refused a flash mid-shot, so there is no
-    // in-progress operation to interrupt here.
+    // The precondition check refused a flash mid-shot, but it ran once in
+    // startUpdate() and the download happened since, so this is not a
+    // guarantee that nothing is running now — only that nothing was when the
+    // user tapped.
     //
     // Order matters: goToSleep() is itself dropped once the flash guard is
     // engaged (de1device.cpp — REQUESTED_STATE bypasses the MMR guard and so
     // carries its own check), so this must run *before* the line below. It
-    // writes via writeUrgent, which prepends to the transport queue, so the
-    // DE1 sees the sleep request ahead of the erase command.
-    m_device->goToSleep();
+    // writes via writeUrgent, which goes straight out when no write is in
+    // flight and otherwise prepends to the queue; either way the DE1 sees the
+    // sleep request ahead of the erase command.
+    //
+    // It can still decline — a profile upload in flight defers it, and the
+    // deferred retry is then dropped by the guard we are about to engage. Say
+    // so rather than letting the flash run with the heaters live and no trace
+    // of why.
+    if (!m_device->goToSleep()) {
+        qCWarning(firmwareLog).noquote()
+            << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+            << "[firmware] machine did not go to sleep before erase — flashing with "
+               "heaters/PID/refill live for the whole upload";
+    }
 
     // Engage the MMR-write guard on the device *before* we subscribe or
     // write anything. Firmware chunks share the WRITE_TO_MMR characteristic
@@ -672,12 +697,12 @@ void FirmwareUpdater::loadCachedPayload() {
     }
     m_firmwareBytes = f.readAll();
 
-    // Fingerprint what we are about to write to flash. FirmwareHeader's
-    // validateFile() only checks BoardMarker (offset 4) and a size floor, so
-    // a file assembled from two different revisions — which the cache's
-    // Range-resume path can produce — passes validation unchanged. A digest
-    // is the only thing that distinguishes the bytes we meant to flash from
-    // the bytes we have. Compare against the CDN file for the active channel.
+    // Fingerprint what we are about to write to flash. The cache now rejects
+    // a spliced file before it gets here (FirmwareAssetCache::versionMatchesMeta
+    // on the resume path, plus the size ceiling and structural checks in
+    // validateFile), so this is no longer the only line of defence — but it is
+    // the only one that states, in a submitted log, exactly which bytes went
+    // to the machine. Compare against the CDN file for the active channel.
     const QByteArray digest =
         QCryptographicHash::hash(m_firmwareBytes, QCryptographicHash::Sha256).toHex();
     auto header = DE1::Firmware::parseHeader(m_firmwareBytes);
@@ -718,6 +743,14 @@ void FirmwareUpdater::onChunkPumpTick() {
 
 void FirmwareUpdater::onFirmwareWriteAcked(const QBluetoothUuid& uuid,
                                            const QByteArray& data) {
+    // The erase request's own ACK is what proves this erase cycle has begun.
+    // Until it lands, an A009 notification in state Erasing cannot have been
+    // caused by our request — see onFwMapResponse.
+    if (m_state == State::Erasing && uuid == DE1::Characteristic::FW_MAP_REQUEST) {
+        m_eraseRequestAcked = true;
+        return;
+    }
+
     if (m_state != State::Uploading) return;
     // Filter: only count ACKs for 20-byte WriteToMMR packets carrying the
     // firmware-chunk length byte (16). Skips any other traffic that might
@@ -767,13 +800,13 @@ void FirmwareUpdater::beginVerifyPhase() {
     setProgress(PROGRESS_UPLOAD_MAX);
 
     // Match de1app's exact ordering: re-enable A009 notifications RIGHT
-    // before sending the verify request (de1_comms.tcl:962). The heavy
+    // before sending the verify request (de1_comms.tcl:991). The heavy
     // upload-write burst can invalidate the CCCD subscription on Android
     // BLE, and the bootloader appears to re-arm its notification handlers
     // after the write phase. Calling subscribe here is the single change
     // that distinguishes "no verify response" from "success notification
     // arrives within seconds". Note that de1app also leaves the original
-    // erase-phase subscription disabled (line 876 commented out) — but
+    // erase-phase subscription disabled (line 903 commented out) — but
     // we keep ours active for diagnostic visibility into the erase-done
     // notification, which has no protocol cost.
     m_device->subscribeFirmwareNotifications();
@@ -805,6 +838,21 @@ void FirmwareUpdater::onFwMapResponse(uint16_t windowIncrement, uint8_t fwToEras
         if (windowIncrement != 0 || fwToMap != 1) {
             return;  // not the erase-complete shape
         }
+        if (!m_eraseRequestAcked) {
+            // Our erase request has not been ACKed yet, so this notification
+            // cannot be its answer. A terminal VERIFY notification has the
+            // identical shape (windowIncrement 0, erase 0, map 1), and the
+            // retry path makes that reachable: a verify that timed out at 60 s
+            // leaves the DE1 still scanning, the user taps Retry, and the late
+            // verify response lands in the new Erasing window. Acting on it
+            // would stream the whole upload into a bank still being erased —
+            // the exact failure this phase exists to avoid.
+            qCDebug(firmwareLog).noquote()
+                << "[firmware] ignoring A009 notification before the erase request "
+                   "was ACKed (stale response from a previous phase): firstError="
+                << firstError.toHex(' ');
+            return;
+        }
         // Erase complete. Deliberately does NOT test firstError: the DE1
         // echoes back whatever we put in that field on the erase request
         // (we send 0,0,0 and get 0,0,0 — captured flash, DE1+/PCB 1.3), so
@@ -822,18 +870,31 @@ void FirmwareUpdater::onFwMapResponse(uint16_t windowIncrement, uint8_t fwToEras
     }
 
     if (m_state == State::Verifying) {
-        // Only a notification with WindowIncrement == 0 and fwToMap == 1 is a
-        // verdict. Anything else is the bootloader talking mid-scan, and its
-        // FirstError is a cursor rather than a corrupt-block address —
-        // reporting it as "Verification failed at block A.B.C" turns normal
-        // progress into a permanent-looking failure that survives Retry.
-        // reaprime/decaid filters on exactly these two fields. Keep waiting;
-        // the verify timeout is the backstop if no verdict ever arrives.
-        if (windowIncrement != 0 || fwToMap != 1) {
+        // A notification is a verdict only when all four of these hold, which
+        // is reaprime/decaid's `_isTerminalVerificationResponse`
+        // (unified_de1.firmware.dart:142-147): WindowIncrement == 0,
+        // fwToErase == 0, fwToMap == 1, and FirstError != FF FF FF.
+        //
+        // The last condition is the one that is easy to drop and expensive to
+        // get wrong. FF FF FF is the bootloader's "no error found" value, and
+        // it is also what we ourselves write into the verify request
+        // (beginVerifyPhase) — the DE1 echoes that field back, as the erase
+        // phase above shows. So an in-progress verify notification carries
+        // FF FF FF with WindowIncrement == 0 and fwToMap == 1, passes any
+        // filter built on the first three conditions, compares unequal to
+        // FF FF FD, and reports "Verification failed at block 255.255.255"
+        // on a flash that was still verifying. Success is FF FF FD and a real
+        // failure carries a real address; FF FF FF is neither.
+        //
+        // Keep waiting; the verify timeout is the backstop if no verdict ever
+        // arrives.
+        const QByteArray noErrorYet = QByteArray::fromHex("FFFFFF");
+        if (windowIncrement != 0 || fwToErase != 0 || fwToMap != 1 ||
+            firstError == noErrorYet) {
             qCDebug(firmwareLog).noquote()
                 << "[firmware] ignoring non-terminal verify notification: "
-                   "windowIncrement=" << windowIncrement << "map=" << fwToMap
-                << "firstError=" << firstError.toHex(' ');
+                   "windowIncrement=" << windowIncrement << "erase=" << fwToErase
+                << "map=" << fwToMap << "firstError=" << firstError.toHex(' ');
             return;
         }
         m_verifyTimeoutTimer.stop();

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -4,7 +4,6 @@
 #include <QDebug>
 #include <QFile>
 #include <QLoggingCategory>
-#include <QOperatingSystemVersion>
 
 #include "ble/de1device.h"
 #include "ble/de1transport.h"
@@ -22,19 +21,27 @@ using namespace DE1::Firmware;
 
 namespace {
 
-constexpr int DEFAULT_POST_ERASE_WAIT_ANDROID_MS = 10000;
-constexpr int DEFAULT_POST_ERASE_WAIT_OTHER_MS   = 1000;
+// Fixed wait between the erase command and the first firmware chunk, on
+// every platform.
+//
+// This was 10 s on Android and 1 s everywhere else, sourced from de1app —
+// but de1app branches on `$::has_bluetooth`, not on platform
+// (de1_comms.tcl:941-947). Its 1 s arm is the no-BLE dry run, a few lines
+// below the block that fakes the connection handles because no machine is
+// attached; every real flash it performs waits 10 s regardless of OS. We
+// read that as "Android vs everything else", so iOS, macOS, Windows and
+// Linux inherited the no-machine timing, and the docs grew a rationale
+// ("an Android-specific BLE race") that nothing in de1app supports.
+//
+// 1 s is not merely unjustified, it is too short: a captured flash on a
+// DE1+/PCB 1.3 took 1.31 s to report erase-complete, so the chunk pump
+// would have started while the bootloader was still erasing.
+constexpr int DEFAULT_POST_ERASE_WAIT_MS = 10000;
 
 // Progress weighting so the bar doesn't sit at 0% and 100% for seconds at
 // a time. See docs/plans/2026-04-20-firmware-update-design.md §5.3.
 constexpr double PROGRESS_ERASE_MAX  = 0.10;
 constexpr double PROGRESS_UPLOAD_MAX = 0.90;
-
-int defaultPostEraseWaitMs() {
-    return (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::Android)
-        ? DEFAULT_POST_ERASE_WAIT_ANDROID_MS
-        : DEFAULT_POST_ERASE_WAIT_OTHER_MS;
-}
 
 // Format an elapsed count as "[+MM:SS.ms]" — fits long uploads and is
 // trivially greppable with /\[\+\d+:/ to strip back to phase order.
@@ -55,7 +62,7 @@ FirmwareUpdater::FirmwareUpdater(DE1Device* device, FirmwareAssetCache* cache,
     : QObject(parent)
     , m_device(device)
     , m_cache(cache)
-    , m_postEraseWaitMs(defaultPostEraseWaitMs())
+    , m_postEraseWaitMs(DEFAULT_POST_ERASE_WAIT_MS)
 {
     m_postEraseWaitTimer.setSingleShot(true);
     m_eraseTimeoutTimer.setSingleShot(true);
@@ -563,6 +570,21 @@ void FirmwareUpdater::beginErasePhase() {
         return;
     }
     m_eraseInProgressSeen = false;
+
+    // Put the machine to sleep first. An awake DE1 runs its heaters, PID and
+    // refill logic for the ~18 minutes this takes, on the same MCU that is
+    // erasing and programming flash. reaprime/decaid requests sleep before
+    // erase for this reason; de1app has the line but leaves it commented out.
+    // Preconditions already refused a flash mid-shot, so there is no
+    // in-progress operation to interrupt here.
+    //
+    // Order matters: goToSleep() is itself dropped once the flash guard is
+    // engaged (de1device.cpp — REQUESTED_STATE bypasses the MMR guard and so
+    // carries its own check), so this must run *before* the line below. It
+    // writes via writeUrgent, which prepends to the transport queue, so the
+    // DE1 sees the sleep request ahead of the erase command.
+    m_device->goToSleep();
+
     // Engage the MMR-write guard on the device *before* we subscribe or
     // write anything. Firmware chunks share the WRITE_TO_MMR characteristic
     // with regular MMR writes (distinguished only by the length byte), so a
@@ -574,17 +596,19 @@ void FirmwareUpdater::beginErasePhase() {
     m_device->writeFWMapRequest(/*erase*/ 1, /*map*/ 1);
     setProgress(0.02);  // visible motion as Phase 1 starts
 
-    // Match de1app's behaviour: don't gate the next phase on receiving the
-    // erase-complete notification. de1app sends the erase command and waits
-    // a fixed OS-appropriate delay (10 s Android / 1 s other) before
-    // starting the chunk pump — see de1_comms.tcl:913 / :920. The
-    // notifications are informational; if Android BLE drops the CCCD
-    // subscription or the DE1 doesn't emit them on this firmware, we
-    // would otherwise hang in Erasing forever waiting for a signal that
-    // never arrives. Use the post-erase timer as the single source of
-    // truth for "erase done, start uploading".
-    qCDebug(firmwareLog) << "[firmware] erase command sent, waiting"
-                         << m_postEraseWaitMs << "ms before chunk pump";
+    // The DE1 tells us when the erase is done; prefer that over the clock.
+    // The erase-complete notification (fwToErase=0, fwToMap=1) starts the
+    // chunk pump as soon as it lands — reaprime/decaid does the same, and a
+    // captured DE1+/PCB 1.3 flash reported it at +1.31 s against a 10 s
+    // wait. The timer stays as the fallback rather than the sole source of
+    // truth, because the notification can genuinely fail to arrive: the
+    // A009 CCCD subscription is fragile enough that verify has to re-subscribe
+    // (see beginVerifyPhase), and de1app gates on nothing at all. So a
+    // dropped notification costs the old fixed delay instead of hanging in
+    // Erasing forever.
+    qCDebug(firmwareLog) << "[firmware] erase command sent, waiting for "
+                            "erase-complete notification or"
+                         << m_postEraseWaitMs << "ms, whichever is first";
     if (m_postEraseWaitMs <= 0) {
         onPostEraseWaitComplete();
     } else {
@@ -764,27 +788,54 @@ void FirmwareUpdater::onVerifyTimeout() {
 
 // ---- fwMapResponse router ----------------------------------------------
 
-void FirmwareUpdater::onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
-                                     QByteArray firstError) {
-    Q_UNUSED(fwToMap);
-
+void FirmwareUpdater::onFwMapResponse(uint16_t windowIncrement, uint8_t fwToErase,
+                                     uint8_t fwToMap, QByteArray firstError) {
     qCDebug(firmwareLog).noquote()
-        << "[firmware] fwMapResponse received: erase=" << fwToErase
+        << "[firmware] fwMapResponse received: windowIncrement=" << windowIncrement
+        << "erase=" << fwToErase
         << "map=" << fwToMap << "firstError=" << firstError.toHex(' ');
 
     if (m_state == State::Erasing) {
-        // Per de1app, these are informational during the erase phase — we
-        // don't gate the post-erase wait on them anymore. Logged so we can
-        // see whether the DE1 is actually sending them on this firmware
-        // generation, and tracked so verify-phase logic can use the flag
-        // if needed.
         if (fwToErase == 1) {
+            // "Still erasing." Older firmware emits this before the
+            // completion notification; v1333+ skips it. Informational.
             m_eraseInProgressSeen = true;
+            return;
         }
+        if (windowIncrement != 0 || fwToMap != 1) {
+            return;  // not the erase-complete shape
+        }
+        // Erase complete. Deliberately does NOT test firstError: the DE1
+        // echoes back whatever we put in that field on the erase request
+        // (we send 0,0,0 and get 0,0,0 — captured flash, DE1+/PCB 1.3), so
+        // comparing it to a constant tests our own outbound bytes, not the
+        // machine. decaid's _isEraseComplete does exactly that against
+        // 0xFF,0xFF,0xFF because 0xFF,0xFF,0xFF is what it happens to send.
+        qCDebug(firmwareLog).noquote()
+            << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+            << "[firmware] erase-complete notification — starting chunk pump "
+               "without waiting out the remaining"
+            << m_postEraseWaitTimer.remainingTime() << "ms";
+        m_postEraseWaitTimer.stop();
+        onPostEraseWaitComplete();
         return;
     }
 
     if (m_state == State::Verifying) {
+        // Only a notification with WindowIncrement == 0 and fwToMap == 1 is a
+        // verdict. Anything else is the bootloader talking mid-scan, and its
+        // FirstError is a cursor rather than a corrupt-block address —
+        // reporting it as "Verification failed at block A.B.C" turns normal
+        // progress into a permanent-looking failure that survives Retry.
+        // reaprime/decaid filters on exactly these two fields. Keep waiting;
+        // the verify timeout is the backstop if no verdict ever arrives.
+        if (windowIncrement != 0 || fwToMap != 1) {
+            qCDebug(firmwareLog).noquote()
+                << "[firmware] ignoring non-terminal verify notification: "
+                   "windowIncrement=" << windowIncrement << "map=" << fwToMap
+                << "firstError=" << firstError.toHex(' ');
+            return;
+        }
         m_verifyTimeoutTimer.stop();
         const QByteArray expected = QByteArray::fromHex("FFFFFD");
         if (firstError == expected) {

--- a/src/controllers/firmwareupdater.h
+++ b/src/controllers/firmwareupdater.h
@@ -193,6 +193,11 @@ private:
     bool        m_updateAvailable  = false;
     bool        m_isDowngrade      = false;
     bool        m_isReflash        = false;
+    // Set when the erase FWMapRequest's own write ACK arrives. Until then an
+    // A009 notification in state Erasing cannot be this cycle's erase-complete
+    // — a terminal verify notification is byte-identical, and the retry path
+    // can deliver one late.
+    bool        m_eraseRequestAcked = false;
     uint32_t    m_availableVersion = 0;
     uint32_t    m_installedVersion = 0;
     double      m_progress         = 0.0;
@@ -213,9 +218,12 @@ private:
     qsizetype   m_chunksQueued     = 0;   // handed to BleTransport
     qsizetype   m_chunksAcked      = 0;   // confirmed by DE1 via writeComplete
 
-    // Erase state: de1app expects *two* notifications — first fwToErase=1
-    // (erase in progress), then fwToErase=0 (erase complete). We only
-    // proceed after the second.
+    // Erase state. de1app's spec describes *two* notifications — fwToErase=1
+    // (in progress), then fwToErase=0 (complete) — but v1333+ sends only the
+    // second, so progression cannot be gated on having seen the first. This
+    // records whether it arrived, for the log and for older firmware; the
+    // transition is driven by the completion notification alone (with the
+    // post-erase timer as fallback).
     bool        m_eraseInProgressSeen = false;
 
     // Dismissed-version memory. When the user taps the banner's "x",

--- a/src/controllers/firmwareupdater.h
+++ b/src/controllers/firmwareupdater.h
@@ -102,7 +102,7 @@ public:
 
     // Timing knobs (defaults match the spec). Tests set these to small
     // values to avoid minute-long test runs.
-    void setPostEraseWaitMs(int ms);          // default 10000 (Android) or 1000 (other)
+    void setPostEraseWaitMs(int ms);          // default 10000, every platform
     void setChunkPumpIntervalMs(int ms);      // default 1
     void setEraseTimeoutMs(int ms);           // default 30000
     void setVerifyTimeoutMs(int ms);          // default 60000
@@ -165,7 +165,8 @@ private slots:
     void onDownloadFinished(QString path, DE1::Firmware::Header header);
     void onDownloadFailed(QString reason);
     void onDownloadProgress(qint64 received, qint64 total);
-    void onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap, QByteArray firstError);
+    void onFwMapResponse(uint16_t windowIncrement, uint8_t fwToErase,
+                         uint8_t fwToMap, QByteArray firstError);
     void onDeviceConnectionChanged();
     void onDeviceFirmwareVersionChanged();
     void onPostEraseWaitComplete();
@@ -265,7 +266,7 @@ private:
     // NB: these inline initializers are the actual defaults. The
     // constexpr DEFAULT_*_MS values in firmwareupdater.cpp are advisory
     // documentation only — they're never used to construct these members.
-    int         m_postEraseWaitMs      = 0;       // overridden in ctor based on OS
+    int         m_postEraseWaitMs      = 0;       // set in ctor; see DEFAULT_POST_ERASE_WAIT_MS
     int         m_chunkPumpIntervalMs  = 1;
     int         m_eraseTimeoutMs       = 30000;
     int         m_verifyTimeoutMs      = 60000;   // bumped from 10000; see below

--- a/src/core/firmwareassetcache.cpp
+++ b/src/core/firmwareassetcache.cpp
@@ -85,6 +85,16 @@ std::optional<Header> FirmwareAssetCache::cachedHeader() const {
     return parseHeader(bytes);
 }
 
+bool FirmwareAssetCache::versionMatchesMeta(uint32_t headerVersion) const {
+    // The sidecar's version is what the server reported for the ETag it is
+    // currently serving on this channel, read from a 64-byte Range GET during
+    // the availability check. A cached file whose header disagrees is not the
+    // file the check was about: a leftover from the other channel, or a body
+    // spliced from an older revision. Zero means we have never completed a
+    // check, so there is nothing to contradict and the file is taken as-is.
+    return m_meta.version == 0 || m_meta.version == headerVersion;
+}
+
 void FirmwareAssetCache::clearCache() {
     abortActiveReply();
     cleanUpDownloadFile();
@@ -297,19 +307,46 @@ void FirmwareAssetCache::downloadIfNeeded() {
                          << "metaVersion=" << m_meta.version
                          << "metaEtag=" << m_meta.etag;
     if (info.exists()) {
-        auto header = cachedHeader();
-        if (header && header->boardMarker == BOARD_MARKER &&
-            info.size() >= qint64(header->byteCount) + HEADER_SIZE) {
-            // Short-circuit: the on-disk file is *accepted without contacting
-            // the server*. Nothing here proves it came from the channel we are
-            // now on — only that its first 64 bytes parse and it is long
-            // enough. Log the version we are about to hand back so a mismatch
-            // against the UI's "Available:" is visible in the trail.
+        auto validated = validateFile(cachePath());
+        if (validated.status == Validation::Ok &&
+            versionMatchesMeta(validated.header.version)) {
+            // Short-circuit: the on-disk file is accepted without contacting
+            // the server. Log the version we hand back so a mismatch against
+            // the UI's "Available:" is visible in the trail.
             qCDebug(firmwareLog) << "[firmware] using cached file without "
-                                    "download: version=" << header->version
+                                    "download: version=" << validated.header.version
                                  << "size=" << info.size();
-            emit downloadFinished(cachePath(), *header);
+            emit downloadFinished(cachePath(), validated.header);
             return;
+        }
+        // Not usable as-is. Resuming onto it is only safe when the bytes on
+        // disk are a genuine prefix of the revision we are about to fetch —
+        // i.e. an interrupted download of *this* file. That is exactly the
+        // Truncated case with a matching Version.
+        //
+        // Any other state must be wiped rather than resumed. The resume below
+        // sends `Range: bytes=<size>-` and appends, so resuming onto a
+        // different revision splices that revision's body to the new one's
+        // tail. The result is a file of the correct total length whose first
+        // 64 bytes are a valid header — it passes BoardMarker, the size
+        // floor and every structural check, and the corruption is only
+        // discovered by the DE1 at the end of a ~18-minute flash.
+        const bool resumable =
+            validated.status == Validation::Truncated &&
+            versionMatchesMeta(validated.header.version);
+        if (resumable) {
+            qCDebug(firmwareLog) << "[firmware] resuming interrupted download of "
+                                    "version" << validated.header.version
+                                 << "from byte" << info.size();
+        } else {
+            qCWarning(firmwareLog) << "[firmware] discarding cached file:"
+                                   << (validated.status == Validation::Ok
+                                           ? QStringLiteral("header version %1 is not the %2 "
+                                                            "the server reported for this ETag")
+                                                 .arg(validated.header.version).arg(m_meta.version)
+                                           : validated.errorDetail);
+            QFile::remove(cachePath());
+            info.refresh();
         }
     }
 
@@ -397,6 +434,17 @@ void FirmwareAssetCache::onDownloadFinished() {
     }
 
     auto result = validateFile(cachePath());
+    if (result.status == Validation::Ok && !versionMatchesMeta(result.header.version)) {
+        // Structurally sound but not the revision this channel is serving —
+        // the signature of a resume that spliced two images. Force the
+        // failure here rather than letting it reach the flash.
+        result.status = Validation::MalformedHeader;
+        result.errorDetail = QStringLiteral(
+            "Downloaded firmware reports version %1, but the server said this "
+            "channel is serving %2. The download was assembled from more than "
+            "one revision; it has been discarded.")
+            .arg(result.header.version).arg(m_meta.version);
+    }
     if (result.status != Validation::Ok) {
         // On any validation failure, the cached file is either invalid or
         // incomplete — either way, wipe it so the next retry starts clean

--- a/src/core/firmwareassetcache.cpp
+++ b/src/core/firmwareassetcache.cpp
@@ -300,6 +300,12 @@ void FirmwareAssetCache::downloadIfNeeded() {
 
     // If we already have a validated file matching the sidecar version,
     // skip the download entirely — the caller can use cachedPath/cachedHeader.
+    // Byte offset a resume should continue from; 0 means "download the whole
+    // body". Tracked explicitly rather than re-derived from the file's size
+    // later, so that a failed delete cannot silently turn a rejected file
+    // back into a resume target.
+    qint64 resumeFrom = 0;
+
     QFileInfo info(cachePath());
     qCDebug(firmwareLog) << "[firmware] downloadIfNeeded: channel="
                          << currentUrl() << "existingBytes="
@@ -331,13 +337,22 @@ void FirmwareAssetCache::downloadIfNeeded() {
         // 64 bytes are a valid header — it passes BoardMarker, the size
         // floor and every structural check, and the corruption is only
         // discovered by the DE1 at the end of a ~18-minute flash.
+        //
+        // A known sidecar version is required, not merely a matching one:
+        // m_meta.version == 0 means we have never completed a check (or the
+        // sidecar is unreadable), so there is nothing to compare against and
+        // "matches" would be vacuously true — exactly the state the guard
+        // exists to reject. A full re-download is cheap next to flashing a
+        // wrong image.
         const bool resumable =
             validated.status == Validation::Truncated &&
+            m_meta.version != 0 &&
             versionMatchesMeta(validated.header.version);
         if (resumable) {
+            resumeFrom = info.size();
             qCDebug(firmwareLog) << "[firmware] resuming interrupted download of "
                                     "version" << validated.header.version
-                                 << "from byte" << info.size();
+                                 << "from byte" << resumeFrom;
         } else {
             qCWarning(firmwareLog) << "[firmware] discarding cached file:"
                                    << (validated.status == Validation::Ok
@@ -345,8 +360,12 @@ void FirmwareAssetCache::downloadIfNeeded() {
                                                             "the server reported for this ETag")
                                                  .arg(validated.header.version).arg(m_meta.version)
                                            : validated.errorDetail);
-            QFile::remove(cachePath());
-            info.refresh();
+            // Deliberately not gated on the result: a failed remove (locked
+            // file, permissions) must not leave us resuming onto the bytes we
+            // just rejected. resumeFrom stays 0 and the file is opened with
+            // Truncate below, so the restart is clean whether or not this
+            // succeeded.
+            (void)QFile::remove(cachePath());
         }
     }
 
@@ -359,28 +378,22 @@ void FirmwareAssetCache::downloadIfNeeded() {
     req.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
                      QNetworkRequest::NoLessSafeRedirectPolicy);
 
-    // Resume-from-partial if we have usable bytes on disk. The existing
-    // partial-size vs. expected-total check is conservative: when we have
-    // no previous ETag we don't know the expected total yet, which the
-    // rangeHeaderFor() "unknownTotal" branch handles.
-    qint64 existing = info.exists() ? info.size() : 0;
-    auto rangeHeader = rangeHeaderFor(existing, /*unknown total*/ -1);
+    auto rangeHeader = rangeHeaderFor(resumeFrom, /*unknown total*/ -1);
+    m_resumedDownload = rangeHeader.has_value();
     if (rangeHeader) {
         req.setRawHeader("Range", *rangeHeader);
-    } else {
-        // Either nothing on disk or a weird overrun → wipe and start clean.
-        if (existing > 0) {
-            QFile::remove(cachePath());
-        }
-        existing = 0;
     }
 
-    // Open the download file in append-or-create mode. QIODevice::Append is
-    // what we want: if Range was set, we pick up where the file left off;
-    // otherwise the file was just removed, so there's nothing to append
-    // over and Append is equivalent to WriteOnly.
+    // Append only when resuming; otherwise Truncate. Truncate is what makes
+    // the restart safe without trusting the delete above to have worked — an
+    // Append onto a file that failed to delete would splice the whole body
+    // onto the rejected bytes, which is the corruption this all exists to
+    // prevent.
     m_downloadFile = new QFile(cachePath());
-    if (!m_downloadFile->open(QIODevice::Append)) {
+    const auto openMode = m_resumedDownload
+                          ? QIODevice::Append
+                          : (QIODevice::WriteOnly | QIODevice::Truncate);
+    if (!m_downloadFile->open(openMode)) {
         const QString msg = QStringLiteral("Cannot open cache file for writing: %1")
                             .arg(m_downloadFile->errorString());
         cleanUpDownloadFile();
@@ -400,6 +413,30 @@ void FirmwareAssetCache::downloadIfNeeded() {
 
 void FirmwareAssetCache::onDownloadReadyRead() {
     if (!m_activeReply || !m_downloadFile) return;
+
+    // A resume is only a resume if the server honoured the Range. Servers,
+    // proxies and redirect targets are all free to ignore it and answer 200
+    // with the WHOLE body — and NoLessSafeRedirectPolicy is set, so a
+    // redirect that drops the header is reachable. Appending a full body to a
+    // partial produces an oversized file whose header is the partial's, which
+    // passes the version check (that is why the resume was allowed) and every
+    // structural check. Abandon the resume and restart clean instead.
+    if (m_resumedDownload && !m_rangeHonoured) {
+        const int status = m_activeReply->attribute(
+            QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (status != 206) {
+            qCWarning(firmwareLog) << "[firmware] resume requested but server answered"
+                                   << status << "- restarting the download from scratch";
+            abortActiveReply();
+            cleanUpDownloadFile();
+            (void)QFile::remove(cachePath());
+            m_resumedDownload = false;
+            downloadIfNeeded();   // cache file is gone, so this cannot re-resume
+            return;
+        }
+        m_rangeHonoured = true;
+    }
+
     QByteArray chunk = m_activeReply->readAll();
     if (!chunk.isEmpty()) {
         m_downloadFile->write(chunk);
@@ -433,16 +470,30 @@ void FirmwareAssetCache::onDownloadFinished() {
         return;
     }
 
+    const bool wasResumed = m_resumedDownload;
+    m_resumedDownload = false;
+    m_rangeHonoured   = false;
+
     auto result = validateFile(cachePath());
-    if (result.status == Validation::Ok && !versionMatchesMeta(result.header.version)) {
-        // Structurally sound but not the revision this channel is serving —
-        // the signature of a resume that spliced two images. Force the
-        // failure here rather than letting it reach the flash.
+    if (result.status == Validation::Ok && wasResumed &&
+        !versionMatchesMeta(result.header.version)) {
+        // A RESUMED body whose header is not the revision we expected is a
+        // splice: old bytes on disk, new bytes appended.
+        //
+        // This must not be applied to a fresh, complete download. startUpdate()
+        // goes straight to downloadIfNeeded() with no new HEAD, so m_meta
+        // holds whatever the last availability check wrote — 30 s after launch,
+        // then weekly. On a tablet left running for days, against a channel
+        // that republishes (nightly does, constantly), a perfectly good
+        // single-revision download can legitimately be newer than the sidecar.
+        // Rejecting that would accuse the server of splicing, delete the file,
+        // and leave Retry looping on the identical rejection until the next
+        // scheduled check — unrecoverable from the UI.
         result.status = Validation::MalformedHeader;
         result.errorDetail = QStringLiteral(
-            "Downloaded firmware reports version %1, but the server said this "
-            "channel is serving %2. The download was assembled from more than "
-            "one revision; it has been discarded.")
+            "Resumed download reports version %1, but the partial on disk was "
+            "version %2. The file was assembled from more than one revision; "
+            "it has been discarded.")
             .arg(result.header.version).arg(m_meta.version);
     }
     if (result.status != Validation::Ok) {

--- a/src/core/firmwareassetcache.h
+++ b/src/core/firmwareassetcache.h
@@ -180,6 +180,11 @@ public:
     std::optional<Header> cachedHeader() const;
     std::optional<MetaJson> cachedMeta() const { return m_meta; }
 
+    // True when `headerVersion` agrees with the version the sidecar recorded
+    // for the ETag this channel is currently serving — the check that tells a
+    // genuine partial of this revision apart from a leftover of another one.
+    bool versionMatchesMeta(uint32_t headerVersion) const;
+
     // Wipe the cache file and the sidecar meta. Used when the user resets,
     // or when validation finds a permanently-invalid file.
     void clearCache();

--- a/src/core/firmwareassetcache.h
+++ b/src/core/firmwareassetcache.h
@@ -228,6 +228,14 @@ private:
     MetaJson m_meta;
     bool     m_metaLoaded = false;
 
+    // True while the in-flight GET carries a Range header, and true once that
+    // Range has been confirmed honoured (HTTP 206). Both are cleared when the
+    // download finishes. The version cross-check on the completed file only
+    // applies to a resumed body — a fresh complete download that is simply
+    // newer than the sidecar is legitimate, not a splice.
+    bool     m_resumedDownload = false;
+    bool     m_rangeHonoured   = false;
+
     QNetworkReply* m_activeReply = nullptr;
     QFile*         m_downloadFile = nullptr;
     QByteArray     m_pendingEtag;             // ETag of in-flight HEAD response

--- a/src/core/firmwareheader.h
+++ b/src/core/firmwareheader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <optional>
@@ -85,7 +86,8 @@ enum class Validation {
     UnreadableFile,
     TooShortHeader,
     BadBoardMarker,
-    Truncated
+    Truncated,
+    MalformedHeader
 };
 
 struct ValidationResult {
@@ -143,6 +145,35 @@ inline ValidationResult validateFile(const QString& path) {
         result.errorDetail = QStringLiteral(
             "Firmware file truncated: have %1 bytes, need at least %2 (ByteCount + header)"
         ).arg(info.size()).arg(expected);
+        return result;
+    }
+
+    // Internal-consistency checks, adopted from reaprime/decaid's
+    // FirmwareValidator. They cost nothing and reject a file whose header is
+    // structurally impossible — which BoardMarker plus a size floor does not,
+    // since BoardMarker sits at offset 4 and is identical in every DE1 image
+    // ever published. A file spliced from two revisions passes both of the
+    // checks above unchanged.
+    const auto& h = result.header;
+    QString malformed;
+    if (h.byteCount == 0) {
+        malformed = QStringLiteral("ByteCount is zero");
+    } else if (h.cpuBytes == 0 || h.cpuBytes > h.byteCount) {
+        malformed = QStringLiteral("CpuBytes %1 is not within ByteCount %2")
+                        .arg(h.cpuBytes).arg(h.byteCount);
+    } else if (h.unused != 0) {
+        malformed = QStringLiteral("reserved header field is %1, expected 0").arg(h.unused);
+    } else if (h.checksum == 0 || h.dcSum == 0 || h.headerChecksum == 0) {
+        // The algorithms are undocumented (TODO(firmware-crc)), so we cannot
+        // recompute these — but a real image never leaves them zero, so an
+        // all-zero field still means the header is not a published one.
+        malformed = QStringLiteral("checksum fields are incomplete");
+    } else if (std::all_of(h.iv.begin(), h.iv.end(), [](uint8_t b) { return b == 0; })) {
+        malformed = QStringLiteral("payload IV is all zeroes");
+    }
+    if (!malformed.isEmpty()) {
+        result.status = Validation::MalformedHeader;
+        result.errorDetail = QStringLiteral("Invalid DE1 firmware header: %1").arg(malformed);
         return result;
     }
 

--- a/src/core/firmwareheader.h
+++ b/src/core/firmwareheader.h
@@ -18,12 +18,14 @@
 // and HeaderChecksum (offsets 28-59 and 60-63) were added to support
 // encrypted payloads and are currently opaque to Decenza.
 //
-// Client-side validation is limited to BoardMarker equality and a
-// byte-count sanity check against the on-disk file size. The CheckSum,
-// DCSum, and HeaderChecksum algorithms are pending a protocol question
-// to Decent (see TODO(firmware-crc)); the DE1's own verify-phase
-// response (FirstError == {0xFF, 0xFF, 0xFD}) is the authoritative
-// correctness gate for the flashed image.
+// Client-side validation covers BoardMarker equality, the on-disk file
+// size against ByteCount (both a floor and a ceiling), and a set of
+// structural invariants on the remaining header fields — see
+// validateFile(). The CheckSum, DCSum and HeaderChecksum *algorithms* are
+// pending a protocol question to Decent (see TODO(firmware-crc)), so those
+// fields can only be asserted non-empty, not recomputed; the DE1's own
+// verify-phase response (FirstError == {0xFF, 0xFF, 0xFD}) remains the
+// authoritative correctness gate for the flashed image.
 
 namespace DE1::Firmware {
 
@@ -97,9 +99,11 @@ struct ValidationResult {
 };
 
 // Validate an on-disk bootfwupdate.dat. Reads the first HEADER_SIZE bytes,
-// parses them, and checks BoardMarker + file-size sanity. Does NOT compute
-// any of the opaque checksum fields — those await a protocol answer from
-// Decent (TODO(firmware-crc)).
+// parses them, and checks BoardMarker, the file size against ByteCount in
+// both directions, and the structural invariants listed at the bottom of
+// the function. Does NOT recompute the opaque checksum fields — those await
+// a protocol answer from Decent (TODO(firmware-crc)) — but does reject them
+// when zero, since no published image leaves them empty.
 inline ValidationResult validateFile(const QString& path) {
     ValidationResult result;
 
@@ -144,6 +148,24 @@ inline ValidationResult validateFile(const QString& path) {
         result.status = Validation::Truncated;
         result.errorDetail = QStringLiteral(
             "Firmware file truncated: have %1 bytes, need at least %2 (ByteCount + header)"
+        ).arg(info.size()).arg(expected);
+        return result;
+    }
+
+    // Upper bound as well as a floor. A file LONGER than its own header
+    // declares is the signature of a resume the server answered with the
+    // whole body instead of the requested range: the partial's bytes with a
+    // complete copy appended. Published images carry a small trailing pad
+    // (nightly v1352 is 463,872 bytes against a ByteCount of 461,824, so
+    // 1,984 bytes past ByteCount + 64), so the ceiling has to allow slack —
+    // but not a second image's worth. A whole duplicate body is orders of
+    // magnitude past this.
+    constexpr qint64 MAX_TRAILING_SLACK = 64 * 1024;
+    if (info.size() > expected + MAX_TRAILING_SLACK) {
+        result.status = Validation::MalformedHeader;
+        result.errorDetail = QStringLiteral(
+            "Firmware file oversized: %1 bytes against a declared %2 "
+            "(ByteCount + header). A body was appended to a partial download."
         ).arg(info.size()).arg(expected);
         return result;
     }

--- a/tests/tst_de1device_firmware.cpp
+++ b/tests/tst_de1device_firmware.cpp
@@ -142,9 +142,27 @@ private slots:
 
         QCOMPARE(spy.count(), 1);
         const QList<QVariant> args = spy.takeFirst();
-        QCOMPARE(args.at(0).toUInt(),         0u);                           // fwToErase
-        QCOMPARE(args.at(1).toUInt(),         1u);                           // fwToMap
-        QCOMPARE(args.at(2).toByteArray(),    QByteArray::fromHex("FFFFFD"));// firstError
+        QCOMPARE(args.at(0).toUInt(),         0u);                           // windowIncrement
+        QCOMPARE(args.at(1).toUInt(),         0u);                           // fwToErase
+        QCOMPARE(args.at(2).toUInt(),         1u);                           // fwToMap
+        QCOMPARE(args.at(3).toByteArray(),    QByteArray::fromHex("FFFFFD"));// firstError
+    }
+
+    void fwMapResponseSignal_carriesWindowIncrement() {
+        TestFixture f;
+        QSignalSpy spy(&f.device, &DE1Device::fwMapResponse);
+        // WindowIncrement is bytes 0-1, big-endian. It has to survive to the
+        // signal: FirmwareUpdater treats a verify notification with a
+        // non-zero value as in-progress rather than as a verdict, and reading
+        // its FirstError as a corrupt-block address reports normal scan
+        // progress as a permanent flash failure.
+        emit f.transport.dataReceived(
+            DE1::Characteristic::FW_MAP_REQUEST,
+            QByteArray::fromHex("01200001004800"));
+        QCOMPARE(spy.count(), 1);
+        const QList<QVariant> args = spy.takeFirst();
+        QCOMPARE(args.at(0).toUInt(), 0x0120u);
+        QCOMPARE(args.at(3).toByteArray(), QByteArray::fromHex("004800"));
     }
 
     void fwMapResponseSignal_firesOnEraseNotification() {
@@ -155,8 +173,8 @@ private slots:
             QByteArray::fromHex("00000100000000"));
         QCOMPARE(spy.count(), 1);
         const auto args = spy.takeFirst();
-        QCOMPARE(args.at(0).toUInt(), 1u);    // fwToErase
-        QCOMPARE(args.at(1).toUInt(), 0u);    // fwToMap
+        QCOMPARE(args.at(1).toUInt(), 1u);    // fwToErase
+        QCOMPARE(args.at(2).toUInt(), 0u);    // fwToMap
     }
 
     void fwMapResponseSignal_ignoresShortBuffer() {

--- a/tests/tst_firmwareheader.cpp
+++ b/tests/tst_firmwareheader.cpp
@@ -46,6 +46,16 @@ QByteArray makeHeader(uint32_t checksum, uint32_t boardMarker, uint32_t version,
     return header;
 }
 
+// Build a header that passes every structural check in validateFile(): a
+// real image never leaves CpuBytes, the three checksum words or the IV at
+// zero, so a header built with makeHeader()'s bare defaults is *supposed* to
+// be rejected. Tests that are about something other than structure use this.
+QByteArray makeValidHeader(uint32_t version, uint32_t byteCount) {
+    return makeHeader(/*checksum*/ 0x11223344, DE1::Firmware::BOARD_MARKER,
+                      version, byteCount, /*cpuBytes*/ byteCount / 2,
+                      /*dcSum*/ 0x55667788, /*headerChecksum*/ 0x99AABBCC);
+}
+
 // Write a synthetic .dat file: 64-byte header plus `payloadSize` bytes of
 // zero payload. Returns the path.
 QString writeSyntheticDat(const QTemporaryDir& dir, const QByteArray& header,
@@ -131,8 +141,7 @@ private slots:
         QTemporaryDir dir;
         QVERIFY(dir.isValid());
         const qsizetype payloadSize = 256;
-        QByteArray header = makeHeader(0, DE1::Firmware::BOARD_MARKER, 1352,
-                                       uint32_t(payloadSize));
+        QByteArray header = makeValidHeader(1352, uint32_t(payloadSize));
         QString path = writeSyntheticDat(dir, header, payloadSize);
 
         auto result = DE1::Firmware::validateFile(path);
@@ -161,12 +170,70 @@ private slots:
         // Retryable: next download may well complete.
         QTemporaryDir dir;
         QVERIFY(dir.isValid());
-        QByteArray header = makeHeader(0, DE1::Firmware::BOARD_MARKER, 1,
-                                       /*byteCount*/ 1024);
+        QByteArray header = makeValidHeader(1, /*byteCount*/ 1024);
         QString path = writeSyntheticDat(dir, header, /*payloadSize*/ 256);
 
         auto result = DE1::Firmware::validateFile(path);
         QCOMPARE(result.status, DE1::Firmware::Validation::Truncated);
+    }
+
+    // ===== validateFile: structural checks =====
+    //
+    // BoardMarker sits at offset 4 and is identical in every DE1 image ever
+    // published, so it plus a size floor accepts a file spliced from two
+    // revisions. These reject headers that no real image produces.
+
+    void validateFile_rejectsMalformedHeaders_data() {
+        QTest::addColumn<uint32_t>("checksum");
+        QTest::addColumn<uint32_t>("byteCount");
+        QTest::addColumn<uint32_t>("cpuBytes");
+        QTest::addColumn<uint32_t>("dcSum");
+        QTest::addColumn<uint32_t>("headerChecksum");
+        QTest::addColumn<bool>("zeroIv");
+
+        //                                   checksum     byteCount cpuBytes  dcSum       hdrSum      zeroIv
+        QTest::newRow("zero ByteCount")    << 0x11223344u << 0u    << 0u     << 0x5566u << 0x99AAu << false;
+        QTest::newRow("zero CpuBytes")     << 0x11223344u << 256u  << 0u     << 0x5566u << 0x99AAu << false;
+        QTest::newRow("CpuBytes > body")   << 0x11223344u << 256u  << 512u   << 0x5566u << 0x99AAu << false;
+        QTest::newRow("zero CheckSum")     << 0u          << 256u  << 128u   << 0x5566u << 0x99AAu << false;
+        QTest::newRow("zero DCSum")        << 0x11223344u << 256u  << 128u   << 0u      << 0x99AAu << false;
+        QTest::newRow("zero HeaderCheckSum")<< 0x11223344u<< 256u  << 128u   << 0x5566u << 0u      << false;
+        QTest::newRow("all-zero IV")       << 0x11223344u << 256u  << 128u   << 0x5566u << 0x99AAu << true;
+    }
+
+    void validateFile_rejectsMalformedHeaders() {
+        QFETCH(uint32_t, checksum);
+        QFETCH(uint32_t, byteCount);
+        QFETCH(uint32_t, cpuBytes);
+        QFETCH(uint32_t, dcSum);
+        QFETCH(uint32_t, headerChecksum);
+        QFETCH(bool, zeroIv);
+
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QByteArray header = makeHeader(checksum, DE1::Firmware::BOARD_MARKER, 1352,
+                                       byteCount, cpuBytes, dcSum, headerChecksum);
+        if (zeroIv) {
+            header.replace(28, 32, QByteArray(32, char(0)));
+        }
+        QString path = writeSyntheticDat(dir, header, /*payloadSize*/ 512);
+
+        auto result = DE1::Firmware::validateFile(path);
+        QCOMPARE(result.status, DE1::Firmware::Validation::MalformedHeader);
+        QVERIFY(!result.errorDetail.isEmpty());
+    }
+
+    void validateFile_acceptsReservedFieldZeroOnly() {
+        // Offset 20 is documented as always zero. A non-zero value means the
+        // bytes at that offset are not a header field we understand.
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QByteArray header = makeValidHeader(1352, 256);
+        packU32LE(header, 20, 0xDEADBEEF);
+        QString path = writeSyntheticDat(dir, header, 256);
+
+        auto result = DE1::Firmware::validateFile(path);
+        QCOMPARE(result.status, DE1::Firmware::Validation::MalformedHeader);
     }
 
     void validateFile_tooShortHeader() {

--- a/tests/tst_firmwareupdater.cpp
+++ b/tests/tst_firmwareupdater.cpp
@@ -38,11 +38,20 @@ void packU32LE(QByteArray& buf, int off, uint32_t v) {
 // side accepts this per the spec (BoardMarker + size check only).
 QByteArray makeFirmwareBlob(uint32_t version, qsizetype payloadSize = 256) {
     QByteArray blob(DE1::Firmware::HEADER_SIZE + payloadSize, char(0));
+    packU32LE(blob, 0,  0x11223344);                            // CheckSum
     packU32LE(blob, 4,  DE1::Firmware::BOARD_MARKER);
     packU32LE(blob, 8,  version);
-    packU32LE(blob, 12, static_cast<uint32_t>(payloadSize));
-    // IV (offsets 28-59) stays all zeros; DE1 side decrypts in real flash,
-    // but tests never reach a real device so content doesn't matter.
+    packU32LE(blob, 12, static_cast<uint32_t>(payloadSize));    // ByteCount
+    packU32LE(blob, 16, static_cast<uint32_t>(payloadSize / 2));// CpuBytes
+    // offset 20 Unused stays zero
+    packU32LE(blob, 24, 0x55667788);                            // DCSum
+    // The checksum words and the IV must be non-zero: validateFile() rejects
+    // an all-zero one, because no published image leaves them empty and that
+    // is what distinguishes a real header from a spliced or synthetic one.
+    for (int i = 0; i < 32; ++i) {
+        blob[28 + i] = static_cast<char>(i + 1);                // IV
+    }
+    packU32LE(blob, 60, 0x99AABBCC);                            // HeaderCheckSum
     return blob;
 }
 
@@ -122,6 +131,43 @@ private slots:
         QVERIFY(f.updater.errorMessage().contains("Erase"));
     }
 
+    void eraseCompleteNotification_startsUploadBeforeFallbackTimer() {
+        Fixture f;
+        // The post-erase wait is a fallback, not the trigger. With it set far
+        // beyond the test's patience, the only thing that can reach Uploading
+        // is the erase-complete notification. A captured DE1+/PCB 1.3 flash
+        // reported it at +1.31 s against a 10 s wait, so this is the normal
+        // path and the timer is the exception.
+        f.updater.setPostEraseWaitMs(60000);
+        f.updater.setEraseTimeoutMs(60000);
+        writeCachedBlob(&f.updater, &f.cache, makeFirmwareBlob(1352));
+        f.updater.startUpdate();
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Erasing);
+
+        // firstError here is the 0,0,0 we sent on the erase request, echoed
+        // back — the transition must not depend on its value.
+        emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
+                                      QByteArray::fromHex("00000001000000"));
+        QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(),
+                                  FirmwareUpdater::State::Uploading, 2000);
+    }
+
+    void eraseInProgressNotification_doesNotStartUpload() {
+        Fixture f;
+        // fwToErase=1 is "still erasing" — v1333+ skips it, but older
+        // firmware sends it first and it must not be mistaken for completion.
+        f.updater.setPostEraseWaitMs(60000);
+        f.updater.setEraseTimeoutMs(60000);
+        writeCachedBlob(&f.updater, &f.cache, makeFirmwareBlob(1352));
+        f.updater.startUpdate();
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Erasing);
+
+        emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
+                                      QByteArray::fromHex("00000101000000"));
+        QTest::qWait(100);
+        QCOMPARE(f.updater.state(), FirmwareUpdater::State::Erasing);
+    }
+
     void disconnectDuringUpload_failsRetryable() {
         Fixture f;
         QTest::ignoreMessage(QtWarningMsg,
@@ -158,6 +204,31 @@ private slots:
         QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Failed);
         QVERIFY(f.updater.retryAvailable());
         QVERIFY(f.updater.errorMessage().contains("Verification"));
+    }
+
+    void verifyIgnoresNonTerminalNotification_thenAcceptsVerdict() {
+        Fixture f;
+        const QByteArray blob = makeFirmwareBlob(1352);
+        writeCachedBlob(&f.updater, &f.cache, blob);
+        f.updater.startUpdate();
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Uploading);
+        simulateFullUpload(f.transport, blob);
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Verifying);
+
+        // WindowIncrement 0x0120 — the bootloader talking mid-scan. Its
+        // FirstError is a cursor, not a corrupt-block address. Treating it as
+        // a verdict reports "Verification failed at block 0.72.0" on a flash
+        // that is still verifying, and Retry cannot help because the next
+        // attempt reports the same cursor.
+        emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
+                                      QByteArray::fromHex("01200001004800"));
+        QTest::qWait(50);
+        QCOMPARE(f.updater.state(), FirmwareUpdater::State::Verifying);
+
+        // The real verdict still lands.
+        emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
+                                      QByteArray::fromHex("00000001FFFFFD"));
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::AwaitingReboot);
     }
 
     void preconditionRefuses_duringShot() {

--- a/tests/tst_firmwareupdater.cpp
+++ b/tests/tst_firmwareupdater.cpp
@@ -1,5 +1,7 @@
 #include <QtTest>
 #include <QSignalSpy>
+
+#include <algorithm>
 #include <QTemporaryDir>
 #include <QFile>
 #include <QRegularExpression>
@@ -67,12 +69,34 @@ void writeCachedBlob(const FirmwareUpdater*, DE1::Firmware::FirmwareAssetCache* 
 // queued into MockTransport, then simulating BLE ACKs for each. Returns
 // after the state has advanced to Verifying (or whatever follows, depending
 // on timings in the specific test).
+// A firmware chunk on the wire: 20 bytes on WRITE_TO_MMR whose length byte
+// is 16. Same discriminator FirmwareUpdater::onFirmwareWriteAcked uses to
+// tell chunks from the MMR writes that share the characteristic.
+bool isFirmwareChunkWrite(const QPair<QBluetoothUuid, QByteArray>& w) {
+    return w.first == DE1::Characteristic::WRITE_TO_MMR &&
+           w.second.size() == 20 &&
+           static_cast<uint8_t>(w.second[0]) == 16;
+}
+
+qsizetype firmwareChunkWriteCount(const MockTransport& transport) {
+    return std::count_if(transport.writes.begin(), transport.writes.end(),
+                         isFirmwareChunkWrite);
+}
+
 void simulateFullUpload(MockTransport& transport, const QByteArray& blob,
                         int ackWaitTimeoutMs = 5000) {
     const qsizetype expectedChunks = (blob.size() + 15) / 16;
-    // Expected writes at this point: 1 erase FWMapRequest + N chunks.
+    // Count the CHUNK writes, not the total. This used to wait for
+    // `writes.size() >= 1 + expectedChunks`, assuming exactly one non-chunk
+    // write (the erase FWMapRequest) precedes them — which stopped being true
+    // the moment beginErasePhase() started sending the DE1 to sleep first.
+    // The total was then reached one chunk early, ackAllWritesInOrder() acked
+    // one chunk short of the total, and the updater sat in Uploading forever
+    // waiting for an ACK that had already been counted against a different
+    // write. Counting the thing we actually mean survives any further
+    // pre-erase traffic.
     QTRY_VERIFY_WITH_TIMEOUT(
-        transport.writes.size() >= 1 + expectedChunks, ackWaitTimeoutMs);
+        firmwareChunkWriteCount(transport) >= expectedChunks, ackWaitTimeoutMs);
     transport.ackAllWritesInOrder();
 }
 
@@ -129,6 +153,35 @@ private slots:
         QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(), FirmwareUpdater::State::Failed, 2000);
         QVERIFY(f.updater.retryAvailable());
         QVERIFY(f.updater.errorMessage().contains("Erase"));
+    }
+
+    void erasePhase_sleepsTheMachineBeforeEngagingTheGuard() {
+        Fixture f;
+        writeCachedBlob(&f.updater, &f.cache, makeFirmwareBlob(1352));
+        f.updater.startUpdate();
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Uploading);
+
+        // The sleep must reach the wire, and it must precede the erase
+        // request. DE1Device::goToSleep() drops the write once
+        // m_firmwareFlashInProgress is set, so moving the call below
+        // setFirmwareFlashInProgress(true) turns it into a silent no-op that
+        // nothing else would catch: the flash still succeeds, it just runs
+        // with the heaters and refill logic live for its whole ~18 minutes.
+        qsizetype sleepAt = -1;
+        qsizetype eraseAt = -1;
+        for (qsizetype i = 0; i < f.transport.writes.size(); ++i) {
+            const auto& w = f.transport.writes.at(i);
+            if (sleepAt < 0 && w.first == DE1::Characteristic::REQUESTED_STATE &&
+                w.second == QByteArray(1, static_cast<char>(DE1::State::Sleep))) {
+                sleepAt = i;
+            }
+            if (eraseAt < 0 && w.first == DE1::Characteristic::FW_MAP_REQUEST) {
+                eraseAt = i;
+            }
+        }
+        QVERIFY2(sleepAt >= 0, "no sleep written to REQUESTED_STATE before the flash");
+        QVERIFY2(eraseAt >= 0, "no erase FWMapRequest written to A009");
+        QVERIFY2(sleepAt < eraseAt, "sleep must precede the erase request");
     }
 
     void eraseCompleteNotification_startsUploadBeforeFallbackTimer() {
@@ -575,11 +628,13 @@ private slots:
         QVERIFY(f.transport.subscribes.contains(DE1::Characteristic::FW_MAP_REQUEST));
 
         // Wait for all chunks to land in MockTransport (the pump queues them
-        // synchronously with a 0 ms interval). The expected write count is
-        // 1 (erase FWMapRequest) + N (firmware chunks).
+        // synchronously with a 0 ms interval). Count chunk writes rather than
+        // total writes — the erase FWMapRequest is not the only non-chunk
+        // write any more, since beginErasePhase() sends the DE1 to sleep
+        // first. See firmwareChunkWriteCount().
         const qsizetype expectedChunksQueued = (blob.size() + 15) / 16;
         QTRY_VERIFY_WITH_TIMEOUT(
-            f.transport.writes.size() >= 1 + expectedChunksQueued, 5000);
+            firmwareChunkWriteCount(f.transport) >= expectedChunksQueued, 5000);
 
         // Now simulate BLE ACKing each write. The updater counts
         // WRITE_TO_MMR ACKs with length==16; after the last chunk's ACK

--- a/tests/tst_firmwareupdater.cpp
+++ b/tests/tst_firmwareupdater.cpp
@@ -197,8 +197,43 @@ private slots:
         f.updater.startUpdate();
         QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Erasing);
 
+        // The erase request's own write ACK is what marks this erase cycle as
+        // started; a notification arriving before it cannot be its answer.
+        emit f.transport.writeComplete(DE1::Characteristic::FW_MAP_REQUEST,
+                                       QByteArray::fromHex("00000101000000"));
+
         // firstError here is the 0,0,0 we sent on the erase request, echoed
         // back — the transition must not depend on its value.
+        emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
+                                      QByteArray::fromHex("00000001000000"));
+        QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(),
+                                  FirmwareUpdater::State::Uploading, 2000);
+    }
+
+    void eraseCompleteBeforeRequestAck_isIgnored() {
+        Fixture f;
+        // A terminal VERIFY notification is byte-identical to an
+        // erase-complete one. The retry path makes that reachable: a verify
+        // that timed out at 60 s leaves the DE1 still scanning, the user taps
+        // Retry, and the late response lands in the new Erasing window. Acting
+        // on it would stream the whole upload into a bank still being erased.
+        // Without the ACK gate this test transitions to Uploading.
+        f.updater.setPostEraseWaitMs(60000);
+        f.updater.setEraseTimeoutMs(60000);
+        writeCachedBlob(&f.updater, &f.cache, makeFirmwareBlob(1352));
+        f.updater.startUpdate();
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Erasing);
+
+        // No writeComplete for the erase request — so this notification cannot
+        // be its answer.
+        emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
+                                      QByteArray::fromHex("00000001FFFFFD"));
+        QTest::qWait(100);
+        QCOMPARE(f.updater.state(), FirmwareUpdater::State::Erasing);
+
+        // Once the request is ACKed, the next notification is acted on.
+        emit f.transport.writeComplete(DE1::Characteristic::FW_MAP_REQUEST,
+                                       QByteArray::fromHex("00000101000000"));
         emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
                                       QByteArray::fromHex("00000001000000"));
         QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(),


### PR DESCRIPTION
## The correlation

Two users failed a v1333 → v1352 flash at the identical point — `Verification failed at block 0.72.0` (FirstError `00 48 00`, address `0x4800`). **Both were on iOS.** A successful reflash captured on an Android tablet against a DE1+/PCB 1.3 supplied the timings below.

The post-erase wait was **10 s on Android and 1 s everywhere else**. Both failures ran the 1 s arm; the success ran the 10 s arm.

That constant was a misreading of de1app, which branches on `$::has_bluetooth`, not on platform (`de1_comms.tcl:941-947`):

```tcl
if {$::has_bluetooth} {
    userdata_append "Erase firmware do: ..." [list de1_comm write "FWMapRequest" $data] 1
    after 10000 write_firmware_now
} else {
    after 1000 write_firmware_now
}
```

The `else` is the no-BLE dry run — a few lines above it, that same branch fakes the connection handles because no machine is attached. **Every real flash de1app performs waits 10 s.** We read `has_bluetooth` as "is Android" and handed iOS, macOS, Windows and Linux the no-machine timing, then documented it as a workaround for an "Android-specific BLE race" that nothing in de1app supports.

1 s is also just too short. The captured flash reported erase-complete at **+1.31 s**, so on iOS the chunk pump started while the bootloader was still erasing.

## Changes

**1 — Post-erase wait is 10 s everywhere, and is now a fallback rather than the trigger.** The chunk pump starts when the erase-complete notification arrives (+1.31 s measured, against a 10 s wait), matching reaprime/decaid. The timer stays because the notification can genuinely fail to arrive — the A009 CCCD subscription is fragile enough that verify has to re-subscribe. `fwToErase=1` ("still erasing") does not trigger the transition.

The completion check deliberately **ignores `FirstError`**: the DE1 echoes back whatever we put in that field on the erase request. We send `0,0,0` and get `0,0,0`. decaid's `_isEraseComplete` asserts `FF FF FF` because `FF FF FF` is what it happens to send — it is testing its own outbound bytes. Only `fwToErase`/`fwToMap` carry machine state there. Verify is different: we send `FF FF FF` and success comes back as `FF FF FD`.

**2 — Verify accepts a verdict only when `WindowIncrement == 0 && fwToMap == 1`.** `WindowIncrement` was decoded and then dropped on the way to `fwMapResponse`, so we accepted the first notification of any shape and reported its `FirstError` as a corrupt-block address. If the bootloader emits progress mid-scan, that turns a healthy flash into a permanent-looking failure that survives Retry — the next attempt reports the same cursor. The signal now carries the field; non-terminal notifications are logged and ignored, with the 60 s verify timeout as the backstop.

**3 — Header validation and splice detection.** `validateFile()` gained reaprime/decaid's structural checks (`ByteCount` non-zero, `0 < CpuBytes <= ByteCount`, reserved word zero, `CheckSum`/`DCSum`/`HeaderChecksum` non-zero, IV not all-zero) as `Validation::MalformedHeader`.

BoardMarker is identical in every DE1 image ever published and sits at offset 4, so BoardMarker plus a size floor accepts a file **spliced from two revisions** — which `downloadIfNeeded()`'s `Range:` resume could produce by appending a new revision's tail onto an old revision's body. Right total length, valid-looking header, corruption found only by the DE1 at the end of a ~18-minute flash.

The splice is caught by `versionMatchesMeta()`: the sidecar records the Version the server reported for the ETag this channel is serving, so a cached or downloaded file whose header disagrees is discarded rather than flashed. A resume is now attempted only when the on-disk bytes are `Truncated` **and** their Version matches — a genuine interrupted download of the same revision.

**4 — The DE1 is put to sleep before erase.** An awake machine runs heaters, PID and refill for the ~18 minutes a flash takes, on the same MCU doing the programming. decaid does this; de1app has the line commented out. It must run before `setFirmwareFlashInProgress(true)`, since `goToSleep()` carries its own guard check and is dropped once the flash is engaged.

## Tests

63 → 75. The synthetic blob builders now populate the checksum words and the IV, because a bare-zero header is correctly rejected.

## What this does not settle

An erase still running when writes begin should corrupt from address 0, so it predicts `0.0.0`, not `0.72.0`. **The correlation with the 1 s wait is exact; the mechanism producing that specific address is not established.** Treat the offset as unexplained rather than solved.

Also unchanged: I deliberately did not adopt decaid's one-write-at-a-time upload. Ours is equivalent in ordering, gives honest ACK-driven progress, and the captured flash pushed 28,992 chunks with zero retries.

Local build and test suite have **not** been run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)