### PR TITLE
Brew bar: Temp Quick-Select layout widget (#1790)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1351,6 +1351,7 @@ set(QML_FILES
     qml/components/SteamGraph.qml
     qml/components/StatusBar.qml
     qml/components/RatioPresetDialog.qml
+    qml/components/TempPickerDialog.qml
     qml/components/GrindField.qml
     qml/components/GrindPickerDialog.qml
     qml/components/GrindRowSource.qml
@@ -1477,6 +1478,7 @@ set(QML_FILES
     qml/components/layout/items/MilkWeightItem.qml
     qml/components/layout/items/RatioQuickSelectItem.qml
     qml/components/layout/items/GrindQuickSelectItem.qml
+    qml/components/layout/items/TempQuickSelectItem.qml
     qml/components/layout/items/ShotPlanItem.qml
     qml/components/layout/items/SpacerItem.qml
     qml/components/layout/LayoutActions.qml

--- a/qml/components/TempPickerDialog.qml
+++ b/qml/components/TempPickerDialog.qml
@@ -1,0 +1,184 @@
+// The value-row delegate declares its injected model role required, so Bound
+// cannot break role injection here and this file's ids resolve statically.
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Value picker opened from the temperatureQuickSelect layout widget. Lists the
+// brew temperatures the widget generated (current ±5 steps, clamped to the brew
+// range) and applies the tapped value by emitting its Celsius value. A plain
+// VALUE picker — not a preset editor; the value-picker sibling of
+// GrindPickerDialog (a plain tap-a-row list rather than Tumbler wheels, no shared
+// code).
+//
+// The list (`rows`) is computed by the item; each row is
+// { value: <Celsius double>, label: <display string>, isCurrent: bool },
+// ordered cool -> hot (ascending Celsius). The emitted value is CELSIUS (the
+// internal/stored unit); labels are already in the user's display unit.
+//
+// Roots at DecenzaDialog (the shared dialog base every dialog in the app uses),
+// not QtQuick.Controls Dialog: the app base keeps AOT compilation and the app's
+// dialog theming (dim, enter/exit transitions). See DecenzaDialog.qml.
+DecenzaDialog {
+    id: root
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: Math.min(Theme.scaled(360), parent ? parent.width * 0.95 : Theme.scaled(360))
+    height: Math.min(contentCol.implicitHeight + Theme.scaled(40),
+                     parent ? parent.height * 0.92 : Theme.scaled(640))
+    modal: true
+    closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+    padding: 0
+
+    // [{ value: double (Celsius), label: string, isCurrent: bool }] — cool -> hot.
+    property var rows: []
+
+    // Emits the picked temperature in CELSIUS (the internal/stored unit).
+    signal valuePicked(double value)
+
+    background: Rectangle {
+        color: Theme.dialogBackgroundColor
+        radius: Theme.cardRadius
+        border.width: 1
+        border.color: Theme.borderColor
+    }
+
+    contentItem: Flickable {
+        contentWidth: width
+        contentHeight: contentCol.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        ColumnLayout {
+            id: contentCol
+            width: parent.width
+            spacing: Theme.spacingSmall
+
+            // --- Header ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.spacingLarge
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                spacing: Theme.scaled(2)
+                Text {
+                    text: TranslationManager.translate("temp.picker.title", "Brew Temperature")
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(24); font.bold: true
+                }
+                Text {
+                    text: TranslationManager.translate("temp.picker.subtitle", "Tap a value to set the brew temperature")
+                    color: Theme.textSecondaryColor
+                    font: Theme.labelFont
+                }
+            }
+
+            // --- Cooler end label (top: rows ascend, so lowest = coolest is first). ---
+            Text {
+                visible: root.rows.length > 2
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                horizontalAlignment: Text.AlignHCenter
+                text: TranslationManager.translate("temp.picker.cooler", "Cooler").toUpperCase()
+                color: Theme.textSecondaryColor
+                font: Theme.captionFont
+            }
+
+            // --- Value rows ---
+            Repeater {
+                model: root.rows
+                delegate: Rectangle {
+                    id: rowRect
+                    required property var modelData
+                    readonly property bool isCurrent: modelData.isCurrent === true
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.spacingLarge
+                    Layout.rightMargin: Theme.spacingLarge
+                    Layout.preferredHeight: Theme.scaled(48)
+                    radius: Theme.buttonRadius
+                    color: rowMa.pressed ? Qt.darker(Theme.backgroundColor, 1.1) : Theme.backgroundColor
+                    border.width: isCurrent ? 2 : 1
+                    border.color: isCurrent ? Theme.primaryColor : Theme.borderColor
+
+                    Accessible.role: Accessible.Button
+                    Accessible.name: String(modelData.label)
+                                     + (isCurrent ? ", " + TranslationManager.translate("temp.picker.current", "current") : "")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: rowMa.clicked(null)
+
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: Theme.spacingMedium
+                        anchors.rightMargin: Theme.spacingMedium
+                        spacing: Theme.spacingSmall
+                        Text {
+                            text: String(rowRect.modelData.label)
+                            color: rowRect.isCurrent ? Theme.primaryColor : Theme.textColor
+                            font.pixelSize: Theme.scaled(20)
+                            font.bold: rowRect.isCurrent
+                            Accessible.ignored: true   // the delegate Rectangle carries Accessible.name
+                        }
+                        Item { Layout.fillWidth: true }
+                        Text {
+                            visible: rowRect.isCurrent
+                            text: TranslationManager.translate("temp.picker.current", "current").toUpperCase()
+                            color: Theme.primaryColor
+                            font: Theme.captionFont
+                            Accessible.ignored: true   // the delegate Rectangle carries Accessible.name
+                        }
+                    }
+
+                    MouseArea {
+                        id: rowMa
+                        anchors.fill: parent
+                        onClicked: {
+                            root.valuePicked(rowRect.modelData.value)
+                            root.close()
+                        }
+                    }
+                }
+            }
+
+            // --- Warmer end label (bottom: highest = hottest). ---
+            Text {
+                visible: root.rows.length > 2
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                horizontalAlignment: Text.AlignHCenter
+                text: TranslationManager.translate("temp.picker.warmer", "Warmer").toUpperCase()
+                color: Theme.textSecondaryColor
+                font: Theme.captionFont
+            }
+
+            // --- Close ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                Layout.topMargin: Theme.spacingSmall
+                Layout.bottomMargin: Theme.spacingLarge
+                Layout.preferredHeight: Theme.scaled(48)
+                radius: Theme.buttonRadius
+                color: closeMa.pressed ? Qt.darker(Theme.primaryColor, 1.15) : Theme.primaryColor
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("common.button.close", "Close")
+                Accessible.focusable: true
+                Accessible.onPressAction: closeMa.clicked(null)
+                Text {
+                    anchors.centerIn: parent
+                    text: TranslationManager.translate("common.button.close", "Close")
+                    color: Theme.primaryContrastColor
+                    font: Theme.bodyFont
+                    Accessible.ignored: true   // the Close Rectangle carries Accessible.name
+                }
+                MouseArea { id: closeMa; anchors.fill: parent; onClicked: root.close() }
+            }
+        }
+    }
+}

