### PR TITLE
fix(inventory): make the whole bag/equipment card tappable (#1798)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1382,6 +1382,7 @@ set(QML_FILES
     qml/components/BeanSummary.qml
     qml/components/LinkBeanBaseDialog.qml
     qml/components/ChangeBeansDialog.qml
+    qml/components/CardTapArea.qml
     qml/components/BagCard.qml
     qml/components/SwitchEquipmentDialog.qml
     qml/components/EquipmentCard.qml

--- a/qml/components/BagCard.qml
+++ b/qml/components/BagCard.qml
@@ -247,6 +247,21 @@ Rectangle {
         }
     }
 
+    // Tap anywhere on the card to select the bag (#1798: the tap area used to
+    // wrap only the info row, so the action row's whitespace and the card's
+    // padding were dead space). z: -1 keeps every button and the thumbnail
+    // above it, so they still win their own taps — the RecipeCard pattern.
+    AccessibleMouseArea {
+        anchors.fill: parent
+        z: -1
+        accessibleName: card.accessibleSummary
+        accessibleItem: card
+        onAccessibleClicked: {
+            if (card.bag && card.bag.id !== undefined)
+                Settings.dye.activeBagId = card.bag.id
+        }
+    }
+
     Timer {
         id: deleteRefusedTimer
         interval: 4000  // UI auto-dismiss (allowed timer use)
@@ -272,119 +287,99 @@ Rectangle {
         anchors.margins: Theme.scaled(12)
         spacing: Theme.scaled(6)
 
-        // Info area — tap to select
-        Item {
-            id: infoArea
+        // Info area — the card-wide tap area below selects the bag
+        RowLayout {
             Layout.fillWidth: true
-            implicitHeight: infoRow.implicitHeight
+            spacing: Theme.scaled(10)
 
-            RowLayout {
-                id: infoRow
-                anchors.left: parent.left
-                anchors.right: parent.right
-                spacing: Theme.scaled(10)
+            // Bag photo — the shared BeanThumbnail cache widget (legacy
+            // blob `image` URL as fallback).
+            BeanThumbnail {
+                Layout.preferredWidth: Theme.scaled(44)
+                Layout.preferredHeight: Theme.scaled(44)
+                Layout.alignment: Qt.AlignTop
+                imageKey: card.imageKey
+                fallbackName: (card.bag && card.bag.coffeeName) || ""
+                link: card.beanBase.link || ""
+                legacyImageUrl: card.beanBase.image || ""
+            }
 
-                // Bag photo — the shared BeanThumbnail cache widget (legacy
-                // blob `image` URL as fallback).
-                BeanThumbnail {
-                    Layout.preferredWidth: Theme.scaled(44)
-                    Layout.preferredHeight: Theme.scaled(44)
-                    Layout.alignment: Qt.AlignTop
-                    imageKey: card.imageKey
-                    fallbackName: (card.bag && card.bag.coffeeName) || ""
-                    link: card.beanBase.link || ""
-                    legacyImageUrl: card.beanBase.image || ""
-                }
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Theme.scaled(2)
 
-                ColumnLayout {
-                    id: infoColumn
+                RowLayout {
                     Layout.fillWidth: true
-                    spacing: Theme.scaled(2)
+                    spacing: Theme.scaled(6)
 
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: Theme.scaled(6)
-
-                        ColoredIcon {
-                            visible: card.hasCanonical
-                            Layout.alignment: Qt.AlignTop
-                            source: "qrc:/icons/tick.svg"
-                            iconWidth: Theme.scaled(14)
-                            iconHeight: Theme.scaled(14)
-                            iconColor: Theme.primaryColor
-                            Accessible.ignored: true
-                        }
-
-                        Text {
-                            Layout.fillWidth: true
-                            text: (card.bag && card.bag.coffeeName) || (card.bag && card.bag.roasterName) || ""
-                            font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.subtitleFont.pixelSize
-                            font.bold: true
-                            color: Theme.textColor
-                            elide: Text.ElideRight
-                            Accessible.ignored: true
-                        }
-                    }
-
-                    Text {
-                        Layout.fillWidth: true
-                        visible: !!(card.bag && card.bag.coffeeName && card.bag.roasterName)
-                        text: (card.bag && card.bag.roasterName) || ""
-                        font: Theme.labelFont
-                        color: Theme.textSecondaryColor
-                        elide: Text.ElideRight
-                        Accessible.ignored: true
-                    }
-
-                    // Canonical: one dense attribute line; partial: nothing (no placeholders)
-                    Text {
-                        Layout.fillWidth: true
-                        visible: card.attrLine.length > 0
-                        text: card.attrLineRich
-                        textFormat: Text.StyledText
-                        font: Theme.captionFont
-                        color: Theme.textSecondaryColor
-                        elide: Text.ElideRight
-                        Accessible.ignored: true
-                    }
-
-                    // Tasting notes earn a line of their own — the most
-                    // interesting canonical data. One elided line; the info
-                    // button opens the full record.
-                    Text {
-                        Layout.fillWidth: true
-                        visible: !!(card.beanBase.tastingNotes)
-                        text: card.beanBase.tastingNotes || ""
-                        font.family: Theme.captionFont.family
-                        font.pixelSize: Theme.captionFont.pixelSize
-                        font.italic: true
-                        color: Theme.textSecondaryColor
-                        elide: Text.ElideRight
+                    ColoredIcon {
+                        visible: card.hasCanonical
+                        Layout.alignment: Qt.AlignTop
+                        source: "qrc:/icons/tick.svg"
+                        iconWidth: Theme.scaled(14)
+                        iconHeight: Theme.scaled(14)
+                        iconColor: Theme.primaryColor
                         Accessible.ignored: true
                     }
 
                     Text {
                         Layout.fillWidth: true
-                        visible: card.metaLine.length > 0
-                        text: card.metaLineRich
-                        textFormat: Text.StyledText
-                        font: Theme.captionFont
+                        text: (card.bag && card.bag.coffeeName) || (card.bag && card.bag.roasterName) || ""
+                        font.family: Theme.bodyFont.family
+                        font.pixelSize: Theme.subtitleFont.pixelSize
+                        font.bold: true
                         color: Theme.textColor
                         elide: Text.ElideRight
                         Accessible.ignored: true
                     }
-
                 }
-            }
 
-            AccessibleMouseArea {
-                anchors.fill: parent
-                accessibleName: card.accessibleSummary
-                accessibleItem: infoArea
-                onAccessibleClicked: {
-                    if (card.bag && card.bag.id !== undefined)
-                        Settings.dye.activeBagId = card.bag.id
+                Text {
+                    Layout.fillWidth: true
+                    visible: !!(card.bag && card.bag.coffeeName && card.bag.roasterName)
+                    text: (card.bag && card.bag.roasterName) || ""
+                    font: Theme.labelFont
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                // Canonical: one dense attribute line; partial: nothing (no placeholders)
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.attrLine.length > 0
+                    text: card.attrLineRich
+                    textFormat: Text.StyledText
+                    font: Theme.captionFont
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                // Tasting notes earn a line of their own — the most
+                // interesting canonical data. One elided line; the info
+                // button opens the full record.
+                Text {
+                    Layout.fillWidth: true
+                    visible: !!(card.beanBase.tastingNotes)
+                    text: card.beanBase.tastingNotes || ""
+                    font.family: Theme.captionFont.family
+                    font.pixelSize: Theme.captionFont.pixelSize
+                    font.italic: true
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.metaLine.length > 0
+                    text: card.metaLineRich
+                    textFormat: Text.StyledText
+                    font: Theme.captionFont
+                    color: Theme.textColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
                 }
             }
         }

--- a/qml/components/BagCard.qml
+++ b/qml/components/BagCard.qml
@@ -222,7 +222,7 @@ Rectangle {
     implicitWidth: Theme.scaled(360)
     implicitHeight: cardColumn.implicitHeight + Theme.scaled(24)
 
-    Accessible.ignored: true  // AccessibleMouseArea below carries the card's accessibility
+    Accessible.ignored: true  // cardTapArea below carries the card's accessibility
 
     BeanBaseDetailsPopup {
         id: beanDetailsPopup
@@ -249,11 +249,10 @@ Rectangle {
 
     // Tap anywhere on the card to select the bag (#1798: the tap area used to
     // wrap only the info row, so the action row's whitespace and the card's
-    // padding were dead space). z: -1 keeps every button and the thumbnail
-    // above it, so they still win their own taps — the RecipeCard pattern.
-    AccessibleMouseArea {
-        anchors.fill: parent
-        z: -1
+    // padding were dead space). The action-row buttons keep their own taps;
+    // everything else — text, photo, whitespace — selects.
+    CardTapArea {
+        id: cardTapArea
         accessibleName: card.accessibleSummary
         accessibleItem: card
         onAccessibleClicked: {
@@ -287,7 +286,7 @@ Rectangle {
         anchors.margins: Theme.scaled(12)
         spacing: Theme.scaled(6)
 
-        // Info area — the card-wide tap area below selects the bag
+        // Info area — cardTapArea (declared above) selects the bag
         RowLayout {
             Layout.fillWidth: true
             spacing: Theme.scaled(10)

--- a/qml/components/BeanBaseSearchBar.qml
+++ b/qml/components/BeanBaseSearchBar.qml
@@ -137,7 +137,7 @@ Item {
             color: Theme.primaryColor
             font.pixelSize: Theme.scaled(12)
             // accessibleItem of the AccessibleMouseArea below — ignore this Text
-            // node so it doesn't overlap the button node (BagCard infoArea pattern).
+            // node so it doesn't overlap the button node (BagCard tap-area pattern).
             Accessible.ignored: true
 
             AccessibleMouseArea {

--- a/qml/components/CardTapArea.qml
+++ b/qml/components/CardTapArea.qml
@@ -1,0 +1,24 @@
+import QtQuick
+import Decenza
+
+// The card-wide "tap anywhere to select this thing" target, as used by the bag,
+// equipment, recipe and profile-tile cards. Declare it as a child of the card's
+// root item and give it an accessibleName plus an onAccessibleClicked handler;
+// everything else is the shared part:
+//
+//   anchors.fill  — the whole card, so no padding or inter-button gap is dead
+//                   space (#1798: a tap area scoped to the info row alone reads
+//                   as "selection only works on the text").
+//   z: -1         — the buttons and any other handler inside the card render at
+//                   the default z and are hit-tested first, so they still win
+//                   their own taps. The card's root Rectangle accepts no mouse
+//                   buttons, so it is never a pointer target and cannot swallow
+//                   the tap on its way here.
+//
+// Both are easy to leave out and neither fails loudly: without the fill the
+// card has dead zones, without the z the card swallows its own buttons. Hence
+// one component rather than a fifth hand-copy.
+AccessibleMouseArea {
+    anchors.fill: parent
+    z: -1
+}

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -32,6 +32,23 @@ Rectangle {
 
     Accessible.ignored: true
 
+    // Tap anywhere on the card to switch to this package (#1798, same defect as
+    // BagCard: the tap area wrapped only the summary row, leaving the action
+    // row's whitespace and the card padding dead). z: -1 keeps the buttons above
+    // it so they still win their own taps.
+    AccessibleMouseArea {
+        anchors.fill: parent
+        z: -1
+        accessibleName: card.selected
+            ? summary.accessibleSummary + ", " + TranslationManager.translate("accessibility.selected", "selected")
+            : summary.accessibleSummary
+        accessibleItem: card
+        onAccessibleClicked: {
+            if (card.pkg && card.pkg.id !== undefined)
+                Settings.dye.switchToEquipment(card.pkg)
+        }
+    }
+
     Timer {
         id: deleteRefusedTimer
         interval: 4000  // UI auto-dismiss (allowed timer use)
@@ -57,40 +74,22 @@ Rectangle {
         anchors.margins: Theme.scaled(12)
         spacing: Theme.scaled(6)
 
-        Item {
-            id: infoArea
+        // Shared identity rendering (grinder/basket/puck prep). The package map
+        // exposes the canonical puck-prep string as `puckPrepCanonical`. The
+        // card-wide tap area above switches to this package.
+        EquipmentSummary {
+            id: summary
             Layout.fillWidth: true
-            implicitHeight: summary.implicitHeight
-
-            // Shared identity rendering (grinder/basket/puck prep). The package map
-            // exposes the canonical puck-prep string as `puckPrepCanonical`.
-            EquipmentSummary {
-                id: summary
-                anchors.left: parent.left
-                anchors.right: parent.right
-                grinderName: (card.pkg && card.pkg.name) ? String(card.pkg.name) : ""
-                grinderBrand: (card.pkg && card.pkg.grinderBrand) || ""
-                grinderModel: (card.pkg && card.pkg.grinderModel) || ""
-                grinderBurrs: (card.pkg && card.pkg.grinderBurrs) || ""
-                // Grind/rpm are a per-shot dial-in, not equipment — the inventory
-                // card lists only what the package IS, so the last-dial line is
-                // left unfed here (Shot Detail / Post-Shot Review still show it).
-                basketBrand: (card.pkg && card.pkg.basketBrand) || ""
-                basketModel: (card.pkg && card.pkg.basketModel) || ""
-                puckPrepCanonical: (card.pkg && card.pkg.puckPrepCanonical) || ""
-            }
-
-            AccessibleMouseArea {
-                anchors.fill: parent
-                accessibleName: card.selected
-                    ? summary.accessibleSummary + ", " + TranslationManager.translate("accessibility.selected", "selected")
-                    : summary.accessibleSummary
-                accessibleItem: infoArea
-                onAccessibleClicked: {
-                    if (card.pkg && card.pkg.id !== undefined)
-                        Settings.dye.switchToEquipment(card.pkg)
-                }
-            }
+            grinderName: (card.pkg && card.pkg.name) ? String(card.pkg.name) : ""
+            grinderBrand: (card.pkg && card.pkg.grinderBrand) || ""
+            grinderModel: (card.pkg && card.pkg.grinderModel) || ""
+            grinderBurrs: (card.pkg && card.pkg.grinderBurrs) || ""
+            // Grind/rpm are a per-shot dial-in, not equipment — the inventory
+            // card lists only what the package IS, so the last-dial line is
+            // left unfed here (Shot Detail / Post-Shot Review still show it).
+            basketBrand: (card.pkg && card.pkg.basketBrand) || ""
+            basketModel: (card.pkg && card.pkg.basketModel) || ""
+            puckPrepCanonical: (card.pkg && card.pkg.puckPrepCanonical) || ""
         }
 
         Tr {

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -4,9 +4,12 @@ import Decenza
 
 // Equipment package card (add-equipment-packages). Mirrors BagCard. Shows the
 // package identity via the shared EquipmentSummary renderer (grinder, dial,
-// basket, puck prep), then adds the inventory chrome. Equipment is switched
-// per-bag from Brew Settings, so the card itself is informational + edit/remove
-// (no global "selected" state). One
+// basket, puck prep), then adds the inventory chrome. Tapping the card switches
+// to the package — `selected` tracks Settings.dye.activeEquipmentId and the tap
+// calls switchToEquipment(), the same shape as BagCard's activeBagId. (This
+// header used to claim the card was informational with "no global selected
+// state"; the property and the tap handler have both been here since the card
+// was written, so that was never true.) One
 // removal action follows the package's life: a trash icon while no SHOT
 // references it (a mistaken creation — hard delete), then "Remove" once shots
 // exist (soft-delete, history kept). Storage is the authoritative backstop — it
@@ -34,11 +37,10 @@ Rectangle {
 
     // Tap anywhere on the card to switch to this package (#1798, same defect as
     // BagCard: the tap area wrapped only the summary row, leaving the action
-    // row's whitespace and the card padding dead). z: -1 keeps the buttons above
-    // it so they still win their own taps.
-    AccessibleMouseArea {
-        anchors.fill: parent
-        z: -1
+    // row's whitespace and the card padding dead). The action-row buttons keep
+    // their own taps.
+    CardTapArea {
+        id: cardTapArea
         accessibleName: card.selected
             ? summary.accessibleSummary + ", " + TranslationManager.translate("accessibility.selected", "selected")
             : summary.accessibleSummary
@@ -75,8 +77,8 @@ Rectangle {
         spacing: Theme.scaled(6)
 
         // Shared identity rendering (grinder/basket/puck prep). The package map
-        // exposes the canonical puck-prep string as `puckPrepCanonical`. The
-        // card-wide tap area above switches to this package.
+        // exposes the canonical puck-prep string as `puckPrepCanonical`.
+        // cardTapArea (declared above) switches to this package.
         EquipmentSummary {
             id: summary
             Layout.fillWidth: true

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -2342,11 +2342,9 @@ T.Page {
                 }
             }
         }
-        // Card-wide select target: sits UNDER the header-action buttons (z:-1)
-        // so their taps win, while a tap anywhere else opens the step.
-        AccessibleMouseArea {
-            anchors.fill: parent
-            z: -1
+        // Card-wide select target: sits under the header-action buttons so
+        // their taps win, while a tap anywhere else opens the step.
+        CardTapArea {
             accessibleName: summaryRow.label + ", " + summaryRow.accessibleValue
             accessibleItem: parent
             onAccessibleClicked: {
@@ -2881,12 +2879,10 @@ T.Page {
                                                     }
                                                 }
                                             }
-                                            // The tile-wide select target sits UNDER the
-                                            // info buttons (z: -1) so their own tap areas
-                                            // win — same pattern as the recipe cards.
-                                            AccessibleMouseArea {
-                                                anchors.fill: parent
-                                                z: -1
+                                            // The tile-wide select target sits under the
+                                            // info buttons so their own tap areas win —
+                                            // same pattern as the recipe cards.
+                                            CardTapArea {
                                                 accessibleName: profileLoader.row.title
                                                     + (tileRect.metaLine !== "" ? ", " + tileRect.metaLine : "")
                                                     + (profileLoader.row.reason !== "" ? ", " + profileLoader.row.reason : "")

--- a/qml/pages/RecipesPage.qml
+++ b/qml/pages/RecipesPage.qml
@@ -471,9 +471,7 @@ T.Page {
         opacity: archivedCard ? 0.7 : 1.0
 
         // Tap anywhere on the card to activate (buttons overlay and win).
-        AccessibleMouseArea {
-            anchors.fill: parent
-            z: -1
+        CardTapArea {
             enabled: !card.archivedCard
             accessibleName: TranslationManager.translate("recipes.accessible.activate", "Activate recipe %1").arg(card.recipe.name || "")
             accessibleItem: card


### PR DESCRIPTION
Fixes #1798.

## The bug

On the Bag Inventory page, the tap-to-select `AccessibleMouseArea` wrapped only the info row (thumbnail + text lines), not the card. Taps in the action row's whitespace or the card's bottom padding hit nothing, so selection appeared to work "only if you tap in line with a line of text".

## The fix

Move the tap area to the card root — `anchors.fill: parent`, `z: -1` — which is the pattern `RecipesPage`'s `RecipeCard` already uses. The whole card selects; the buttons and thumbnail render above the area and still win their own taps. The `Item` wrapper that existed only to host the old area is removed, along with two ids nothing referenced.

`EquipmentCard` mirrors `BagCard` and carried the identical dead-space bug — fixed in the same pass rather than left to be reported separately.

## Testing

Builds clean (0 errors). QML behaviour is runtime-only — needs a tap on device: card whitespace selects the bag, and Find in Bean Base / Bag finished / Edit / Thaw / Mark Opened / delete still do their own thing rather than selecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)