### PR TITLE
fix(ble): trigger the GATT dispatch log on contention, and flush collapsed tallies at their real run ends

### DIFF
--- a/src/ble/blegattqueue.cpp
+++ b/src/ble/blegattqueue.cpp
@@ -99,29 +99,53 @@ void BleGattQueue::dispatchNext() {
     // under a FOREIGN_WAIT_WARN episode, naming what was delayed and how deep
     // the queue was when it finally ran.
     //
-    // Queue DEPTH is deliberately not a trigger, only a payload. Depth is a
-    // proxy for delay and a bad one, because the app's own connect sequence is
-    // the deepest thing that ever happens here: applyAllSettings enqueues the
-    // whole settings blast the moment the DE1 reports ready, and a measured,
-    // entirely healthy tablet connect peaks at 35. QUEUE_DEPTH_WARN is 40, so
-    // any depth trigger below 35 fires on every launch, and one between 35 and
-    // 40 is a five-wide window that a single new setting closes. There is no
-    // value of it that is quiet on a good connect and loud on a bad one.
+    // Queue DEPTH is deliberately not a trigger, only a payload, because the
+    // app's own connect sequence is the deepest thing that ever happens here.
+    // DE1Device::sendInitialSettings() enqueues five subscribes, the ready
+    // marker, four reads and then its initial MMR writes, and
+    // MainController::applyAllSettings() piles the profile upload on top from
+    // the initialSettingsComplete signal that sequence ends with — peaking the
+    // shared queue at 35 on an entirely healthy connect. That measurement, its
+    // device and its composition are recorded on QUEUE_DEPTH_WARN in the header
+    // rather than restated here, so there is one copy to re-derive. Any depth
+    // trigger below that peak therefore fires on every single launch.
     //
-    // Foreign wait has no such problem: it is the delay itself, it is zero on
-    // an uncontended queue however deep, and it is already the quantity the WARN
-    // is computed from. Half of FOREIGN_WAIT_WARN_MS so a reader sees the
-    // near-misses around an episode, not only the operations that crossed it.
+    // Foreign wait does not have that problem, but its bound is narrower than
+    // "quiet", and worth stating exactly because the difference is the whole
+    // behaviour of this gate:
+    //
+    //   - It is zero while ONE device holds the queue alone, however deep the
+    //     backlog, because chargeForeignWait() skips every operation whose
+    //     requester matches the holder. That is the healthy-launch case above.
+    //   - On a SIMULTANEOUS two-device connect it is not quiet at all, and is
+    //     not meant to be. chargeForeignWait() accumulates onto every queued
+    //     foreign operation, so a slow scale discovery — 6.0 s in the #1819
+    //     capture — charges seconds to the whole DE1 backlog and every one of
+    //     those operations clears this gate. On that connect this logs MORE
+    //     than the depth gate did.
+    //
+    // That second case is the point rather than a regression: it is contention,
+    // it is what #1819 was, and the trail is what a reader needs then. What the
+    // change buys is that the loud case is now the contended one instead of
+    // every launch.
+    //
+    // Half of FOREIGN_WAIT_WARN_MS so a reader sees the near-misses around an
+    // episode, not only the operations that crossed it.
     //
     // (Fourth attempt. The first logged unconditionally — 97.8% of a 7-hour
     // device log. The second collapsed repeats but still fired on the routine
     // once-a-minute overlap of the DE1 keepalive and the scale heartbeat,
-    // ~120 lines/hour. The third gated on depth >= 2, which was silent at idle
-    // but restored 43 lines to every single launch — a healthy 4h17m field
-    // session logged 50 of these and not one of them said anything the single
-    // WARN episode line did not. Each looked obviously sufficient when written,
-    // and only a real device log settled it. Do not reintroduce a depth
-    // trigger without a field log showing what it would have caught.)
+    // ~120 lines/hour. The third gated on depth >= 2 OR the foreign wait below
+    // — the wait half was already right and has been live since d5b6bba6; the
+    // depth half put 43 lines back into every launch. This removes the depth
+    // half only, so what is new here is a deletion, not an untried trigger.
+    //
+    // The evidence for the deletion is a 4h17m field session on the maintainer's
+    // tablet, summarised in PR #1831: 50 dispatch lines, none saying anything
+    // the single WARN episode line did not. That is maintainer testimony about
+    // a log nobody else holds, not a reproducible measurement — weigh it as
+    // such, and do not reintroduce a depth trigger without a field log showing
+    // what it would have caught.)
     if (m_inFlight->foreignWaitMs >= BleGatt::FOREIGN_WAIT_WARN_MS / 2) {
         const QString msg = QString("dispatch %1 (%2 queued)")
                                 .arg(m_inFlight->label)
@@ -343,6 +367,18 @@ void BleGattQueue::reportForeignWaitEpisode() {
     m_foreignWaitCount = 0;
     m_foreignWaitWorstMs = 0;
     m_foreignWaitWorstLabel.clear();
+
+    // The episode is the dispatch line's run end, so its collapsed tallies are
+    // spoken for here or never. Without this they sit in the table until some
+    // later episode happens to reuse the same label and prints them annotated
+    // with a span measured to THAT moment — last week's repeat count stapled to
+    // today's first line, which is the failure LogCollapse::flushAll() exists
+    // to prevent. Nothing keeps a set of the labels an episode touched, which
+    // is why this flushes all of them rather than naming any.
+    for (const auto& [label, collapsed] : m_dispatchLog.flushAll(nowMs())) {
+        GQ_LOG(QString("dispatch %1%2")
+                   .arg(label, LogCollapse::suffix(collapsed)));
+    }
 }
 
 void BleGattQueue::emitDrainedIfIdle() {

--- a/src/ble/blegattqueue.cpp
+++ b/src/ble/blegattqueue.cpp
@@ -94,27 +94,35 @@ void BleGattQueue::dispatchNext() {
     m_inFlightSince = nowMs();
     ++m_generation;
 
-    // Logged only when the ORDERING is non-trivial, which is the only thing this
-    // line is read for.
+    // Logged only for an operation that actually WAITED behind another device.
+    // That is the whole readership of this line: it is the per-operation detail
+    // under a FOREIGN_WAIT_WARN episode, naming what was delayed and how deep
+    // the queue was when it finally ran.
     //
-    // "Non-trivial" is not "anything was queued". Two devices with periodic
-    // traffic overlap by one operation as a matter of course — the DE1's
-    // once-a-minute keepalive lands on the scale's 1 Hz heartbeat and they clear
-    // ~54 ms apart. Measured on a tablet, gating on depth >= 1 left exactly that
-    // pair repeating every minute forever: ~120 lines/hour, still the loudest
-    // source in an app whose every other subsystem totals ~82.
+    // Queue DEPTH is deliberately not a trigger, only a payload. Depth is a
+    // proxy for delay and a bad one, because the app's own connect sequence is
+    // the deepest thing that ever happens here: applyAllSettings enqueues the
+    // whole settings blast the moment the DE1 reports ready, and a measured,
+    // entirely healthy tablet connect peaks at 35. QUEUE_DEPTH_WARN is 40, so
+    // any depth trigger below 35 fires on every launch, and one between 35 and
+    // 40 is a five-wide window that a single new setting closes. There is no
+    // value of it that is quiet on a good connect and loud on a bad one.
     //
-    // So the bar is two deep, or a wait already half way to the one worth
-    // warning about. Below that a reader learns nothing they could act on; above
-    // it, these are the DEBUG context around a FOREIGN_WAIT_WARN episode rather
-    // than a permanent drip. At idle this is silent.
+    // Foreign wait has no such problem: it is the delay itself, it is zero on
+    // an uncontended queue however deep, and it is already the quantity the WARN
+    // is computed from. Half of FOREIGN_WAIT_WARN_MS so a reader sees the
+    // near-misses around an episode, not only the operations that crossed it.
     //
-    // (Third attempt at this gate. The first logged unconditionally — 97.8% of a
-    // 7-hour device log. The second collapsed repeats but still fired on the
-    // routine interleave. Each looked obviously sufficient when written, and
-    // only a real log settled it.)
-    if (m_queue.size() >= BleGatt::DISPATCH_LOG_MIN_DEPTH
-        || m_inFlight->foreignWaitMs >= BleGatt::FOREIGN_WAIT_WARN_MS / 2) {
+    // (Fourth attempt. The first logged unconditionally — 97.8% of a 7-hour
+    // device log. The second collapsed repeats but still fired on the routine
+    // once-a-minute overlap of the DE1 keepalive and the scale heartbeat,
+    // ~120 lines/hour. The third gated on depth >= 2, which was silent at idle
+    // but restored 43 lines to every single launch — a healthy 4h17m field
+    // session logged 50 of these and not one of them said anything the single
+    // WARN episode line did not. Each looked obviously sufficient when written,
+    // and only a real device log settled it. Do not reintroduce a depth
+    // trigger without a field log showing what it would have caught.)
+    if (m_inFlight->foreignWaitMs >= BleGatt::FOREIGN_WAIT_WARN_MS / 2) {
         const QString msg = QString("dispatch %1 (%2 queued)")
                                 .arg(m_inFlight->label)
                                 .arg(m_queue.size());

--- a/src/ble/blegattqueue.cpp
+++ b/src/ble/blegattqueue.cpp
@@ -17,6 +17,23 @@ BleGattQueue::BleGattQueue(QObject* parent)
     m_clock.start();
 }
 
+
+namespace BleGatt {
+
+QString dispatchCollapseKey(const QString& label, qsizetype depth) {
+    return depth < 0 ? QString("dispatch %1").arg(label)
+                     : QString("dispatch %1 (%2 queued)").arg(label).arg(depth);
+}
+
+QString dispatchLine(const QString& label, qsizetype depth, int waitedMs) {
+    const QString base = dispatchCollapseKey(label, depth);
+    return waitedMs < 0 ? base
+                        : base + QString(", waited %1 ms behind another device")
+                                     .arg(waitedMs);
+}
+
+}  // namespace BleGatt
+
 void BleGattQueue::submit(Operation op) {
     if (!validate(op)) return;
     op.enqueuedAtMs = nowMs();
@@ -146,13 +163,15 @@ void BleGattQueue::dispatchNext() {
     // a log nobody else holds, not a reproducible measurement — weigh it as
     // such, and do not reintroduce a depth trigger without a field log showing
     // what it would have caught.)
-    if (m_inFlight->foreignWaitMs >= BleGatt::FOREIGN_WAIT_WARN_MS / 2) {
-        const QString msg = QString("dispatch %1 (%2 queued)")
-                                .arg(m_inFlight->label)
-                                .arg(m_queue.size());
+    if (m_inFlight->foreignWaitMs >= BleGatt::FOREIGN_WAIT_DETAIL_MS) {
+        const QString key = BleGatt::dispatchCollapseKey(m_inFlight->label,
+                                                         m_queue.size());
         LogCollapse::Collapsed collapsed;
-        if (m_dispatchLog.shouldLog(m_inFlight->label, msg, nowMs(), &collapsed))
-            GQ_LOG(msg + LogCollapse::suffix(collapsed));
+        if (m_dispatchLog.shouldLog(m_inFlight->label, key, nowMs(), &collapsed)) {
+            GQ_LOG(BleGatt::dispatchLine(m_inFlight->label, m_queue.size(),
+                                         static_cast<int>(m_inFlight->foreignWaitMs))
+                   + LogCollapse::suffix(collapsed));
+        }
     }
 
     // Accumulated, not reported here. Reported once when the queue goes idle —
@@ -368,17 +387,6 @@ void BleGattQueue::reportForeignWaitEpisode() {
     m_foreignWaitWorstMs = 0;
     m_foreignWaitWorstLabel.clear();
 
-    // The episode is the dispatch line's run end, so its collapsed tallies are
-    // spoken for here or never. Without this they sit in the table until some
-    // later episode happens to reuse the same label and prints them annotated
-    // with a span measured to THAT moment — last week's repeat count stapled to
-    // today's first line, which is the failure LogCollapse::flushAll() exists
-    // to prevent. Nothing keeps a set of the labels an episode touched, which
-    // is why this flushes all of them rather than naming any.
-    for (const auto& [label, collapsed] : m_dispatchLog.flushAll(nowMs())) {
-        GQ_LOG(QString("dispatch %1%2")
-                   .arg(label, LogCollapse::suffix(collapsed)));
-    }
 }
 
 void BleGattQueue::emitDrainedIfIdle() {
@@ -388,6 +396,18 @@ void BleGattQueue::emitDrainedIfIdle() {
     // Before the drained() post, not inside it: drained() is suppressed when one
     // is already pending, and the episode must be reported either way.
     reportForeignWaitEpisode();
+
+    // Idle is ALSO the dispatch line's run end, and it is a different event from
+    // the one above. reportForeignWaitEpisode() returns early unless something
+    // crossed FOREIGN_WAIT_WARN_MS, while the dispatch line logs at
+    // FOREIGN_WAIT_DETAIL_MS — half of it. Flushing inside that function
+    // therefore leaked every tally from a run of near-misses, which is the exact
+    // misattribution the flush exists to prevent: the count sits in the table
+    // until some later run reuses the label, then prints annotated with a span
+    // measured to THAT moment. Nothing keeps a set of the labels a run touched,
+    // hence flushAll() rather than naming any.
+    for (const auto& [label, collapsed] : m_dispatchLog.flushAll(nowMs()))
+        GQ_LOG(BleGatt::dispatchLine(label, -1) + LogCollapse::suffix(collapsed));
     // Collapsed to one emission per idle transition. Two paths can observe the
     // same transition — discard() emptying the queue, and the dispatch it had
     // already posted then finding it empty — and a consumer that acts on

--- a/src/ble/blegattqueue.h
+++ b/src/ble/blegattqueue.h
@@ -328,21 +328,28 @@ private:
     // True between posting a dispatch and running it. The guard a timer's
     // isActive() used to provide, without the timer.
     bool m_dispatchPosted = false;
-    // The dispatch line is the busiest thing this class emits — one per
-    // operation — and at idle the Decent Scale's 1 Hz heartbeat makes it
-    // periodic forever. Measured on a tablet: 25,992 of 26,565 lines in a 7-hour
-    // session, 97.8%, which had evicted every other subsystem's history from the
-    // ring buffer and left two sessions in a file that should hold many.
+    // Collapses a repeated dispatch line inside one contention episode.
     //
-    // LogCollapse already existed for exactly this and already had three callers
-    // (MMR keepalive, memory sampler, ShotServer poll) whose comment records
-    // them as 35% of a 48-hour capture. This was a fourth periodic source that
-    // did not use it.
+    // Its original job is gone. The dispatch line used to be emitted for every
+    // operation, which at idle made it periodic forever on the Decent Scale's
+    // 1 Hz heartbeat — measured on a tablet at 25,992 of 26,565 lines in a
+    // 7-hour session, 97.8%, which had evicted every other subsystem's history
+    // from the ring buffer. That is now the GATE's doing, not the collapser's:
+    // an idle beat never reaches this object at all. The figure is kept because
+    // it is why the gate exists, not because it describes what happens here.
     //
-    // Keyed by label so one device's repeats cannot swallow another's, and a
-    // CHANGED text always emits at once — so every burst, every queue depth
-    // above zero and every non-heartbeat operation still logs immediately. Only
-    // the unchanging idle beat collapses.
+    // What is left is narrow but real: one label repeatedly crossing the
+    // foreign-wait threshold during a sustained episode — a stalled DE1
+    // delaying successive 1 Hz scale heartbeats produces identical text at the
+    // same depth. Keyed by label so one device's repeats cannot swallow
+    // another's, and changed text always emits at once.
+    //
+    // EPISODIC, which changes the contract. LogCollapse's own header warns that
+    // an episodic source must flush at its run end or a suppressed tally is not
+    // merely late but MISATTRIBUTED — stapled onto the next episode's first
+    // line hours later, annotated with a span that dates it to now. While the
+    // dispatch line was periodic there was no run end and no flush was needed;
+    // there is one now, and reportForeignWaitEpisode() is it.
     LogCollapse m_dispatchLog{60 * 1000};
 
     // One line per CONTENTION EPISODE rather than per delayed operation. A

--- a/src/ble/blegattqueue.h
+++ b/src/ble/blegattqueue.h
@@ -109,9 +109,6 @@ inline constexpr int DISCOVERY_TIMEOUT_MS = 20000;
 // holding things up.
 inline constexpr int FOREIGN_WAIT_WARN_MS = 500;
 
-// Queue depth at which a dispatch is worth a DEBUG line. Two, not one: one is
-// the routine periodic overlap of two healthy devices. See dispatchNext().
-inline constexpr qsizetype DISPATCH_LOG_MIN_DEPTH = 2;
 }  // namespace BleGatt
 
 class BleGattQueue : public QObject {

--- a/src/ble/blegattqueue.h
+++ b/src/ble/blegattqueue.h
@@ -109,6 +109,41 @@ inline constexpr int DISCOVERY_TIMEOUT_MS = 20000;
 // holding things up.
 inline constexpr int FOREIGN_WAIT_WARN_MS = 500;
 
+// Foreign wait at which a dispatch earns its per-operation DEBUG line.
+//
+// Half the warning, so a reader already looking at an episode sees the
+// near-misses around it and not only the operations that crossed it. Named
+// rather than written as FOREIGN_WAIT_WARN_MS / 2 at the one call site: the
+// constant this replaced (DISPATCH_LOG_MIN_DEPTH) was named and documented
+// here, and burying the replacement as arithmetic inside an `if` is how the
+// difference between this threshold and the warning above stopped being
+// visible — which is exactly the bug that shipped, a flush gated on the WARN
+// firing while the line it flushed logs at half that.
+inline constexpr int FOREIGN_WAIT_DETAIL_MS = FOREIGN_WAIT_WARN_MS / 2;
+
+// The dispatch line, in one place.
+//
+// Built at two sites — the live dispatch and the run-end flush — and matched by
+// a third in tst_blegattqueue.cpp. They were three independent spellings of one
+// string, so renaming the line at either site would have silently desynchronised
+// the subsystem's own log from the test that guards its volume, with nothing
+// failing. `depth < 0` means "not known here", which is the flush's case: it
+// speaks for operations whose queue depth is long gone.
+//
+// waitedMs is the value the GATE fired on and is what a reader chasing a delay
+// actually needs; without it the line cannot tell 260 ms from 480 ms. It is
+// deliberately NOT part of collapseKey() below — see there.
+QString dispatchLine(const QString& label, qsizetype depth, int waitedMs = -1);
+
+// What LogCollapse compares to decide a line REPEATED rather than changed.
+//
+// Same line without the wait. Including a millisecond figure would make every
+// dispatch unique, so nothing would ever collapse and a sustained episode would
+// print one line per operation — the behaviour three earlier attempts at this
+// gate were trying to escape. Collapsing on the shape and letting the first
+// line of a run carry its own wait keeps both.
+QString dispatchCollapseKey(const QString& label, qsizetype depth);
+
 }  // namespace BleGatt
 
 class BleGattQueue : public QObject {

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -181,6 +181,18 @@ void DE1Device::onTransportConnected() {
 }
 
 void DE1Device::onTransportDisconnected() {
+    // The keepalive run ends here. Without this its suppressed tally sat in the
+    // table across the whole disconnect, and the first keepalive after a
+    // reconnect — possibly hours later — printed carrying the PREVIOUS session's
+    // count, annotated with a span measured to the moment a reader is looking at
+    // it. Keyed by MMR address, which this function does not enumerate, so it
+    // flushes all of them.
+    for (const auto& [address, collapsed] :
+         m_keepaliveLog.flushAll(QDateTime::currentMSecsSinceEpoch())) {
+        MMR_LOG(QString("MMR keepalive 0x%1%2")
+                    .arg(address, LogCollapse::suffix(collapsed)));
+    }
+
     // Tier by whether the machine was BUSY, because that is what separates a
     // fault from a shutdown, and nothing else here can.
     //

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -487,6 +487,7 @@ private:
     // and cannot be dropped). Its LOG line, repeated 3,042 times in a 48-hour capture for 15% of the
     // whole log, can be. One line per 10 minutes carrying the count; a value CHANGE still prints
     // immediately, because that is the event worth seeing.
+    // Episodic: a run is one connected session. Flushed in onTransportDisconnected().
     LogCollapse m_keepaliveLog{10 * 60 * 1000};
     // Pending one-shot MMR reads keyed by address — covers both the
     // post-connect informational reads issued via issueMMRReadWithRetry().

--- a/src/core/batterymanager.h
+++ b/src/core/batterymanager.h
@@ -185,5 +185,6 @@ private:
     // One line per window while the poll result is unchanged; a change emits at
     // once. 15 min: the poll runs every ~60 s and a plugged-in tablet never
     // varies, so the window only decides how often "still the same" is restated.
+    // Periodic: polls for the process lifetime, so there is no run end and nothing to flush.
     LogCollapse m_pollCollapse{15 * 60 * 1000};
 };

--- a/src/core/logcollapse.h
+++ b/src/core/logcollapse.h
@@ -31,10 +31,32 @@
 class LogCollapse
 {
 public:
+    // ON RUN ENDS, which is the one thing a caller has to get right and the thing four of six got
+    // wrong.
+    //
+    // A source that runs for the process lifetime cannot leak — the memory sampler, the battery
+    // poll. Every OTHER source eventually goes quiet, and when it does its pending tally sits in
+    // the table until the next run reuses the key and prints it annotated with a span measured to
+    // THAT moment: last week's repeat count on today's first line. Such a source must flush() or
+    // flushAll() at whatever event ends its run.
+    //
+    // This was a rule in a comment on flush() and it stayed one until someone checked the callers:
+    // of six, three are episodic and two of those never flushed (the MMR keepalive across a
+    // disconnect, the ShotServer request log across a server stop). Both are fixed, and every
+    // declaration site now states which kind it is and where it flushes.
+    //
+    // It is NOT a constructor mode with a destructor assert. That was built and removed: process
+    // exit is not a run end anyone can observe, so an episodic source holds a legitimate tally when
+    // it is destroyed, and the assert aborted on a CORRECT caller — MqttClient, which flushes on
+    // every reconnect, died at teardown. With the assert gone the mode had no reader at all and the
+    // compiler said so (-Wunused-private-field). An enum nobody reads is a comment with a type, so
+    // this is the comment.
+
     // `windowMs` is the minimum spacing between emitted lines for a given key while the text is
     // unchanged. A CHANGED text always emits immediately regardless of the window — a value that
     // moved is the interesting event, and holding it back is how a collapser turns into a bug.
     explicit LogCollapse(qint64 windowMs) : m_windowMs(windowMs) {}
+
 
     // What a single emitted line stood in for. Both fields are needed to describe it honestly, and
     // they travel together for exactly that reason — see suffix().
@@ -57,7 +79,7 @@ public:
 
         if (!e.everEmitted || changed || windowElapsed) {
             if (out)
-                *out = {e.suppressed, e.everEmitted ? nowMs - e.lastEmitMs : 0};
+                *out = pending(e, nowMs);
             e.text = text;
             e.lastEmitMs = nowMs;
             e.suppressed = 0;
@@ -85,7 +107,7 @@ public:
         const auto it = m_entries.constFind(key);
         if (it == m_entries.cend())
             return {};
-        const Collapsed c{it->suppressed, it->everEmitted ? nowMs - it->lastEmitMs : 0};
+        const Collapsed c = pending(*it, nowMs);
         m_entries.erase(it);
         return c;
     }
@@ -106,7 +128,7 @@ public:
         QList<QPair<QString, Collapsed>> out;
         for (auto it = m_entries.cbegin(); it != m_entries.cend(); ++it) {
             if (it->suppressed > 0)
-                out.append({it.key(), {it->suppressed, it->everEmitted ? nowMs - it->lastEmitMs : 0}});
+                out.append({it.key(), pending(*it, nowMs)});
         }
         m_entries.clear();
         return out;
@@ -139,6 +161,14 @@ private:
         int suppressed = 0;
         bool everEmitted = false;
     };
+
+    // One definition of what a pending tally is. The expression was written at three sites after
+    // flushAll() arrived, in a file whose own suffix() comment records what happened last time this
+    // class had one definition worded slightly differently at one of them.
+    static Collapsed pending(const Entry& e, qint64 nowMs)
+    {
+        return {e.suppressed, e.everEmitted ? nowMs - e.lastEmitMs : 0};
+    }
 
     qint64 m_windowMs;
     QHash<QString, Entry> m_entries;

--- a/src/core/logcollapse.h
+++ b/src/core/logcollapse.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QHash>
+#include <QList>
+#include <QPair>
 #include <QString>
 
 // Collapses a repeating log line to one entry per window, carrying the count of what it stood in
@@ -88,6 +90,28 @@ public:
         return c;
     }
 
+    // Ends a run across EVERY key at once, returning what was still pending for each.
+    //
+    // flush() above takes a key because its callers observe the end of one named thing — a broker
+    // reconnecting, a poll stopping. An episodic source that is keyed by something it does not
+    // enumerate cannot use it: the GATT queue keys its dispatch line by operation LABEL, and a
+    // contention episode touches whatever labels happened to be queued. Making each caller keep a
+    // set of the keys it has used, purely so it can flush them, is the copy-per-caller this class
+    // exists to prevent.
+    //
+    // The caller is expected to LOG what comes back. Dropping the return value silently discards
+    // the tallies, which is the same misattribution as never flushing, only quieter.
+    QList<QPair<QString, Collapsed>> flushAll(qint64 nowMs)
+    {
+        QList<QPair<QString, Collapsed>> out;
+        for (auto it = m_entries.cbegin(); it != m_entries.cend(); ++it) {
+            if (it->suppressed > 0)
+                out.append({it.key(), {it->suppressed, it->everEmitted ? nowMs - it->lastEmitMs : 0}});
+        }
+        m_entries.clear();
+        return out;
+    }
+
     // Convenience for the common shape: " (+N identical in the preceding M s)" or an empty string.
     // Centralized so the five callers cannot word the same annotation five ways — which is what
     // happened to the [USB Scale] prefix (73 hand-written sites, 21 of them drifted).
@@ -105,15 +129,6 @@ public:
         return QStringLiteral(" (+%1 identical in the preceding %2 s)")
             .arg(c.suppressed)
             .arg(c.spanMs / 1000);
-    }
-
-    // How many identical lines are currently held back for `key`. Read-only, for
-    // tests that need to assert a source collapses rather than counting log
-    // lines — which qDebug output does not let a test do directly.
-    int suppressedFor(const QString& key) const
-    {
-        const auto it = m_entries.constFind(key);
-        return it == m_entries.cend() ? 0 : it->suppressed;
     }
 
 private:

--- a/src/core/memorymonitor.h
+++ b/src/core/memorymonitor.h
@@ -77,6 +77,7 @@ private:
 
     // Collapses the per-sample log line while a plateau holds — see onSampleTimerTick(). Sampling
     // itself is untouched; this only decides whether the sample is worth a line.
+    // Periodic: samples for the process lifetime, so there is no run end and nothing to flush.
     LogCollapse m_logCollapse{10 * 60 * 1000};
     // RSS as of the last line PRINTED — the anchor the 5 MB band is measured from, so a value
     // sitting on a fixed bucket edge cannot oscillate across it. Negative until the first line.

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -169,6 +169,8 @@ private:
     // message emits at once. 10 min: a broker that is down stays down for hours,
     // and the retry ladder already has its own one-shot "backing off" warning, so
     // this only decides how often "still down, same reason" is restated.
+    // Episodic: a run is one connection attempt sequence. Flushed on a successful connect in
+    // onConnected() — the only caller that got this right before the others were audited.
     LogCollapse m_logCollapse{10 * 60 * 1000};
     // A stop the user asked for is not a fault, so it must not re-arm the retry loop.
     //

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -572,6 +572,15 @@ bool ShotServer::start()
 
 void ShotServer::stop()
 {
+    // The request log's run ends with the server. Its keys are request lines,
+    // which nothing here enumerates, and a tally left behind would be printed by
+    // whatever request first repeats after the NEXT start — a count from the
+    // previous run dated to the new one.
+    for (const auto& [line, collapsed] :
+         m_requestLog.flushAll(QDateTime::currentMSecsSinceEpoch())) {
+        qDebug().noquote() << line + LogCollapse::suffix(collapsed);
+    }
+
     cancelAllLibraryRequests();
 
     if (m_discoverySocket) {

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -152,6 +152,7 @@ private:
     // Collapses repeated identical request lines — see handleRequest(). One minute, not the ten
     // used by the periodic samplers: a request is user-driven, so a path that has been quiet
     // should log the moment it comes back.
+    // Episodic: a run is one server lifetime. Flushed in stop().
     LogCollapse m_requestLog{60 * 1000};
 
     void handleRequest(QTcpSocket* socket, const QByteArray& request);

--- a/tests/messagecapture.h
+++ b/tests/messagecapture.h
@@ -3,7 +3,6 @@
 #include <QList>
 #include <QRegularExpression>
 #include <QString>
-#include <QVector>
 #include <QtGlobal>
 
 // Scoped qInstallMessageHandler helpers, in one place.
@@ -36,14 +35,10 @@
 // So a test built on ignoreMessage alone still passes if the line under test is
 // demoted a tier or deleted outright.
 //
-// And why not LogCollapse::suppressedFor(): that counts COLLAPSED repeats, so a
-// line that prints for the first time leaves it at zero. Zero there is equally
-// consistent with silence and with one printed line — blind in the direction
-// that matters for a "was not logged" assertion.
-//
-// count() deliberately spans EVERY tier. A tier promotion is a normal edit to
-// make to a noisy line, and it must turn a "not logged" assertion red rather
-// than satisfying it. Use countAtTier() where the tier is itself the subject.
+// The predecessor of this class asserted silence by reading a collapsed-repeat
+// count, which is zero both when nothing was logged and when one line printed —
+// blind in the one direction a "was not logged" assertion needs. Counting the
+// emitted lines is the assertion; anything derived from the collapser is not.
 class MessageCapture {
 public:
     // Whether messages also reach the handler that was installed before this
@@ -62,18 +57,18 @@ public:
         : m_chaining(chaining) {
         m_outer = s_active;
         s_active = this;
-        // Depth-counted rather than one install per instance: a nested instance
-        // that installed again would get &handler back as its "previous", and
-        // the first message would recurse into handler() forever. Installing
-        // once and walking the m_outer chain removes that failure mode instead
-        // of documenting it.
-        if (s_depth++ == 0)
+        // Installed ONCE, for the outermost instance only. A nested instance
+        // that installed again would get &handler back as its "previous" and the
+        // first message would recurse into handler() forever; walking the
+        // m_outer chain removes that failure mode instead of documenting it.
+        // No depth counter — an empty chain is depth zero.
+        if (!m_outer)
             s_original = qInstallMessageHandler(&MessageCapture::handler);
     }
 
     ~MessageCapture() {
         s_active = m_outer;
-        if (--s_depth == 0) {
+        if (!s_active) {
             qInstallMessageHandler(s_original);
             s_original = nullptr;
         }
@@ -83,56 +78,34 @@ public:
 
     void clear() { m_entries.clear(); }
 
-    const QList<Entry>& entries() const { return m_entries; }
-
-    // Messages containing `needle`, at ANY tier. See the class comment on why
-    // this is not tier-filtered.
-    int count(const QString& needle) const {
-        int n = 0;
-        for (const Entry& e : m_entries) {
-            if (e.text.contains(needle))
-                ++n;
-        }
-        return n;
-    }
-
-    int countAtTier(const QString& needle, QtMsgType type) const {
-        int n = 0;
-        for (const Entry& e : m_entries) {
-            if (e.type == type && e.text.contains(needle))
-                ++n;
-        }
-        return n;
-    }
-
-    // Last message containing `needle`, or an empty Entry.
-    Entry last(const QString& needle) const {
-        Entry found;
-        for (const Entry& e : m_entries) {
-            if (e.text.contains(needle))
-                found = e;
-        }
-        return found;
-    }
+    // Messages containing `needle`, at ANY tier. Not tier-filtered, deliberately:
+    // a tier promotion is a normal edit to make to a noisy line, and it must
+    // turn a "was not logged" assertion red rather than satisfying it. Filtering
+    // to QtDebugMsg is what made the first version of this helper blind in the
+    // one direction that mattered.
+    qsizetype count(const QString& needle) const { return matching(needle).size(); }
 
     // The one message containing `needle`, or false. Insists on EXACTLY one:
     // zero means the line vanished, more than one means the event was announced
-    // twice, and a test that accepted either would not notice.
+    // twice, and a test that accepted either would not notice. Carries the tier
+    // out with it, so a slot asserting ON the tier reads `.type`.
     bool single(const QString& needle, Entry* out) const {
-        Entry found;
-        int matches = 0;
-        for (const Entry& e : m_entries) {
-            if (e.text.contains(needle)) {
-                found = e;
-                ++matches;
-            }
-        }
-        if (matches == 1 && out)
-            *out = found;
-        return matches == 1;
+        const QList<Entry> m = matching(needle);
+        if (m.size() == 1 && out)
+            *out = m.first();
+        return m.size() == 1;
     }
 
 private:
+    QList<Entry> matching(const QString& needle) const {
+        QList<Entry> out;
+        for (const Entry& e : m_entries) {
+            if (e.text.contains(needle))
+                out.append(e);
+        }
+        return out;
+    }
+
     static void handler(QtMsgType type, const QMessageLogContext& ctx,
                         const QString& msg) {
         // Every live capture records, innermost first. A nested capture does
@@ -156,7 +129,6 @@ private:
 
     static inline MessageCapture* s_active = nullptr;
     static inline QtMessageHandler s_original = nullptr;
-    static inline int s_depth = 0;
 };
 
 // Suppresses qWarning messages matching a pattern, so expected noise does not
@@ -169,40 +141,45 @@ private:
 // The distinction that matters: ignoreMessage REQUIRES its message to fire,
 // this only ALLOWS it.
 struct ScopedWarningFilter {
-    static inline QVector<QRegularExpression*> s_filters;
-    static inline QtMessageHandler s_originalHandler = nullptr;
-    static inline int s_depth = 0;
-
-    static void handler(QtMsgType type, const QMessageLogContext& ctx,
-                        const QString& msg) {
-        if (type == QtWarningMsg) {
-            for (auto* f : s_filters) {
-                if (f && f->match(msg).hasMatch())
-                    return;  // Suppress
-            }
-        }
-        if (s_originalHandler)
-            s_originalHandler(type, ctx, msg);
-    }
-
-    QRegularExpression m_pattern;
-
-    // A copy would register nothing but still decrement s_depth on destruction,
-    // uninstalling the handler early and leaving a dangling &m_pattern in
-    // s_filters. Nothing copies one today; this makes sure nothing starts.
-    Q_DISABLE_COPY_MOVE(ScopedWarningFilter)
-
+    // Same chain as MessageCapture above, for the same reason: one idiom for
+    // "nest a message handler" in this header rather than two. It replaced a
+    // QVector<QRegularExpression*> plus a depth counter, whose only real cost
+    // was a dangling-pointer hazard that existed solely BECAUSE the pattern was
+    // parked in a container — the chain has nowhere to dangle. Requires LIFO
+    // destruction, which stack scoping gives for free.
     explicit ScopedWarningFilter(const QString& pattern) : m_pattern(pattern) {
-        s_filters.append(&m_pattern);
-        if (s_depth++ == 0)
-            s_originalHandler = qInstallMessageHandler(handler);
+        m_outer = s_active;
+        s_active = this;
+        if (!m_outer)
+            s_original = qInstallMessageHandler(&ScopedWarningFilter::handler);
     }
 
     ~ScopedWarningFilter() {
-        s_filters.removeOne(&m_pattern);
-        if (--s_depth == 0) {
-            qInstallMessageHandler(s_originalHandler);
-            s_originalHandler = nullptr;
+        s_active = m_outer;
+        if (!s_active) {
+            qInstallMessageHandler(s_original);
+            s_original = nullptr;
         }
     }
+
+    Q_DISABLE_COPY_MOVE(ScopedWarningFilter)
+
+private:
+    static void handler(QtMsgType type, const QMessageLogContext& ctx,
+                        const QString& msg) {
+        if (type == QtWarningMsg) {
+            for (const ScopedWarningFilter* f = s_active; f; f = f->m_outer) {
+                if (f->m_pattern.match(msg).hasMatch())
+                    return;  // Suppressed by this filter or one enclosing it.
+            }
+        }
+        if (s_original)
+            s_original(type, ctx, msg);
+    }
+
+    QRegularExpression m_pattern;
+    ScopedWarningFilter* m_outer = nullptr;
+
+    static inline ScopedWarningFilter* s_active = nullptr;
+    static inline QtMessageHandler s_original = nullptr;
 };

--- a/tests/mocks/McpTestFixture.h
+++ b/tests/mocks/McpTestFixture.h
@@ -9,6 +9,7 @@
 #include "mcp/mcptoolregistry.h"
 
 #include <memory>
+#include "messagecapture.h"   // ScopedWarningFilter
 
 // Shared test fixture for MCP tool tests.
 // Wires ProfileManager with a MockTransport so BLE writes can be verified.
@@ -17,43 +18,6 @@
 //   McpTestFixture f;
 //   registerProfileTools(f.registry, f.profileManager);
 //   auto result = f.callTool("profiles_list", {});
-
-// RAII guard to suppress qWarning messages matching a pattern.
-// Nestable: patterns are pushed onto a stack. A warning is suppressed if it
-// matches ANY active filter's pattern. Non-matching messages are forwarded
-// to Qt Test's handler so QTest::ignoreMessage still works.
-struct ScopedWarningFilter {
-    static inline QVector<QRegularExpression*> s_filters;
-    static inline QtMessageHandler s_originalHandler = nullptr;
-    static inline int s_depth = 0;
-
-    static void handler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
-        if (type == QtWarningMsg) {
-            for (auto* f : s_filters) {
-                if (f && f->match(msg).hasMatch())
-                    return;  // Suppress
-            }
-        }
-        // Forward to Qt Test's handler
-        if (s_originalHandler)
-            s_originalHandler(type, ctx, msg);
-    }
-
-    QRegularExpression m_pattern;
-
-    ScopedWarningFilter(const QString& pattern) : m_pattern(pattern) {
-        s_filters.append(&m_pattern);
-        if (s_depth++ == 0)
-            s_originalHandler = qInstallMessageHandler(handler);
-    }
-    ~ScopedWarningFilter() {
-        s_filters.removeOne(&m_pattern);
-        if (--s_depth == 0) {
-            qInstallMessageHandler(s_originalHandler);
-            s_originalHandler = nullptr;
-        }
-    }
-};
 
 struct McpTestFixture {
     QTemporaryDir tempDir;   // isolated profile storage

--- a/tests/mocks/McpTestFixture.h
+++ b/tests/mocks/McpTestFixture.h
@@ -9,7 +9,7 @@
 #include "mcp/mcptoolregistry.h"
 
 #include <memory>
-#include "messagecapture.h"   // ScopedWarningFilter
+#include "../messagecapture.h"   // ScopedWarningFilter
 
 // Shared test fixture for MCP tool tests.
 // Wires ProfileManager with a MockTransport so BLE writes can be verified.

--- a/tests/mocks/messagecapture.h
+++ b/tests/mocks/messagecapture.h
@@ -1,0 +1,208 @@
+#pragma once
+
+#include <QList>
+#include <QRegularExpression>
+#include <QString>
+#include <QVector>
+#include <QtGlobal>
+
+// Scoped qInstallMessageHandler helpers, in one place.
+//
+// There were four hand-rolled copies of this idea in tests/ — two of them
+// verbatim duplicates of each other — and they had already drifted into three
+// different answers for the same question. Worse, the newest copy was the
+// weakest: it filtered on QtDebugMsg alone, so promoting the line it watched to
+// qInfo would have made every "this was not logged" assertion pass while the
+// log got LOUDER, which is the exact regression its test file exists to prevent.
+// One definition, so a fix to the shape reaches every caller.
+//
+// Two types, because there are two genuinely different jobs and merging them
+// would produce a framework nobody wants:
+//
+//   MessageCapture      — record messages so a test can ASSERT on them
+//   ScopedWarningFilter — suppress expected noise so it does not fail the run
+//
+// Header-only and dependency-free on purpose. tests/mocks/McpTestFixture.h used
+// to host ScopedWarningFilter, and tst_decentscalewifi.cpp inlined its own copy
+// specifically to avoid pulling in that header's Settings/MockTransport. This
+// header pulls in nothing, so that reason to copy is gone.
+
+// Records messages so a test can assert on their COUNT, TEXT and TIER.
+//
+// Why this rather than QTest::ignoreMessage: ignoreMessage is a PERMISSION, not
+// an assertion. An unmatched pattern is reported by printUnhandledIgnoreMessages()
+// via addMessage() with QAbstractTestLogger::Info
+// (qtbase/src/testlib/qtestlog.cpp:397-419) — a printed line, never a failure.
+// So a test built on ignoreMessage alone still passes if the line under test is
+// demoted a tier or deleted outright.
+//
+// And why not LogCollapse::suppressedFor(): that counts COLLAPSED repeats, so a
+// line that prints for the first time leaves it at zero. Zero there is equally
+// consistent with silence and with one printed line — blind in the direction
+// that matters for a "was not logged" assertion.
+//
+// count() deliberately spans EVERY tier. A tier promotion is a normal edit to
+// make to a noisy line, and it must turn a "not logged" assertion red rather
+// than satisfying it. Use countAtTier() where the tier is itself the subject.
+class MessageCapture {
+public:
+    // Whether messages also reach the handler that was installed before this
+    // one. Chain when the surrounding QTest machinery must keep working —
+    // QTest::ignoreMessage and QTest::failOnWarning both live in that handler.
+    // Swallow when the test is ASSERTING on a warning that failOnWarning would
+    // otherwise treat as a failure.
+    enum Chaining { ChainToPrevious, SwallowAll };
+
+    struct Entry {
+        QtMsgType type = QtDebugMsg;
+        QString text;
+    };
+
+    explicit MessageCapture(Chaining chaining = ChainToPrevious)
+        : m_chaining(chaining) {
+        m_outer = s_active;
+        s_active = this;
+        // Depth-counted rather than one install per instance: a nested instance
+        // that installed again would get &handler back as its "previous", and
+        // the first message would recurse into handler() forever. Installing
+        // once and walking the m_outer chain removes that failure mode instead
+        // of documenting it.
+        if (s_depth++ == 0)
+            s_original = qInstallMessageHandler(&MessageCapture::handler);
+    }
+
+    ~MessageCapture() {
+        s_active = m_outer;
+        if (--s_depth == 0) {
+            qInstallMessageHandler(s_original);
+            s_original = nullptr;
+        }
+    }
+
+    Q_DISABLE_COPY_MOVE(MessageCapture)
+
+    void clear() { m_entries.clear(); }
+
+    const QList<Entry>& entries() const { return m_entries; }
+
+    // Messages containing `needle`, at ANY tier. See the class comment on why
+    // this is not tier-filtered.
+    int count(const QString& needle) const {
+        int n = 0;
+        for (const Entry& e : m_entries) {
+            if (e.text.contains(needle))
+                ++n;
+        }
+        return n;
+    }
+
+    int countAtTier(const QString& needle, QtMsgType type) const {
+        int n = 0;
+        for (const Entry& e : m_entries) {
+            if (e.type == type && e.text.contains(needle))
+                ++n;
+        }
+        return n;
+    }
+
+    // Last message containing `needle`, or an empty Entry.
+    Entry last(const QString& needle) const {
+        Entry found;
+        for (const Entry& e : m_entries) {
+            if (e.text.contains(needle))
+                found = e;
+        }
+        return found;
+    }
+
+    // The one message containing `needle`, or false. Insists on EXACTLY one:
+    // zero means the line vanished, more than one means the event was announced
+    // twice, and a test that accepted either would not notice.
+    bool single(const QString& needle, Entry* out) const {
+        Entry found;
+        int matches = 0;
+        for (const Entry& e : m_entries) {
+            if (e.text.contains(needle)) {
+                found = e;
+                ++matches;
+            }
+        }
+        if (matches == 1 && out)
+            *out = found;
+        return matches == 1;
+    }
+
+private:
+    static void handler(QtMsgType type, const QMessageLogContext& ctx,
+                        const QString& msg) {
+        // Every live capture records, innermost first. A nested capture does
+        // not hide the message from the one that encloses it.
+        bool swallow = false;
+        for (MessageCapture* c = s_active; c; c = c->m_outer) {
+            c->m_entries.append({type, msg});
+            if (c->m_chaining == SwallowAll)
+                swallow = true;
+        }
+        // Any live capture asking to swallow wins. A test that installed one to
+        // keep a warning away from failOnWarning must get that, even if an
+        // enclosing capture is content to chain.
+        if (!swallow && s_original)
+            s_original(type, ctx, msg);
+    }
+
+    QList<Entry> m_entries;
+    MessageCapture* m_outer = nullptr;
+    Chaining m_chaining = ChainToPrevious;
+
+    static inline MessageCapture* s_active = nullptr;
+    static inline QtMessageHandler s_original = nullptr;
+    static inline int s_depth = 0;
+};
+
+// Suppresses qWarning messages matching a pattern, so expected noise does not
+// fail a run under QTest::failOnWarning().
+//
+// Nestable: patterns are pushed onto a stack and a warning is suppressed if it
+// matches ANY active filter. Non-matching messages forward to whatever handler
+// was installed before, so QTest::ignoreMessage still works alongside it.
+//
+// The distinction that matters: ignoreMessage REQUIRES its message to fire,
+// this only ALLOWS it.
+struct ScopedWarningFilter {
+    static inline QVector<QRegularExpression*> s_filters;
+    static inline QtMessageHandler s_originalHandler = nullptr;
+    static inline int s_depth = 0;
+
+    static void handler(QtMsgType type, const QMessageLogContext& ctx,
+                        const QString& msg) {
+        if (type == QtWarningMsg) {
+            for (auto* f : s_filters) {
+                if (f && f->match(msg).hasMatch())
+                    return;  // Suppress
+            }
+        }
+        if (s_originalHandler)
+            s_originalHandler(type, ctx, msg);
+    }
+
+    QRegularExpression m_pattern;
+
+    // A copy would register nothing but still decrement s_depth on destruction,
+    // uninstalling the handler early and leaving a dangling &m_pattern in
+    // s_filters. Nothing copies one today; this makes sure nothing starts.
+    Q_DISABLE_COPY_MOVE(ScopedWarningFilter)
+
+    explicit ScopedWarningFilter(const QString& pattern) : m_pattern(pattern) {
+        s_filters.append(&m_pattern);
+        if (s_depth++ == 0)
+            s_originalHandler = qInstallMessageHandler(handler);
+    }
+
+    ~ScopedWarningFilter() {
+        s_filters.removeOne(&m_pattern);
+        if (--s_depth == 0) {
+            qInstallMessageHandler(s_originalHandler);
+            s_originalHandler = nullptr;
+        }
+    }
+};

--- a/tests/tst_blegattqueue.cpp
+++ b/tests/tst_blegattqueue.cpp
@@ -66,6 +66,47 @@ private:
     // simulated.
     static void advanceQueueClock(BleGattQueue& q, qint64 ms) { q.m_testClockSkewMs += ms; }
 
+    // Counts DEBUG lines containing a needle, so "this was NOT logged" is an
+    // assertion that can fail.
+    //
+    // suppressedFor() cannot do that job, and the slots below used to lean on
+    // it: it counts COLLAPSED repeats, so a line that passes the gate and
+    // prints for the first time leaves it at zero. Zero there is equally
+    // consistent with silence and with one printed line, which makes it blind
+    // to exactly the regression these slots exist to catch. Chains to the
+    // previous handler so QTest::ignoreMessage and failOnWarning still work.
+    class DebugLineCounter {
+    public:
+        explicit DebugLineCounter(QString needle) {
+            s_needle = std::move(needle);
+            s_count = 0;
+            s_last.clear();
+            s_prev = qInstallMessageHandler(&DebugLineCounter::handle);
+        }
+        ~DebugLineCounter() { qInstallMessageHandler(s_prev); }
+        DebugLineCounter(const DebugLineCounter&) = delete;
+        DebugLineCounter& operator=(const DebugLineCounter&) = delete;
+
+        int count() const { return s_count; }
+        QString lastLine() const { return s_last; }
+
+    private:
+        static void handle(QtMsgType type, const QMessageLogContext& ctx,
+                           const QString& msg) {
+            if (type == QtDebugMsg && msg.contains(s_needle)) {
+                ++s_count;
+                s_last = msg;
+            }
+            if (s_prev)
+                s_prev(type, ctx, msg);
+        }
+
+        static inline QtMessageHandler s_prev = nullptr;
+        static inline QString s_needle;
+        static inline int s_count = 0;
+        static inline QString s_last;
+    };
+
 private slots:
     void init() { QTest::failOnWarning(); }
 
@@ -281,6 +322,7 @@ private slots:
     void anIdleDispatchIsNotLoggedAtAll() {
         BleGattQueue q;
         Recorder rec;
+        DebugLineCounter log(QStringLiteral("dispatch "));
 
         for (int i = 0; i < 5; ++i) {
             q.submit(op(scale(), QStringLiteral("scale write"), &rec));
@@ -290,24 +332,30 @@ private slots:
         }
 
         QCOMPARE(rec.issued.size(), 5);   // all five ran...
-        // ...and none reached the log, so none was even offered to the
-        // collapser. Collapsing alone was not enough: one line a minute still
-        // out-logs every other subsystem in the app combined.
-        QCOMPARE(q.m_dispatchLog.suppressedFor(QStringLiteral("scale write")), 0);
+        // ...and none reached the log. Counted, not inferred from
+        // suppressedFor(): collapsing alone was never enough — one line a
+        // minute still out-logs every other subsystem in the app combined — and
+        // a suppressed-repeat count of zero cannot tell silence apart from a
+        // first line that printed.
+        QCOMPARE(log.count(), 0);
     }
 
-    // A CHANGED line must still print at once, or a burst — the case a reader
-    // actually needs — would be swallowed by the collapse that exists for the
-    // idle case. The queue depth is part of the text precisely so this holds.
-    // The gate keeps every line that carries ORDERING — which is what this class
-    // is read for. A dispatch with work queued behind it is exactly that, and
-    // must survive both the gate and the collapser.
-    void aDispatchWithWorkQueuedBehindItIsLogged() {
+    // Queue DEPTH alone must not produce a line, however deep.
+    //
+    // This is the regression that shipped: gating on depth >= 2 was silent at
+    // idle and therefore looked correct, but the app's own connect sequence is
+    // the deepest thing that ever happens here — applyAllSettings enqueues the
+    // settings blast the instant the DE1 reports ready — so a healthy launch
+    // peaked at 35 and wrote 43 lines every single time. A measured 4h17m field
+    // session logged 50 of these, and not one said anything the single
+    // FOREIGN_WAIT_WARN episode line did not.
+    //
+    // All three operations here belong to the SAME requester, so nothing waits
+    // on a foreign device and nothing is worth a line.
+    void aDeepQueueOfOneDevicesOwnWorkIsNotLogged() {
         BleGattQueue q;
         Recorder rec;
-
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(QStringLiteral("dispatch de1-a \\(2 queued\\)")));
+        DebugLineCounter log(QStringLiteral("dispatch "));
 
         q.submit(op(de1(), QStringLiteral("de1-a"), &rec));
         q.submit(op(de1(), QStringLiteral("de1-b"), &rec));
@@ -315,23 +363,56 @@ private slots:
         pump();
 
         QCOMPARE(rec.issued, QStringList{QStringLiteral("de1-a")});
+        QCOMPARE(log.count(), 0);
     }
 
-    // ONE deep is the routine overlap of two healthy periodic devices — the
-    // DE1's once-a-minute keepalive landing on the scale's 1 Hz heartbeat. It
-    // repeats forever, so logging it made this line the loudest source in the
-    // app at ~120/hour even after collapsing. Measured on a tablet; this is the
-    // assertion that keeps it silent.
-    void aSingleOperationQueuedBehindIsNotWorthALine() {
+    // ...but an operation that actually WAITED behind another device is logged,
+    // and carries the depth as payload. Depth is what a reader wants once they
+    // are already looking at a delay; it is not what tells them to look.
+    //
+    // Held below FOREIGN_WAIT_WARN_MS deliberately: the near-miss must reach
+    // the log as DEBUG context WITHOUT raising the WARN, so this also pins that
+    // the two thresholds are independent. init()'s failOnWarning is what makes
+    // that half able to fail.
+    void anOperationDelayedByAnotherDeviceIsLogged() {
         BleGattQueue q;
         Recorder rec;
+
+        q.submit(op(scale(), QStringLiteral("slow-scale"), &rec));
+        pump();
+
+        q.submit(op(de1(), QStringLiteral("de1 stop"), &rec));
+        advanceQueueClock(q, BleGatt::FOREIGN_WAIT_WARN_MS / 2 + 40);
+
+        DebugLineCounter log(QStringLiteral("dispatch "));
+        q.noteSucceeded(scale());
+        pump();
+
+        QCOMPARE(log.count(), 1);
+        QVERIFY(log.lastLine().contains(QStringLiteral("dispatch de1 stop")));
+        QVERIFY(log.lastLine().contains(QStringLiteral("queued)")));
+    }
+
+    // TWO devices overlapping briefly is silent too — the case above is one
+    // device's own backlog, this is the routine interleave of two healthy
+    // periodic ones: the DE1's once-a-minute keepalive landing on the scale's
+    // 1 Hz heartbeat, clearing ~54 ms apart. It repeats forever, so logging it
+    // made this line the loudest source in the app at ~120/hour even after
+    // collapsing. Nothing here waits long enough to be worth a reader's time.
+    void aBriefOverlapOfTwoDevicesIsNotWorthALine() {
+        BleGattQueue q;
+        Recorder rec;
+        DebugLineCounter log(QStringLiteral("dispatch "));
 
         q.submit(op(de1(), QStringLiteral("de1-keepalive"), &rec));
         q.submit(op(scale(), QStringLiteral("scale write"), &rec));
         pump();
+        q.noteSucceeded(de1());
+        pump();
 
-        QCOMPARE(rec.issued, QStringList{QStringLiteral("de1-keepalive")});
-        QCOMPARE(q.m_dispatchLog.suppressedFor(QStringLiteral("de1-keepalive")), 0);
+        QCOMPARE(rec.issued, (QStringList{QStringLiteral("de1-keepalive"),
+                                          QStringLiteral("scale write")}));
+        QCOMPARE(log.count(), 0);
     }
 
     // --- foreign wait reporting -------------------------------------------

--- a/tests/tst_blegattqueue.cpp
+++ b/tests/tst_blegattqueue.cpp
@@ -3,7 +3,7 @@
 
 #include "ble/blegattqueue.h"
 #include "ble/protocol/de1characteristics.h"
-#include "mocks/messagecapture.h"
+#include "messagecapture.h"
 
 // The shared cross-device GATT queue (#1819).
 //
@@ -67,11 +67,12 @@ private:
     // simulated.
     static void advanceQueueClock(BleGattQueue& q, qint64 ms) { q.m_testClockSkewMs += ms; }
 
-    // The needle every log-volume slot below counts. One constant, so a slot
-    // cannot silently stop matching because someone retyped the string.
-    static const QString& dispatchNeedle() {
-        static const QString s = QStringLiteral("dispatch ");
-        return s;
+    // The needle every log-volume slot below counts, DERIVED from the production
+    // formatter rather than retyped. A hardcoded copy would keep passing the
+    // three zero-assertions after someone reworded the line, matching nothing.
+    static QString dispatchNeedle() {
+        return BleGatt::dispatchCollapseKey(QStringLiteral("x"), 0)
+            .left(QStringLiteral("dispatch ").size());
     }
 
 private slots:
@@ -291,10 +292,10 @@ private slots:
     // become vacuous. MessageCapture::count() spans every tier for the same
     // reason — a line promoted to qInfo must turn these red, not satisfy them.
 
-    // At idle the Decent Scale's 1 Hz heartbeat made this line periodic
-    // forever: 25,992 of 26,565 lines in a measured 7-hour tablet session,
-    // which evicted every other subsystem from the ring buffer. With the gate
-    // in place an idle beat never reaches the collapser at all.
+    // At idle the Decent Scale's 1 Hz heartbeat made this line periodic forever
+    // and it dominated the log; the measurement is on m_dispatchLog in
+    // blegattqueue.h, which holds custody of that figure. With the gate in place
+    // an idle beat never reaches the collapser at all.
     void anIdleDispatchIsNotLoggedAtAll() {
         BleGattQueue q;
         Recorder rec;
@@ -308,11 +309,10 @@ private slots:
         }
 
         QCOMPARE(rec.issued.size(), 5);   // all five ran...
-        // ...and none reached the log. Counted, not inferred from
-        // LogCollapse::suppressedFor(), which counts COLLAPSED repeats: a line
-        // that prints for the first time leaves it at zero, so zero there is
-        // equally consistent with silence and with one printed line.
-        QCOMPARE(log.count(dispatchNeedle()), 0);
+        // ...and none reached the log. Counted rather than inferred from the
+        // collapser — see MessageCapture's header for why anything derived from
+        // it is blind here.
+        QCOMPARE(log.count(dispatchNeedle()), qsizetype(0));
     }
 
     // Queue DEPTH alone must not produce a line, at the depth the old gate
@@ -322,7 +322,8 @@ private slots:
     // depth >= 2 was silent at idle and therefore looked correct, but the app's
     // own connect sequence is the deepest thing that ever happens on this queue
     // (see the QUEUE_DEPTH_WARN comment in blegattqueue.h for the measured
-    // peak), so a healthy launch wrote 43 lines every single time.
+    // peak), so a healthy launch wrote a line per operation every single time —
+    // the count and its evidence are on the gate in blegattqueue.cpp.
     //
     // All three operations belong to the SAME requester, so chargeForeignWait()
     // skips every one of them and foreignWaitMs is identically zero. This slot
@@ -338,7 +339,7 @@ private slots:
         q.submit(op(de1(), QStringLiteral("de1-c"), &rec));
         pump();
         QCOMPARE(rec.issued, QStringList{QStringLiteral("de1-a")});
-        QCOMPARE(log.count(dispatchNeedle()), 0);
+        QCOMPARE(log.count(dispatchNeedle()), qsizetype(0));
 
         // Drain, so the assertion covers depths 1 and 0 as well as 2 rather
         // than only the one the old threshold happened to sit on.
@@ -347,18 +348,34 @@ private slots:
         q.noteSucceeded(de1());
         pump();
         QCOMPARE(rec.issued.size(), 3);
-        QCOMPARE(log.count(dispatchNeedle()), 0);
+        QCOMPARE(log.count(dispatchNeedle()), qsizetype(0));
     }
 
-    // ...but an operation that actually WAITED behind another device is logged.
+    // ...but an operation that actually WAITED behind another device is logged,
+    // and the depth behind it rides along as PAYLOAD.
     //
-    // Held below FOREIGN_WAIT_WARN_MS deliberately: the near-miss must reach
-    // the log as DEBUG context WITHOUT raising the WARN, so this also pins that
-    // the two thresholds are independent. init()'s failOnWarning is what makes
-    // that half able to fail. Written as a proportion of the constant so it
-    // tracks BOTH bounds — it has to stay above FOREIGN_WAIT_WARN_MS / 2 to
-    // reach the gate and below FOREIGN_WAIT_WARN_MS to stay under the warning.
+    // The two rows are the pair that makes the distinction assertable: depth 2
+    // with a wait logs and reports "2 queued", while depth 2 WITHOUT a wait
+    // (aDeepQueueOfOneDevicesOwnWorkIsNotLogged) logs nothing at all. Same
+    // depth, opposite outcome, so the trigger is demonstrably the wait.
+    //
+    // Held below FOREIGN_WAIT_WARN_MS deliberately: the near-miss must reach the
+    // log as DEBUG context WITHOUT raising the WARN, so this also pins that the
+    // two thresholds are independent. init()'s failOnWarning is what makes that
+    // half able to fail. Written as a proportion of the constant so it tracks
+    // BOTH bounds — above FOREIGN_WAIT_DETAIL_MS to reach the gate, below
+    // FOREIGN_WAIT_WARN_MS to stay under the warning.
+    void anOperationDelayedByAnotherDeviceIsLogged_data() {
+        QTest::addColumn<int>("queuedBehind");
+        QTest::addColumn<QString>("expectedDepth");
+        QTest::newRow("nothing behind it") << 0 << "(0 queued)";
+        QTest::newRow("two behind it")     << 2 << "(2 queued)";
+    }
+
     void anOperationDelayedByAnotherDeviceIsLogged() {
+        QFETCH(int, queuedBehind);
+        QFETCH(QString, expectedDepth);
+
         BleGattQueue q;
         Recorder rec;
 
@@ -366,6 +383,8 @@ private slots:
         pump();
 
         q.submit(op(de1(), QStringLiteral("de1 stop"), &rec));
+        for (int i = 0; i < queuedBehind; ++i)
+            q.submit(op(de1(), QStringLiteral("de1-filler-%1").arg(i), &rec));
         advanceQueueClock(q, BleGatt::FOREIGN_WAIT_WARN_MS * 3 / 4);
 
         // Installed AFTER the setup submits, so it counts only the dispatch
@@ -374,38 +393,13 @@ private slots:
         q.noteSucceeded(scale());
         pump();
 
-        QCOMPARE(log.count(dispatchNeedle()), 1);
-        const QString line = log.last(dispatchNeedle()).text;
-        QVERIFY(line.contains(QStringLiteral("dispatch de1 stop")));
-        // Depth is PAYLOAD, and this pins the value rather than the word:
-        // "de1 stop" is the only queued operation and is dequeued before the
-        // line is built, so the depth behind it is 0. Asserting merely that the
-        // text contains "queued)" would hold against a hardcoded number.
-        QVERIFY(line.contains(QStringLiteral("(0 queued)")));
-    }
-
-    // A nonzero depth DOES reach the text when the operation also waited. The
-    // pair of assertions is the point: aDeepQueueOfOneDevicesOwnWorkIsNotLogged
-    // shows depth alone does not trigger, this shows depth is still reported
-    // once something else did. Rides on an existing episode rather than adding
-    // a slot to arrange the same state again.
-    void aDelayedDispatchReportsTheDepthBehindIt() {
-        BleGattQueue q;
-        Recorder rec;
-
-        q.submit(op(scale(), QStringLiteral("slow-scale"), &rec));
-        pump();
-        q.submit(op(de1(), QStringLiteral("de1-a"), &rec));
-        q.submit(op(de1(), QStringLiteral("de1-b"), &rec));
-        q.submit(op(de1(), QStringLiteral("de1-c"), &rec));
-        advanceQueueClock(q, BleGatt::FOREIGN_WAIT_WARN_MS * 3 / 4);
-
-        MessageCapture log;
-        q.noteSucceeded(scale());
-        pump();
-
-        QCOMPARE(log.count(dispatchNeedle()), 1);
-        QVERIFY(log.last(dispatchNeedle()).text.contains(QStringLiteral("(2 queued)")));
+        MessageCapture::Entry line;
+        QVERIFY(log.single(dispatchNeedle(), &line));
+        QVERIFY(line.text.contains(QStringLiteral("dispatch de1 stop")));
+        QVERIFY(line.text.contains(expectedDepth));
+        // The value the gate fired on has to be IN the line it fired: without it
+        // a reader cannot tell a 260 ms wait from a 480 ms one.
+        QVERIFY(line.text.contains(QStringLiteral("waited")));
     }
 
     // TWO devices overlapping briefly is silent too — the slot above covers one
@@ -436,7 +430,7 @@ private slots:
 
         QCOMPARE(rec.issued, (QStringList{QStringLiteral("de1-keepalive"),
                                           QStringLiteral("scale write")}));
-        QCOMPARE(log.count(dispatchNeedle()), 0);
+        QCOMPARE(log.count(dispatchNeedle()), qsizetype(0));
     }
 
     // --- foreign wait reporting -------------------------------------------

--- a/tests/tst_blegattqueue.cpp
+++ b/tests/tst_blegattqueue.cpp
@@ -3,6 +3,7 @@
 
 #include "ble/blegattqueue.h"
 #include "ble/protocol/de1characteristics.h"
+#include "mocks/messagecapture.h"
 
 // The shared cross-device GATT queue (#1819).
 //
@@ -66,46 +67,12 @@ private:
     // simulated.
     static void advanceQueueClock(BleGattQueue& q, qint64 ms) { q.m_testClockSkewMs += ms; }
 
-    // Counts DEBUG lines containing a needle, so "this was NOT logged" is an
-    // assertion that can fail.
-    //
-    // suppressedFor() cannot do that job, and the slots below used to lean on
-    // it: it counts COLLAPSED repeats, so a line that passes the gate and
-    // prints for the first time leaves it at zero. Zero there is equally
-    // consistent with silence and with one printed line, which makes it blind
-    // to exactly the regression these slots exist to catch. Chains to the
-    // previous handler so QTest::ignoreMessage and failOnWarning still work.
-    class DebugLineCounter {
-    public:
-        explicit DebugLineCounter(QString needle) {
-            s_needle = std::move(needle);
-            s_count = 0;
-            s_last.clear();
-            s_prev = qInstallMessageHandler(&DebugLineCounter::handle);
-        }
-        ~DebugLineCounter() { qInstallMessageHandler(s_prev); }
-        DebugLineCounter(const DebugLineCounter&) = delete;
-        DebugLineCounter& operator=(const DebugLineCounter&) = delete;
-
-        int count() const { return s_count; }
-        QString lastLine() const { return s_last; }
-
-    private:
-        static void handle(QtMsgType type, const QMessageLogContext& ctx,
-                           const QString& msg) {
-            if (type == QtDebugMsg && msg.contains(s_needle)) {
-                ++s_count;
-                s_last = msg;
-            }
-            if (s_prev)
-                s_prev(type, ctx, msg);
-        }
-
-        static inline QtMessageHandler s_prev = nullptr;
-        static inline QString s_needle;
-        static inline int s_count = 0;
-        static inline QString s_last;
-    };
+    // The needle every log-volume slot below counts. One constant, so a slot
+    // cannot silently stop matching because someone retyped the string.
+    static const QString& dispatchNeedle() {
+        static const QString s = QStringLiteral("dispatch ");
+        return s;
+    }
 
 private slots:
     void init() { QTest::failOnWarning(); }
@@ -311,18 +278,27 @@ private slots:
     }
 
     // --- dispatch log volume ----------------------------------------------
-
-    // The dispatch line is one per operation, and at idle the Decent Scale's
-    // 1 Hz heartbeat makes it periodic forever: 25,992 of 26,565 lines in a
-    // measured 7-hour tablet session, which evicted every other subsystem from
-    // the ring buffer. An unchanging repeat must collapse.
     //
-    // init()'s failOnWarning cannot catch this — these are DEBUG — so the
-    // assertion is the ignoreMessage pair: exactly one line for the run.
+    // These four slots assert VOLUME, not correctness — a regression here costs
+    // a ring buffer full of noise, not a missed stop-at-weight. They are cheap
+    // because they share a file, and they exist because this gate has been got
+    // wrong four times.
+    //
+    // Three of them assert ZERO lines, which is only an assertion at all
+    // because anOperationDelayedByAnotherDeviceIsLogged() proves the same
+    // needle CAN reach a non-zero count in this binary. That slot is
+    // load-bearing for the other three: delete or rename it and they quietly
+    // become vacuous. MessageCapture::count() spans every tier for the same
+    // reason — a line promoted to qInfo must turn these red, not satisfy them.
+
+    // At idle the Decent Scale's 1 Hz heartbeat made this line periodic
+    // forever: 25,992 of 26,565 lines in a measured 7-hour tablet session,
+    // which evicted every other subsystem from the ring buffer. With the gate
+    // in place an idle beat never reaches the collapser at all.
     void anIdleDispatchIsNotLoggedAtAll() {
         BleGattQueue q;
         Recorder rec;
-        DebugLineCounter log(QStringLiteral("dispatch "));
+        MessageCapture log;
 
         for (int i = 0; i < 5; ++i) {
             q.submit(op(scale(), QStringLiteral("scale write"), &rec));
@@ -333,47 +309,55 @@ private slots:
 
         QCOMPARE(rec.issued.size(), 5);   // all five ran...
         // ...and none reached the log. Counted, not inferred from
-        // suppressedFor(): collapsing alone was never enough — one line a
-        // minute still out-logs every other subsystem in the app combined — and
-        // a suppressed-repeat count of zero cannot tell silence apart from a
-        // first line that printed.
-        QCOMPARE(log.count(), 0);
+        // LogCollapse::suppressedFor(), which counts COLLAPSED repeats: a line
+        // that prints for the first time leaves it at zero, so zero there is
+        // equally consistent with silence and with one printed line.
+        QCOMPARE(log.count(dispatchNeedle()), 0);
     }
 
-    // Queue DEPTH alone must not produce a line, however deep.
+    // Queue DEPTH alone must not produce a line, at the depth the old gate
+    // tripped on.
     //
-    // This is the regression that shipped: gating on depth >= 2 was silent at
-    // idle and therefore looked correct, but the app's own connect sequence is
-    // the deepest thing that ever happens here — applyAllSettings enqueues the
-    // settings blast the instant the DE1 reports ready — so a healthy launch
-    // peaked at 35 and wrote 43 lines every single time. A measured 4h17m field
-    // session logged 50 of these, and not one said anything the single
-    // FOREIGN_WAIT_WARN episode line did not.
+    // This is the regression that shipped in the third attempt: gating on
+    // depth >= 2 was silent at idle and therefore looked correct, but the app's
+    // own connect sequence is the deepest thing that ever happens on this queue
+    // (see the QUEUE_DEPTH_WARN comment in blegattqueue.h for the measured
+    // peak), so a healthy launch wrote 43 lines every single time.
     //
-    // All three operations here belong to the SAME requester, so nothing waits
-    // on a foreign device and nothing is worth a line.
+    // All three operations belong to the SAME requester, so chargeForeignWait()
+    // skips every one of them and foreignWaitMs is identically zero. This slot
+    // can therefore only fail to a DEPTH trigger — which is exactly what it is
+    // guarding, and what makes it the negative control for the shipped defect.
     void aDeepQueueOfOneDevicesOwnWorkIsNotLogged() {
         BleGattQueue q;
         Recorder rec;
-        DebugLineCounter log(QStringLiteral("dispatch "));
+        MessageCapture log;
 
         q.submit(op(de1(), QStringLiteral("de1-a"), &rec));
         q.submit(op(de1(), QStringLiteral("de1-b"), &rec));
         q.submit(op(de1(), QStringLiteral("de1-c"), &rec));
         pump();
-
         QCOMPARE(rec.issued, QStringList{QStringLiteral("de1-a")});
-        QCOMPARE(log.count(), 0);
+        QCOMPARE(log.count(dispatchNeedle()), 0);
+
+        // Drain, so the assertion covers depths 1 and 0 as well as 2 rather
+        // than only the one the old threshold happened to sit on.
+        q.noteSucceeded(de1());
+        pump();
+        q.noteSucceeded(de1());
+        pump();
+        QCOMPARE(rec.issued.size(), 3);
+        QCOMPARE(log.count(dispatchNeedle()), 0);
     }
 
-    // ...but an operation that actually WAITED behind another device is logged,
-    // and carries the depth as payload. Depth is what a reader wants once they
-    // are already looking at a delay; it is not what tells them to look.
+    // ...but an operation that actually WAITED behind another device is logged.
     //
     // Held below FOREIGN_WAIT_WARN_MS deliberately: the near-miss must reach
     // the log as DEBUG context WITHOUT raising the WARN, so this also pins that
     // the two thresholds are independent. init()'s failOnWarning is what makes
-    // that half able to fail.
+    // that half able to fail. Written as a proportion of the constant so it
+    // tracks BOTH bounds — it has to stay above FOREIGN_WAIT_WARN_MS / 2 to
+    // reach the gate and below FOREIGN_WAIT_WARN_MS to stay under the warning.
     void anOperationDelayedByAnotherDeviceIsLogged() {
         BleGattQueue q;
         Recorder rec;
@@ -382,37 +366,77 @@ private slots:
         pump();
 
         q.submit(op(de1(), QStringLiteral("de1 stop"), &rec));
-        advanceQueueClock(q, BleGatt::FOREIGN_WAIT_WARN_MS / 2 + 40);
+        advanceQueueClock(q, BleGatt::FOREIGN_WAIT_WARN_MS * 3 / 4);
 
-        DebugLineCounter log(QStringLiteral("dispatch "));
+        // Installed AFTER the setup submits, so it counts only the dispatch
+        // under test.
+        MessageCapture log;
         q.noteSucceeded(scale());
         pump();
 
-        QCOMPARE(log.count(), 1);
-        QVERIFY(log.lastLine().contains(QStringLiteral("dispatch de1 stop")));
-        QVERIFY(log.lastLine().contains(QStringLiteral("queued)")));
+        QCOMPARE(log.count(dispatchNeedle()), 1);
+        const QString line = log.last(dispatchNeedle()).text;
+        QVERIFY(line.contains(QStringLiteral("dispatch de1 stop")));
+        // Depth is PAYLOAD, and this pins the value rather than the word:
+        // "de1 stop" is the only queued operation and is dequeued before the
+        // line is built, so the depth behind it is 0. Asserting merely that the
+        // text contains "queued)" would hold against a hardcoded number.
+        QVERIFY(line.contains(QStringLiteral("(0 queued)")));
     }
 
-    // TWO devices overlapping briefly is silent too — the case above is one
+    // A nonzero depth DOES reach the text when the operation also waited. The
+    // pair of assertions is the point: aDeepQueueOfOneDevicesOwnWorkIsNotLogged
+    // shows depth alone does not trigger, this shows depth is still reported
+    // once something else did. Rides on an existing episode rather than adding
+    // a slot to arrange the same state again.
+    void aDelayedDispatchReportsTheDepthBehindIt() {
+        BleGattQueue q;
+        Recorder rec;
+
+        q.submit(op(scale(), QStringLiteral("slow-scale"), &rec));
+        pump();
+        q.submit(op(de1(), QStringLiteral("de1-a"), &rec));
+        q.submit(op(de1(), QStringLiteral("de1-b"), &rec));
+        q.submit(op(de1(), QStringLiteral("de1-c"), &rec));
+        advanceQueueClock(q, BleGatt::FOREIGN_WAIT_WARN_MS * 3 / 4);
+
+        MessageCapture log;
+        q.noteSucceeded(scale());
+        pump();
+
+        QCOMPARE(log.count(dispatchNeedle()), 1);
+        QVERIFY(log.last(dispatchNeedle()).text.contains(QStringLiteral("(2 queued)")));
+    }
+
+    // TWO devices overlapping briefly is silent too — the slot above covers one
     // device's own backlog, this is the routine interleave of two healthy
     // periodic ones: the DE1's once-a-minute keepalive landing on the scale's
     // 1 Hz heartbeat, clearing ~54 ms apart. It repeats forever, so logging it
     // made this line the loudest source in the app at ~120/hour even after
-    // collapsing. Nothing here waits long enough to be worth a reader's time.
+    // collapsing.
+    //
+    // NOT redundant with aDeepQueueOfOneDevicesOwnWorkIsNotLogged: two
+    // requesters means chargeForeignWait() DOES charge the second operation, so
+    // this is the only slot that would catch a gate loosened towards
+    // foreignWaitMs > 0. The 54 ms is simulated rather than left to whatever
+    // pump() really takes, so the number in this comment is the number the test
+    // encodes, and lowering the gate towards the routine interleave turns it
+    // red.
     void aBriefOverlapOfTwoDevicesIsNotWorthALine() {
         BleGattQueue q;
         Recorder rec;
-        DebugLineCounter log(QStringLiteral("dispatch "));
+        MessageCapture log;
 
         q.submit(op(de1(), QStringLiteral("de1-keepalive"), &rec));
         q.submit(op(scale(), QStringLiteral("scale write"), &rec));
         pump();
+        advanceQueueClock(q, 54);
         q.noteSucceeded(de1());
         pump();
 
         QCOMPARE(rec.issued, (QStringList{QStringLiteral("de1-keepalive"),
                                           QStringLiteral("scale write")}));
-        QCOMPARE(log.count(), 0);
+        QCOMPARE(log.count(dispatchNeedle()), 0);
     }
 
     // --- foreign wait reporting -------------------------------------------

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -11,7 +11,7 @@
 #include <optional>
 
 #include "ble/scales/decentscalewifi.h"
-#include "mocks/messagecapture.h"
+#include "messagecapture.h"
 
 // Fake WebSocket server used to drive the DecentScaleWifi driver under test.
 // Spins up on a random local port; the test connects the driver to

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 
 #include "ble/scales/decentscalewifi.h"
+#include "mocks/messagecapture.h"
 
 // Fake WebSocket server used to drive the DecentScaleWifi driver under test.
 // Spins up on a random local port; the test connects the driver to
@@ -110,51 +111,6 @@ signals:
     void clientConnected();
 private:
     QWebSocketServer* m_server = nullptr;
-};
-
-// RAII warning filter — same shape as ScopedWarningFilter in
-// tests/mocks/McpTestFixture.h, inlined here rather than including that header
-// (which drags in Settings/MockTransport this target doesn't link). Suppresses
-// warnings matching a pattern; everything else forwards to Qt Test's handler so
-// QTest::ignoreMessage still works alongside it.
-//
-// The distinction that matters: ignoreMessage REQUIRES its message to fire,
-// this only ALLOWS it. See the note on m_disconnectNoise below.
-struct ScopedWarningFilter {
-    static inline QVector<QRegularExpression*> s_filters;
-    static inline QtMessageHandler s_originalHandler = nullptr;
-    static inline int s_depth = 0;
-
-    static void handler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
-        if (type == QtWarningMsg) {
-            for (auto* f : s_filters) {
-                if (f && f->match(msg).hasMatch())
-                    return;  // Suppress
-            }
-        }
-        if (s_originalHandler)
-            s_originalHandler(type, ctx, msg);
-    }
-
-    QRegularExpression m_pattern;
-
-    // A copy would register nothing but still decrement s_depth on destruction,
-    // uninstalling the handler early and leaving a dangling &m_pattern in
-    // s_filters. Nothing copies one today; this makes sure nothing starts.
-    Q_DISABLE_COPY_MOVE(ScopedWarningFilter)
-
-    explicit ScopedWarningFilter(const QString& pattern) : m_pattern(pattern) {
-        s_filters.append(&m_pattern);
-        if (s_depth++ == 0)
-            s_originalHandler = qInstallMessageHandler(handler);
-    }
-    ~ScopedWarningFilter() {
-        s_filters.removeOne(&m_pattern);
-        if (--s_depth == 0) {
-            qInstallMessageHandler(s_originalHandler);
-            s_originalHandler = nullptr;
-        }
-    }
 };
 
 class tst_DecentScaleWifi : public QObject {

--- a/tests/tst_logcollapse.cpp
+++ b/tests/tst_logcollapse.cpp
@@ -1,5 +1,7 @@
 #include <QtTest>
 
+#include <algorithm>
+
 #include "core/logcollapse.h"
 
 // LogCollapse decides whether a repeating log line is worth printing. Three periodic sources share
@@ -123,6 +125,50 @@ private slots:
         QVERIFY(c.shouldLog("k", "text", 500'000, &c2));
         QCOMPARE(c2.suppressed, 0);
         QCOMPARE(c2.spanMs, 0);
+    }
+
+    // flush() and flushAll() had no coverage at all until an episodic caller
+    // needed them. Both are the mechanism that keeps one run's tally off the
+    // next run's first line, so "it compiles" was the only thing asserting them.
+
+    void flushAllReturnsEveryPendingTallyAndForgetsTheKeys()
+    {
+        LogCollapse c(60'000);
+        LogCollapse::Collapsed ignored;
+
+        // Two keys, each emitted once then repeated inside the window.
+        QVERIFY(c.shouldLog("a", "same", 0, &ignored));
+        QVERIFY(!c.shouldLog("a", "same", 1'000, &ignored));
+        QVERIFY(!c.shouldLog("a", "same", 2'000, &ignored));
+        QVERIFY(c.shouldLog("b", "other", 0, &ignored));
+        QVERIFY(!c.shouldLog("b", "other", 1'000, &ignored));
+
+        auto pending = c.flushAll(3'000);
+        std::sort(pending.begin(), pending.end(),
+                  [](const auto& l, const auto& r) { return l.first < r.first; });
+        QCOMPARE(pending.size(), 2);
+        QCOMPARE(pending[0].first, QStringLiteral("a"));
+        QCOMPARE(pending[0].second.suppressed, 2);
+        QCOMPARE(pending[0].second.spanMs, 3'000);
+        QCOMPARE(pending[1].second.suppressed, 1);
+
+        // Forgotten, so the next run starts as a first sighting rather than
+        // carrying this one's count -- the whole point of flushing.
+        QVERIFY(c.flushAll(4'000).isEmpty());
+        LogCollapse::Collapsed after;
+        QVERIFY(c.shouldLog("a", "same", 5'000, &after));
+        QCOMPARE(after.suppressed, 0);
+        QCOMPARE(after.spanMs, 0);
+    }
+
+    // A key that was emitted and never repeated has nothing to say, and saying
+    // it would put "(+0 identical)" noise on every run end.
+    void flushAllSkipsKeysWithNothingSuppressed()
+    {
+        LogCollapse c(60'000);
+        LogCollapse::Collapsed ignored;
+        QVERIFY(c.shouldLog("a", "once", 0, &ignored));
+        QVERIFY(c.flushAll(1'000).isEmpty());
     }
 };
 

--- a/tests/tst_simulatedscale.cpp
+++ b/tests/tst_simulatedscale.cpp
@@ -11,6 +11,7 @@
 #include "profile/profile.h"
 #include "simulator/de1simulator.h"
 #include "simulator/simulatedscale.h"
+#include "mocks/messagecapture.h"
 
 // End-to-end cover for the simulator's scale channel: DE1Simulator emits a
 // weight, SimulatedScale publishes it like any ScaleDevice, and MachineState
@@ -27,61 +28,6 @@ class DisconnectTierProbe : public SimulatedScale {
 public:
     using SimulatedScale::setConnected;
     void markExpected() { markExpectedDisconnect(); }
-};
-
-// Captures messages so a test can ASSERT on their tier.
-//
-// QTest::ignoreMessage is a PERMISSION, not an assertion. An unmatched pattern is
-// reported by printUnhandledIgnoreMessages() by calling addMessage() with
-// QAbstractTestLogger::Info (qtbase/src/testlib/qtestlog.cpp:397-419) — a printed
-// line, never a failure. So disconnect tests built on ignoreMessage alone still
-// pass if the line under test is demoted a tier or deleted outright, which is
-// exactly the regression they exist to catch: this whole change is about WHICH
-// TIER a disconnect is reported at, and the one thing ignoreMessage cannot check
-// is that.
-//
-// Deliberately does NOT chain to the previous handler. init() calls
-// QTest::failOnWarning(), and here the WARN branch is a thing being asserted
-// rather than a thing that went wrong.
-class CapturedMessages {
-public:
-    struct Entry { QtMsgType type = QtDebugMsg; QString text; };
-
-    CapturedMessages() {
-        s_entries = &m_entries;
-        m_previous = qInstallMessageHandler(&CapturedMessages::handler);
-    }
-    ~CapturedMessages() {
-        qInstallMessageHandler(m_previous);
-        s_entries = nullptr;
-    }
-    Q_DISABLE_COPY_MOVE(CapturedMessages)
-
-    void clear() { m_entries.clear(); }
-
-    // The one message containing `needle`, or false. Insists on EXACTLY one:
-    // zero means the line vanished, more than one means the event was announced
-    // twice, and a test that accepted either would not notice.
-    bool single(const QString& needle, Entry* out) const {
-        Entry found;
-        int matches = 0;
-        for (const Entry& e : m_entries) {
-            if (e.text.contains(needle)) { found = e; ++matches; }
-        }
-        if (matches == 1 && out)
-            *out = found;
-        return matches == 1;
-    }
-
-private:
-    static void handler(QtMsgType type, const QMessageLogContext&, const QString& msg) {
-        if (s_entries)
-            s_entries->append({type, msg});
-    }
-
-    QList<Entry> m_entries;
-    QtMessageHandler m_previous = nullptr;
-    static inline QList<Entry>* s_entries = nullptr;
 };
 
 class tst_SimulatedScale : public QObject {
@@ -196,14 +142,17 @@ private slots:
     // deliberate DE1-sleep close reported as a fault. Neither a blanket WARN nor
     // a blanket demotion is correct, which is why the driver declares intent.
     void expectedDisconnectIsNarrativeNotAFault() {
-        CapturedMessages log;
+        // Deliberately does NOT chain: init() calls QTest::failOnWarning(), and
+        // here the WARN branch is a thing being asserted rather than a thing
+        // that went wrong.
+        MessageCapture log(MessageCapture::SwallowAll);
         DisconnectTierProbe probe;
         probe.setConnected(true);
 
         // Unmarked: the link went away by itself. WARN.
         log.clear();
         probe.setConnected(false);
-        CapturedMessages::Entry drop;
+        MessageCapture::Entry drop;
         QVERIFY2(log.single(QStringLiteral("DISCONNECTED"), &drop),
                  "expected exactly one DISCONNECTED line");
         QCOMPARE(drop.type, QtWarningMsg);
@@ -224,13 +173,16 @@ private slots:
     // The flag is ONE-SHOT. A stale flag would silently downgrade the next
     // genuine failure — turning the fix into a way to hide real faults.
     void expectedDisconnectDoesNotPersistToTheNextOne() {
-        CapturedMessages log;
+        // Deliberately does NOT chain: init() calls QTest::failOnWarning(), and
+        // here the WARN branch is a thing being asserted rather than a thing
+        // that went wrong.
+        MessageCapture log(MessageCapture::SwallowAll);
         DisconnectTierProbe probe;
         probe.setConnected(true);
         probe.markExpected();
         log.clear();
         probe.setConnected(false);
-        CapturedMessages::Entry drop;
+        MessageCapture::Entry drop;
         QVERIFY(log.single(QStringLiteral("DISCONNECTED"), &drop));
         QCOMPARE(drop.type, QtInfoMsg);
 
@@ -252,12 +204,15 @@ private slots:
     // local and hands it over immediately before the transition; this pins the
     // base class's half, that reconnecting discards a mark nothing used.
     void expectedDisconnectDoesNotSurviveAReconnect() {
-        CapturedMessages log;
+        // Deliberately does NOT chain: init() calls QTest::failOnWarning(), and
+        // here the WARN branch is a thing being asserted rather than a thing
+        // that went wrong.
+        MessageCapture log(MessageCapture::SwallowAll);
         DisconnectTierProbe probe;
         probe.setConnected(true);
         log.clear();
         probe.setConnected(false);
-        CapturedMessages::Entry drop;
+        MessageCapture::Entry drop;
         QVERIFY(log.single(QStringLiteral("DISCONNECTED"), &drop));
         QCOMPARE(drop.type, QtWarningMsg);
 

--- a/tests/tst_simulatedscale.cpp
+++ b/tests/tst_simulatedscale.cpp
@@ -11,7 +11,7 @@
 #include "profile/profile.h"
 #include "simulator/de1simulator.h"
 #include "simulator/simulatedscale.h"
-#include "mocks/messagecapture.h"
+#include "messagecapture.h"
 
 // End-to-end cover for the simulator's scale channel: DE1Simulator emits a
 // weight, SimulatedScale publishes it like any ScaleDevice, and MachineState
@@ -142,9 +142,8 @@ private slots:
     // deliberate DE1-sleep close reported as a fault. Neither a blanket WARN nor
     // a blanket demotion is correct, which is why the driver declares intent.
     void expectedDisconnectIsNarrativeNotAFault() {
-        // Deliberately does NOT chain: init() calls QTest::failOnWarning(), and
-        // here the WARN branch is a thing being asserted rather than a thing
-        // that went wrong.
+        // SwallowAll, not chaining: init() calls QTest::failOnWarning(), and
+        // here the WARN branch is a thing being ASSERTED rather than a fault.
         MessageCapture log(MessageCapture::SwallowAll);
         DisconnectTierProbe probe;
         probe.setConnected(true);
@@ -173,9 +172,6 @@ private slots:
     // The flag is ONE-SHOT. A stale flag would silently downgrade the next
     // genuine failure — turning the fix into a way to hide real faults.
     void expectedDisconnectDoesNotPersistToTheNextOne() {
-        // Deliberately does NOT chain: init() calls QTest::failOnWarning(), and
-        // here the WARN branch is a thing being asserted rather than a thing
-        // that went wrong.
         MessageCapture log(MessageCapture::SwallowAll);
         DisconnectTierProbe probe;
         probe.setConnected(true);
@@ -204,9 +200,6 @@ private slots:
     // local and hands it over immediately before the transition; this pins the
     // base class's half, that reconnecting discards a mark nothing used.
     void expectedDisconnectDoesNotSurviveAReconnect() {
-        // Deliberately does NOT chain: init() calls QTest::failOnWarning(), and
-        // here the WARN branch is a thing being asserted rather than a thing
-        // that went wrong.
         MessageCapture log(MessageCapture::SwallowAll);
         DisconnectTierProbe probe;
         probe.setConnected(true);


### PR DESCRIPTION
## What

Started as one line — the GATT queue's per-dispatch DEBUG line gated on queue depth, and now gates on **foreign wait**, the time an operation spent behind a *different* device. Review found a bug in that fix, and fixing it properly turned up the same bug in two unrelated subsystems. Scope grew accordingly; the title now says so.

Three commits, each reviewable on its own: the gate change, the `/review` fixes, the `/simplify` pass.

## 1. The gate

Depth `>= 2` was silent at idle, which is what made it look correct when it shipped in #1820. But the app's own connect sequence is the deepest thing that ever happens on this queue — `DE1Device::sendInitialSettings()` enqueues five subscribes, the ready marker, four reads and its initial MMR writes, then `MainController::applyAllSettings()` piles the profile upload on top. A healthy connect peaks at depth 35 (measured; provenance lives on `QUEUE_DEPTH_WARN`), so **43 lines every launch**.

A 4h17m field session logged 50 of these, and none said anything the single `FOREIGN_WAIT_WARN` episode line did not. Depth 35 was information exactly once — when it set `QUEUE_DEPTH_WARN = 40`.

Depth can't be tuned out of it: any trigger below the healthy peak fires on every launch. Depth is a *proxy* for delay; foreign wait is the delay itself, and is already what the WARN is computed from. Depth stays in the line as payload.

**What this does not claim.** `chargeForeignWait()` accumulates onto every queued foreign operation, so on a *simultaneous* two-device connect a slow scale discovery — 6.0 s in the #1819 capture — charges seconds to the whole DE1 backlog, and all of it clears this gate. **There, the new gate logs more than the old one.** That's the intent: it's contention, it's what #1819 was, and the trail is what a reader needs then. The change is that the loud case is now the *contended* one rather than every launch. "50 → 1–3" describes the measured session, not a general bound.

The field session is maintainer testimony about a log nobody else holds, and is labelled as such in the code.

## 2. Flushing collapsed tallies at the right run end

`LogCollapse` holds back repeated lines and reports the count on the next one. If a source goes quiet without flushing, that count lands on the *next* run's first line, annotated with a span measured to the moment a reader is looking at it.

**The bug I introduced:** gating on foreign wait turned the dispatch line from periodic into episodic, so I added a flush — and attached it to the wrong event. `reportForeignWaitEpisode()` returns early unless something crossed `FOREIGN_WAIT_WARN_MS`, but the dispatch line logs at **half** that. Every run of near-misses leaked exactly the tally the flush existed to prevent. It now flushes in `emitDrainedIfIdle()`, which is where the collapser's run actually ends.

**Two pre-existing callers had the same bug**, found by walking every `LogCollapse` instance and answering the question for each:

- **`DE1Device::m_keepaliveLog`** — the MMR keepalive run ends at disconnect and never flushed, so the first keepalive after a reconnect (possibly hours later) carried the *previous session's* count. Now flushes in `onTransportDisconnected()`.
- **`ShotServer::m_requestLog`** — same across a server stop. Now flushes in `stop()`.

`MqttClient` was the only caller already doing it right.

**Built and reverted:** a `Lifecycle{Periodic,Episodic}` constructor mode with a destructor assert. It aborted `tst_mqttclient` — on a *correct* caller, because process exit is not a run end anyone can observe, so an episodic source legitimately holds a tally when destroyed. With the assert gone the mode had no reader and `-Wunused-private-field` said so. The lifecycle is now stated at each of the six declaration sites, naming where each flushes. Worth building only as a forcing function: it is how the two bugs above were found.

## 3. Centralization

- `"dispatch "` was composed at three sites. One `BleGatt::dispatchLine()` / `dispatchCollapseKey()`, and the test needle now *derives* from the production formatter — a rewording would otherwise have left three zero-assertions passing while matching nothing.
- **The wait that fired the gate is now in the line it fired.** Without it a reader can't tell 260 ms from 480 ms. It's deliberately excluded from the *collapse key*: a millisecond figure in the compared text makes every line unique, so nothing would ever collapse.
- `FOREIGN_WAIT_WARN_MS / 2` → named `FOREIGN_WAIT_DETAIL_MS`. Burying it as arithmetic in one `if` is what hid its difference from the warning threshold — which is what let the flush bug look correct.
- The pending-tally expression had reached three copies in `logcollapse.h`; now one `pending()`.

## 4. Tests

`tests/messagecapture.h` replaces **four** hand-rolled `qInstallMessageHandler` helpers, two of which were verbatim duplicates. The newest was mine and the weakest: it filtered on `QtDebugMsg` alone, so promoting a watched line to `qInfo` would have satisfied every "was not logged" assertion *while the log got louder*; and its static `s_prev` meant two live instances self-chained into infinite recursion and then destroyed QTest's handler for the rest of the process.

- `count()` spans every tier, so a tier promotion turns the negative assertions red instead of green.
- `ScopedWarningFilter` moved onto the same nesting idiom, deleting its pointer vector, its depth counter, a null check, and a dangling-pointer hazard that existed only because the pattern was parked in a container.
- Header left `tests/mocks/` — it mocks nothing, and that directory's `McpTestFixture.h` is precisely why `tst_decentscalewifi.cpp` had copied rather than included.
- Two slots that were the same nine-line arrangement merged into one `_data()` pair — which also makes the point explicit: same depth, opposite outcome, so the trigger is demonstrably the wait.
- `flushAll()` had no coverage at all; two slots now pin what it returns and that it forgets its keys.
- A vacuous assertion is gone: `contains("queued)")` matched a literal that is always present, in a slot whose depth was 0.

## Verification

Full suite via Qt Creator: **113 passed, 0 failed, 0 warnings.**

Negative controls, each reverted after:

- restoring `m_queue.size() >= 2` turns `tst_blegattqueue` red;
- forcing the gate open while logging at **INFO** turns it red — which the old `QtDebugMsg`-only counter would have passed;
- hardcoding the depth in the format string turns it red.

On the first: it flips **one of four** slots (`aDeepQueueOfOneDevicesOwnWorkIsNotLogged`, the only one dispatching at depth ≥ 2). The others guard different prior attempts — unconditional logging, depth ≥ 1, the foreign-wait arm being removed — so the binary going red is not evidence that all four control the same defect.

No user-visible change, so no wiki update — same as #1820.

Refs #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
