### PR TITLE
ci: turn the PCH off on the nightly, matching the linux leg

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -471,10 +471,21 @@ jobs:
         run: |
           # A mechanism that cannot assert its own effect is the failure mode
           # this workflow exists to avoid -- see the ccache and qmllint_check
-          # gates above. LSan does Die() on an unreadable suppressions file, so a
-          # wrong path fails red rather than silently unsuppressed, but it fails
-          # as ~110 aborted binaries with a one-line libc message, which looks
-          # nothing like a leak. Name the real problem instead.
+          # gates above.
+          #
+          # This check is load-bearing, not belt-and-braces. LSan reads the
+          # suppressions file LAZILY -- only when it has a leak to check -- so a
+          # wrong path is SILENT on every clean night and only speaks up on the
+          # rare night a leak occurs, where it reads as the suppression having
+          # failed rather than as a bad path. Measured on ASan/glibc 2.39:
+          #
+          #   leaking binary,     bad path -> "failed to read suppressions
+          #                                    file '<path>'", exit 1
+          #   non-leaking binary, bad path -> no output, exit 0
+          #
+          # An earlier version of this comment claimed LSan Die()s at startup so
+          # a bad path could not go unnoticed. That is wrong, and it is exactly
+          # the assumption that would have justified deleting this check.
           test -f "$GITHUB_WORKSPACE/tests/lsan-suppressions.txt" || {
             echo "::error::LSan suppressions file missing at the path LSAN_OPTIONS names"
             exit 1

--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -330,8 +330,18 @@ jobs:
         run: |
           mkdir -p build
           cd build
+          # PCH off: a compile that consumes a PCH is uncacheable, so leaving it
+          # on made ccache miss ~90% of this leg's compiles. See PR #1738.
+          #
+          # This leg was omitted when #1738 turned the PCH off on the four legs
+          # that carry a warm ccache, because it predates that change (#1560).
+          # The cost was invisible: the cache restored and reported a healthy
+          # 83% hit rate, on the 9.6% of calls that were cacheable at all --
+          # measured on run 31996391080, where Build was 1792 s of a 1913 s job
+          # while the tests it exists to run took 59 s.
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DDECENZA_ENABLE_PCH=OFF \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \


### PR DESCRIPTION
## What

One flag: `-DDECENZA_ENABLE_PCH=OFF` in `nightly-sanitizers.yml`'s configure, so it matches `linux-release.yml` and the other cached legs.

## Why

PR #1738 turned precompiled headers off on the four CI legs carrying a warm ccache — a compile that consumes a PCH is uncacheable, and leaving it on cost those legs ~90% of their cache hits. **The nightly was not one of them**: it predates that change (#1560), so it kept the CMakeLists default, which is ON for anything that is neither `WIN32` nor `IOS`.

That leaves it as the only CI build still using a PCH:

| workflow | PCH | how |
|---|---|---|
| android-release | OFF | explicit flag |
| linux-release | OFF | explicit flag |
| linux-arm64-release | OFF | explicit flag |
| macos-release | OFF | explicit flag |
| windows-release | OFF | `WIN32` default (`CMakeLists.txt:95`) |
| ios-release | OFF | `IOS` default (same line) |
| **nightly-sanitizers** | **ON** | falls through both — its log reads `Precompiled headers: ON` |

## The cost was invisible, which is why it lasted

The cache restored every night and reported a healthy hit rate. The hit rate was healthy — on the tenth of calls that reached the cache at all. From run 31996391080:

```
Cacheable calls:    84 / 875 ( 9.60%)
  Hits:             70 /  84 (83.33%)
  Misses:           14 /  84 (16.67%)
Uncacheable calls: 791 / 875 (90.40%)
```

90.4% matches the ~90% #1738 measured. In that same run `Build` was **1792 s of a 1913 s job**, while the tests the job exists to run took **59 s**. So the nightly spends 30 minutes recompiling to run one minute of tests.

## Mechanism, verified rather than assumed

Reproduced against ccache 4.9.1 — the version CI installs — with a PCH-consuming compile run twice:

```
sloppiness=<empty>                  Cacheable 0/2 (0.00%)   Uncacheable 2/2 (100%)
sloppiness=pch_defines,time_macros  Cacheable 2/2 (100%)    Hits 1/2
```

## The alternative fix, and why not

`sloppiness=pch_defines,time_macros` would keep both the PCH and the cache, and the test above shows it works. It is deliberately not taken: it works by relaxing how thoroughly ccache validates PCH contents, which can serve stale objects. That is a poor trade on the one job whose entire purpose is trustworthy sanitizer results, and it would reverse a decision this repo already measured in #1738.

## Testing

No app or test code changes; the sanitizers are untouched. YAML re-parsed and the flag confirmed present in the `Configure CMake` step.

Note the benefit will **not** show on the next run. Qt 6.11.2 (#1825) just invalidated every cached object, so the next build is cold regardless. The first meaningful comparison is the run after that, against the 1792 s baseline above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