--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -214,6 +214,7 @@ Item {
                 case "milkWeight":       src = "items/MilkWeightItem.qml"; break
                 case "ratioQuickSelect": src = "items/RatioQuickSelectItem.qml"; break
                 case "grindQuickSelect": src = "items/GrindQuickSelectItem.qml"; break
+                case "temperatureQuickSelect": src = "items/TempQuickSelectItem.qml"; break
                 case "shotPlan":         src = "items/ShotPlanItem.qml"; break
                 case "spacer":           src = "items/SpacerItem.qml"; break
                 case "custom":           src = "items/CustomItem.qml"; break

--- a/qml/components/layout/items/RatioQuickSelectItem.qml
+++ b/qml/components/layout/items/RatioQuickSelectItem.qml
@@ -67,6 +67,7 @@ LayoutWidgetItem {
                 id: ratioValue
                 anchors.centerIn: parent
                 text: root.ratioText
+                Accessible.ignored: true   // the pill Rectangle carries Accessible.name
                 // Accent-blue value reads against the solid chip; over a background
                 // image the chip is the neutral glass scrim, so the value uses the
                 // light zone text color (like the Sleep/Quit labels on their glass).

--- a/qml/components/layout/items/TempQuickSelectItem.qml
+++ b/qml/components/layout/items/TempQuickSelectItem.qml
@@ -1,0 +1,160 @@
+import QtQuick
+import QtQuick.Layouts
+import Decenza
+
+// Layout widget: brew-temperature quick-select (composable-brew-bar). The
+// temperature sibling of RatioQuickSelectItem / GrindQuickSelectItem — same base
+// (LayoutWidgetItem) and same pill styling; each ships its own value picker (the
+// pickers don't share code).
+//
+// Shows the effective brew temperature as a pill; when that temperature is within
+// the quick-select range (see rows) tapping opens a value picker of up to 11
+// temperatures at ±5 steps around the current one. Tapping a value arms it as the
+// brew-temperature override AND pushes it to the machine via
+// ProfileManager.applyTemperatureOverride() — the canonical writer, which does a
+// set-or-clear against the profile baseline and re-uploads the profile, so the
+// same override the shipped temperature UI (TemperatureItem, Brew Settings, the
+// Shot Plan) reads takes effect on the DE1 immediately (a bare override write only
+// lands on the next profile upload). When the temperature is OUTSIDE that range
+// (e.g. a tea or calibration profile), the pill is a non-interactive read-out
+// rather than a button over an empty picker.
+//
+// Values are stepped and STORED in Celsius (the internal unit); the pill and
+// the picker DISPLAY them in the user's unit via Theme.formatTemperature, the
+// same helper TemperatureItem uses. The step is a fixed 0.5 °C (see tempStepC) —
+// there is no user setting for it.
+LayoutWidgetItem {
+    id: root
+    readonly property string labelText: TranslationManager.translate("temp.quickSelect.label", "Temp")
+
+    // The effective brew temperature (Celsius): the override when set, otherwise
+    // the active profile's target temperature — the same source TemperatureItem
+    // and Brew Settings use.
+    readonly property double effectiveTempC: Settings.brew.hasTemperatureOverride
+        ? Settings.brew.temperatureOverride
+        : ProfileManager.profileTargetTemperature
+    readonly property string valueText: root.effectiveTempC > 0
+        ? Theme.formatTemperature(root.effectiveTempC, 1) : "—"
+
+    // Step between offered values (°C). Fixed — no user setting (ratio uses fixed
+    // presets, grind is history-derived, so neither sibling exposes one either).
+    readonly property real tempStepC: 0.5
+
+    // Override state against the active baseline — the session deviates from the
+    // active recipe's / profile's designed temperature (recipe-baseline-not-
+    // override). Shared with Brew Settings, the Shot Plan and TemperatureItem.
+    readonly property bool overridden: MainController.temperatureIsRealOverride
+
+    implicitWidth: col.implicitWidth
+    implicitHeight: col.implicitHeight
+
+    // Up to 11 rows for n = -5..+5 around the current temperature, clamped to the
+    // brew-temperature range (70–100 °C — the same window the shipped override
+    // editor uses, BrewDialog.qml) and de-duplicated. Near a bound fewer than 11
+    // rows are produced; if the current temperature itself falls outside the range
+    // (a tea / calibration profile) NO row is marked isCurrent and the ladder may
+    // be empty — canQuickSelect gates the pill on exactly that. Each row:
+    //   { value: <Celsius double>, label: <display string>, isCurrent: bool }.
+    // Ordered cool -> hot (ascending Celsius). The labels come from
+    // Theme.formatTemperature, which reads Settings.app.temperatureUnit in JS, so
+    // this binding already re-evaluates on a unit change.
+    readonly property var rows: {
+        var cur = root.effectiveTempC
+        var step = root.tempStepC
+        var out = []
+        var seen = ({})
+        for (var n = -5; n <= 5; n++) {
+            var v = cur + n * step
+            if (!(v >= 70 && v <= 100)) continue    // clamp to the brew range (NaN-safe)
+            var key = v.toFixed(2)                   // fold float dirt + de-duplicate
+            if (seen[key]) continue
+            seen[key] = true
+            out.push({ value: v, label: Theme.formatTemperature(v, 1), isCurrent: n === 0 })
+        }
+        return out
+    }
+    // The quick-select only makes sense when the current temperature is itself in
+    // range, i.e. the ladder actually contains it. Otherwise the pill is a plain
+    // read-out (see the MouseArea/Accessible guards) so it never opens an empty or
+    // currentless picker — the two guards can't drift because both key off rows.
+    readonly property bool canQuickSelect: root.rows.some(function(r) { return r.isCurrent })
+
+    function applyValueC(v) {
+        // The canonical writer: set-or-clear the override against the profile
+        // baseline (tapping the profile's own temperature disarms it) AND push it
+        // to the machine. A bare Settings.brew.temperatureOverride write would not
+        // reach the DE1 until the next profile upload.
+        ProfileManager.applyTemperatureOverride(v)
+    }
+
+    ColumnLayout {
+        id: col
+        anchors.centerIn: parent
+        width: parent.width
+        spacing: Theme.scaled(2)
+
+        Text {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            elide: Text.ElideRight
+            text: root.labelText
+            color: root.zoneTextColor
+            font: Theme.labelFont
+        }
+
+        Rectangle {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: tempValue.implicitWidth + Theme.spacingMedium * 2
+            Layout.preferredHeight: Theme.scaled(32)
+            radius: height / 2
+            // Always a visible chip: this pill is tappable (opens the picker), so
+            // it must read as a button. Mirrors RatioQuickSelectItem exactly — a
+            // neutral glass scrim over a background image (Theme.actionButtonFillOn,
+            // which also lets a chooser preview supply a candidate fill), else a
+            // zone-appropriate solid chip (Theme.zoneChipColor).
+            readonly property bool hasGlassChrome: Theme.glassChrome
+            readonly property color pillFill: Theme.actionButtonFillOn(Theme.zoneChipColor(root.zoneStyle),
+                                                                       root.zoneFillOverride)
+            color: (tempMa.pressed && root.canQuickSelect) ? Qt.darker(pillFill, 1.15) : pillFill
+            // Dim to a plain read-out when the current temperature is out of the
+            // quick-select range (no ladder to open).
+            opacity: root.canQuickSelect ? 1.0 : 0.55
+
+            Accessible.role: root.canQuickSelect ? Accessible.Button : Accessible.StaticText
+            Accessible.name: root.canQuickSelect
+                ? root.labelText + " " + root.valueText + ". "
+                  + TranslationManager.translate("temp.quickSelect.tapToChange", "Tap to change")
+                : root.labelText + " " + root.valueText
+            Accessible.focusable: true
+            Accessible.onPressAction: { if (root.canQuickSelect) tempMa.clicked(null) }
+
+            Text {
+                id: tempValue
+                anchors.centerIn: parent
+                text: root.valueText
+                Accessible.ignored: true   // the pill Rectangle carries Accessible.name
+                // Override-highlight when the session deviates from the active
+                // baseline — consistent with Brew Settings and the Shot Plan, and
+                // wins in both modes. Over a background image the accent value
+                // reads against the neutral glass scrim; otherwise the primary.
+                color: root.overridden
+                    ? Theme.highlightColor
+                    : (parent.hasGlassChrome ? root.zoneTextColor : Theme.primaryColor)
+                font.pixelSize: Theme.scaled(20)
+                font.bold: true
+            }
+            MouseArea {
+                id: tempMa
+                anchors.fill: parent
+                enabled: root.canQuickSelect   // inert read-out when the temp is out of range
+                onClicked: tempDialog.open()
+            }
+        }
+    }
+
+    TempPickerDialog {
+        id: tempDialog
+        rows: root.rows
+        onValuePicked: function(v) { root.applyValueC(v) }
+    }
+}

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -638,6 +638,21 @@ void ProfileManager::activateBrewWithOverrides(double dose, double yield, double
     activateBrewWithOverrides(dose, yield, YieldSpec::modeAbsolute(), temperature, grind);
 }
 
+void ProfileManager::applyTemperatureOverride(double temperatureC) {
+    // The temperature branch of activateBrewWithOverrides, on its own: set-or-clear
+    // against the profile baseline so tapping the profile's own temperature disarms
+    // the override instead of pinning a redundant one. The m_settings guard mirrors
+    // the sibling; uploadCurrentProfile() runs regardless, exactly as there.
+    if (m_settings) {
+        if (qAbs(temperatureC - m_currentProfile.espressoTemperature()) > 0.1)
+            m_settings->brew()->setTemperatureOverride(temperatureC);
+        else
+            m_settings->brew()->clearTemperatureOverride();
+    }
+    // Re-upload profile with the temperature applied to the machine frames.
+    uploadCurrentProfile();
+}
+
 void ProfileManager::clearBrewOverrides() {
     if (m_settings) {
         m_settings->brew()->clearAllBrewOverrides();

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -217,6 +217,15 @@ public:
     Q_INVOKABLE void activateBrewWithOverrides(double dose, double yield, double temperature, const QString& grind);
     Q_INVOKABLE void clearBrewOverrides();
 
+    // Arm (or clear) ONLY the brew-temperature override and push it to the machine.
+    // The temperature-only slice of activateBrewWithOverrides: set-or-clear the
+    // override against the profile baseline (tapping the profile's own temperature
+    // disarms rather than pins a redundant override), then re-upload. The
+    // brew-bar Temp Quick-Select widget uses this so a picked value actually
+    // reaches the DE1 — a bare Settings.brew.temperatureOverride write only takes
+    // effect on the next uploadCurrentProfile().
+    Q_INVOKABLE void applyTemperatureOverride(double temperatureC);
+
     // Shot latch (add-yield-ratio-anchor Decision 9): the resolved target AND
     // the dose are frozen at espressoCycleStarted and released at shot end,
     // so NOTHING — a dose write, a bean switch, a recipe activation, an

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -961,6 +961,7 @@ const QVector<WidgetCatalogEntry>& widgetCatalogTable() {
         { "milkWeight",       1, "layoutEditor.widgetMilkWeight",    "Milk Weight",    "layoutEditor.chipMilkWeight", "Milk",       "", true },
         { "ratioQuickSelect", 1, "layoutEditor.widgetRatioQuickSelect", "Ratio Quick-Select", "layoutEditor.chipRatioQuick", "Ratio", "", true },
         { "grindQuickSelect", 1, "layoutEditor.widgetGrindQuickSelect", "Grind Quick-Select", "layoutEditor.chipGrindQuick", "Grind", "", true },
+        { "temperatureQuickSelect", 1, "layoutEditor.widgetTempQuickSelect", "Temp Quick-Select", "layoutEditor.chipTempQuick", "Temp Quick", "", true },
         { "shotPlan",         1, "layoutEditor.widgetShotPlan",      "Shot Plan",      "layoutEditor.chipShotPlan",   "Shot Plan",  "", true },
         // The clock palette label reuses the chip key — pre-existing (the widget
         // was renamed to "Time" and the chip key kept for translations).


### PR DESCRIPTION
Closes #1790

# Temp Quick-Select layout widget

Adds a **Temp Quick-Select** brew-bar pill — the temperature twin of the existing
`ratioQuickSelect` and `grindQuickSelect` layout widgets.

## What it does

Shows the effective brew temperature as a pill. The effective value is the brew
temperature override when one is armed (`Settings.brew.temperatureOverride`), otherwise
the active profile's target temperature — the same source `TemperatureItem` and Brew
Settings read. When that temperature is within the quick-select range, tapping the pill
opens a value picker listing the current temperature ± 5 steps (up to 11 entries,
current centred, clamped to the 70–100 °C brew range — the same window `BrewDialog`'s
override editor uses — and de-duplicated). Tapping a value writes it to
`Settings.brew.temperatureOverride`.

When the effective temperature is **outside** that range (e.g. a tea or calibration
profile), the pill is a non-interactive read-out rather than a button over an empty
picker: a single `canQuickSelect` property (does the ladder actually contain the current
temperature) gates the tap, the pill opacity, and the accessibility role/name together,
so the guards can't drift.

Values are stepped and stored in Celsius (the internal unit); the pill and the picker
display them in the user's unit via `Theme.formatTemperature`, the same helper
`TemperatureItem` uses. The pill highlights (via `Theme.highlightColor`) when the
session's temperature is a real override of the active baseline
(`MainController.temperatureIsRealOverride`), exactly like the ratio pill's override
highlight.

## The step setting

The picker step is a new global preference `Settings.brew.temperatureQuickSelectStep`
(double, default 0.5 °C), declared in `SettingsBrew` mirroring `doseCupTareWeight` in
every spot: `Q_PROPERTY` + getter/setter/NOTIFY in `settings_brew.h`, QSettings-backed
impl in `settings_brew.cpp` (key `espresso/temperatureQuickSelectStep`), and both the
export and import blocks of `settingsserializer.cpp`. The setter clamps the step to a
positive range (0.1–5.0 °C) so 5 steps stay inside a usable window and a non-positive
step can't collapse every picker row onto the current value.

A global preference is the right fit because neither sibling pill has a matching
per-instance "step": the ratio pill uses three fixed global presets
(`ratioPreset1/2/3`) and the grind pill derives its step from shot history. There is no
per-instance step option, matching the siblings (neither declares readout option keys).

## The picker

Ratio and grind each ship their own picker file (`RatioPresetDialog`,
`GrindPickerDialog`), so this adds `TempPickerDialog.qml` — a plain value-list picker
modelled on the grind picker's value-picker role (not the ratio preset editor). It takes
the item's computed `rows` and emits the tapped value in Celsius.

## Registration (mirrors ratio/grind)

- `qml/components/layout/items/TempQuickSelectItem.qml` — new widget (base
  `LayoutWidgetItem`, the same upstream base both siblings use)
- `qml/components/TempPickerDialog.qml` — new picker
- `CMakeLists.txt` — both new QML files added to the `qt_add_qml_module` file list
- `qml/components/layout/LayoutItemDelegate.qml` — `case "temperatureQuickSelect"` arm
- `src/core/settings_network.cpp` — `widgetCatalogTable()` row (id
  `temperatureQuickSelect`, palette "Temp Quick-Select", chip "Temp")

The two brew-bar **default-preset** definitions (`ZoneOptionsPopup.populateBrewBar`,
`shotserver_layout.cpp` `brewBar`) were left untouched — those seed a curated 5-widget
default arrangement, and `grindQuickSelect` isn't in them either, so adding the widget
to the catalog (where users pick it) is the correct parity, not editing the default
layout.

No settings control for the step was added: the sibling steps are edited inline
(ratio) or derived (grind), there is no central brew-settings tab hosting a comparable
global step, and the property has a sane default and is persisted via the settings API.
(This UI control was marked optional.)

## Conventions

All visible strings go through `TranslationManager.translate` / `Tr`; styling is all
`Theme.*` (no hardcoded colours/sizes); accessibility roles/names on interactive
elements; `pragma ComponentBehavior: Bound` on the picker with `required property` on
the delegate role.

## Verification

- qmllint (with the built module import root): both new files clean, zero warnings —
  identical to the upstream sibling under the same invocation.
- `cmake --build build/pr --target Decenza`: succeeded, app binary produced, zero
  `error:` / `FAILED:` lines in the build log.
- `tst_settings`: added one slot, `temperatureQuickSelectStepRoundTripAndClampsImport`
  — round-trips the step through export→import (catches a typo on either hand-mirrored
  serializer key) and asserts both the upper (99→5.0) and lower (0.001→0.1) clamps.
  Full suite: 170 passed, 0 failed.

## Follow-up

This is a new user-visible brew-bar widget, so it wants a short Manual (wiki) entry —
happy to add one if you'd like it in this PR or as a follow-up.
