### PR TITLE
chore: bump version to 2.0.4 for the next pre-release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 2.0.3 LANGUAGES CXX)
+project(Decenza VERSION 2.0.4 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
One line in `CMakeLists.txt`.

v2.0.3 is a **stable** release (`isPrerelease=false`, currently Latest), so the BLE write-retry and queue-policy work in #1811 cannot ship by re-tagging it — that would push those changes to every user on the stable channel. It goes out as a v2.0.4 **pre-release** instead, which only users with "Beta updates" enabled receive.

The bump is required rather than cosmetic: the auto-updater compares display version before build number, so a v2.0.4 release against a binary still reporting 2.0.3 would keep offering the same update after it had been installed.

No release notes are planned for this build — #1811 has no clearly user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)