### PR TITLE
sync(profiles): add Adaptive v3 from de1app

### DIFF
--- a/resources/ai/profile_knowledge.json
+++ b/resources/ai/profile_knowledge.json
@@ -552,6 +552,19 @@
       "prose": "By John Buckman (Decent founder), synthesized from Brakel's preinfusion technique, Scott Rao's Blooming, and Jonathan Gagné's Adaptive flow-locking — the distillation of what the Decent community learned was optimal for light roasts; it subsequently evolved into the \"Adaptive\" profile. Preinfusion at low pressure (3 bar) until dripping, then a 1.5 bar gentle soak to fully saturate the puck, then pressure ramps to ~9–10.5 bar, then flow-controlled extraction at ~2.5 ml/s with a 10.5 bar limiter. Canonical recipe: 18g in, 50g out, ~60s. Expected curves: very low pressure during fill/soak (~1.5–3 bar), then a rise to ~9–10 bar, then pressure-limited flow extraction; pressure may not reach the limiter if the grind is coarse; variable curves expected (adapts to grind). Temperature 92°C preinfusion, 90°C extraction. ~50–70s total. Grind coarse for light roasts (target ~2.5 ml/s extraction flow); grind fine enough to maintain dripping during preinfusion — if dripping stops, too coarse. Roast light primarily; can adapt to medium with temperature adjustment. DO NOT flag the long low-pressure soak. DO NOT flag channeling in dC/dt — the extended low-flow soak followed by the pressure ramp produces large conductance-derivative spikes regardless of puck quality."
     },
     {
+      "id": "adaptive-v3",
+      "roastAffinity": [
+        "medium"
+      ],
+      "displayName": "Adaptive v3",
+      "analysisFlags": [
+        "flow_trend_ok",
+        "channeling_expected"
+      ],
+      "family": "flow-adaptive",
+      "prose": "By Decent (author: Decent), the sibling of \"Best Practice (light roast)\" this KB's `best-practice-light-roast` entry says it evolved into — same lineage (Brakel preinfusion + Rao Blooming + Gagné Adaptive flow-locking) in a 7-frame shot: Prefill/Fill push flow to the puck under a 3 bar cap, Compressing switches to pressure control until flow drops below 6.8 ml/s, Dripping holds a near-zero 0.1 bar so the puck drips freely, Pressurize ramps to 11 bar (capped at 7.7 bar exit), then Extraction start/Extraction run flow-controlled at the rate read off the Pressurize step and gently increased from there — the same auto flow-lock as Gagné's Adaptive. Canonical recipe (from the profile's own notes): 15g in, 33g out, ~32s, medium roast; target ~1.5 ml/s flow at the Pressurize step and ~4g (±1g) of dripping during Dripping. Temperature 93°C fill, 89°C hold/extraction. Expected curves: near-zero pressure during Dripping (by design), a sharp ramp to ~11 bar at Pressurize, then flow-controlled extraction with flow rising gradually. DO NOT flag the low-pressure Dripping step or the rising flow during Extraction — both are the adaptive mechanism working as intended."
+    },
+    {
       "id": "easy-blooming-active-pressure-decline",
       "roastAffinity": [
         "light"

--- a/resources/profiles.qrc
+++ b/resources/profiles.qrc
@@ -8,6 +8,7 @@
         <file>profiles/a_flow_default_medium.json</file>
         <file>profiles/a_flow_default_very_dark.json</file>
         <file>profiles/adaptive_v2.json</file>
+        <file>profiles/adaptive_v3.json</file>
         <file>profiles/advanced_spring_lever.json</file>
         <file>profiles/baseline_high_contact_8_bar.json</file>
         <file>profiles/baseline_low_contact_4_bar.json</file>

--- a/resources/profiles/adaptive_v3.json
+++ b/resources/profiles/adaptive_v3.json
@@ -1,0 +1,180 @@
+{
+    "author": "Decent",
+    "beverage_type": "espresso",
+    "changes_since_last_espresso": "",
+    "espresso_decline_time": "30.00",
+    "espresso_hold_time": "15.00",
+    "espresso_pressure": "6.00",
+    "espresso_temperature": "93.00",
+    "flow_profile_decline": "1.20",
+    "flow_profile_decline_time": "17.00",
+    "flow_profile_hold": "2.00",
+    "flow_profile_hold_time": "8.00",
+    "flow_profile_minimum_pressure": "4",
+    "flow_profile_preinfusion": "4",
+    "flow_profile_preinfusion_time": "5",
+    "has_recommended_dose": false,
+    "hidden": "0",
+    "lang": "en",
+    "legacy_profile_type": "settings_2c",
+    "maximum_flow": "0.00",
+    "maximum_flow_range_advanced": "0.60",
+    "maximum_flow_range_default": "1.00",
+    "maximum_pressure": "0.00",
+    "maximum_pressure_range_advanced": "0.60",
+    "maximum_pressure_range_default": "0.90",
+    "minimum_pressure": "4.00",
+    "mode": "frame_based",
+    "notes": "This profile aims to unite the best practices in espresso extraction that we have learned so far with the Decent. It unites Brakel's Londonium, Rao's Blooming and Gagné's Adaptive profiles. The flow rate during extraction will automatically adjust itself from the flow rate actually happening during the Pressurize step and then gently increase it from there.  A 15g dose is typical.  Aim for a flow rate around 1.5 ml/s at the Pressurize step. 15g in, 33g out, in 32 seconds is a typical recipe for a medium roast.  Grind fine enough to keep dripping during preinfusion to around 4g. If you have a bluetooth scale, you can keep track of how much dripping into the cup there is before the ramp stage.  4 grams of total dripping, within 1 gram, seems to give the best tasting results. Try adusting your grind and dose to get that amount of dripping, and see if you like how it tastes.",
+    "number_of_preinfuse_frames": "3",
+    "preinfusion_flow_rate": "4.00",
+    "preinfusion_stop_pressure": "4.00",
+    "preinfusion_time": "20.00",
+    "pressure_end": "4.00",
+    "read_only": 1,
+    "recommended_dose": "18.0",
+    "reference_file": "Adaptive v3",
+    "steps": [
+        {
+            "flow": "8.00",
+            "limiter": {
+                "range": "0.60",
+                "value": "0.00"
+            },
+            "name": "Prefill",
+            "pressure": "3.00",
+            "pump": "flow",
+            "seconds": "5.00",
+            "sensor": "coffee",
+            "temperature": "93.00",
+            "transition": "fast",
+            "volume": "100.0"
+        },
+        {
+            "exit": {
+                "condition": "over",
+                "type": "pressure",
+                "value": "3.00"
+            },
+            "flow": "8.00",
+            "limiter": {
+                "range": "0.60",
+                "value": "0.00"
+            },
+            "name": "Fill",
+            "pressure": "3.00",
+            "pump": "flow",
+            "seconds": "12.00",
+            "sensor": "coffee",
+            "temperature": "93.00",
+            "transition": "fast",
+            "volume": "100.0"
+        },
+        {
+            "exit": {
+                "condition": "under",
+                "type": "flow",
+                "value": "3.00"
+            },
+            "flow": "6.80",
+            "limiter": {
+                "range": "0.60",
+                "value": "0.00"
+            },
+            "name": "Compressing",
+            "pressure": "3.00",
+            "pump": "pressure",
+            "seconds": "12.00",
+            "sensor": "coffee",
+            "temperature": "88.00",
+            "transition": "fast",
+            "volume": "100.0"
+        },
+        {
+            "flow": "6.80",
+            "limiter": {
+                "range": "0.60",
+                "value": "0.00"
+            },
+            "name": "Dripping",
+            "pressure": "0.10",
+            "pump": "pressure",
+            "seconds": "6.00",
+            "sensor": "coffee",
+            "temperature": "88.00",
+            "transition": "fast",
+            "volume": "0.0"
+        },
+        {
+            "exit": {
+                "condition": "over",
+                "type": "pressure",
+                "value": "7.70"
+            },
+            "flow": "0.00",
+            "limiter": {
+                "range": "0.60",
+                "value": "3.50"
+            },
+            "name": "Pressurize",
+            "popup": "$weight",
+            "pressure": "11.00",
+            "pump": "pressure",
+            "seconds": "6.00",
+            "sensor": "coffee",
+            "temperature": "88.00",
+            "transition": "smooth",
+            "volume": "100.0"
+        },
+        {
+            "exit": {
+                "condition": "over",
+                "type": "pressure",
+                "value": "0.00"
+            },
+            "flow": "1.50",
+            "limiter": {
+                "range": "0.60",
+                "value": "8.60"
+            },
+            "name": "Extraction start",
+            "pressure": "3.00",
+            "pump": "flow",
+            "seconds": "0.00",
+            "sensor": "coffee",
+            "temperature": "88.00",
+            "transition": "fast",
+            "volume": "0.0"
+        },
+        {
+            "flow": "3.50",
+            "limiter": {
+                "range": "0.60",
+                "value": "8.60"
+            },
+            "name": "Extraction",
+            "pressure": "3.00",
+            "pump": "flow",
+            "seconds": "60.00",
+            "sensor": "coffee",
+            "temperature": "88.00",
+            "transition": "smooth",
+            "volume": "100.0"
+        }
+    ],
+    "tank_desired_water_temperature": "0.0",
+    "tank_temperature": "0.0",
+    "target_volume": "36.0",
+    "target_volume_count_start": "3",
+    "target_weight": "36.0",
+    "temp_steps_enabled": true,
+    "temperature_presets": [
+        "89.00",
+        "89.00",
+        "89.00",
+        "89.00"
+    ],
+    "title": "Adaptive v3",
+    "type": "advanced",
+    "version": "2"
+}

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -3129,7 +3129,7 @@ private slots:
         f.close();
         QVERIFY(!kb.isEmpty());
         // Structural-stability pin (restructure-kb-as-validated-json): exactly
-        // 47 entries. Parsed (not a raw "id": substring count, which a future
+        // 48 entries. Parsed (not a raw "id": substring count, which a future
         // prose/rationale string containing `"id":` would falsely break). If a
         // KB entry is intentionally added/removed, update this count AND
         // re-verify #1160 resolution.
@@ -3138,10 +3138,13 @@ private slots:
         // Decenza did not are now built-ins, and every built-in needs a KB entry —
         // baseline-contact-series covers all four Baseline levels through
         // alsoMatches, plus icbinf, psph and soup-58.
+        //
+        // 47 -> 48: de1app added a new built-in, Adaptive v3 (best_practice.tcl),
+        // synced in with KB entry `adaptive-v3`.
         const QJsonArray kbProfiles =
             QJsonDocument::fromJson(kb.toUtf8()).object()
                 .value(QStringLiteral("profiles")).toArray();
-        QCOMPARE(kbProfiles.size(), 47);
+        QCOMPARE(kbProfiles.size(), 48);
 
         // LLM-facing scope: the (a)/(c) framing checks target what the model
         // ingests — `prose` + identity. `rationale` (and `src`) are

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -2086,20 +2086,32 @@ private slots:
     // shipped-profile edit that collapses d-flow-q-variant into d-flow fails
     // here rather than silently widening a bucket.
     //
-    // TWO, not the three design.md first measured. The third was
-    // {damians-lr-v2-v3, londinium}, and it was never a collision of two
-    // profiles — it was one profile carrying two KB entries. londonium.json
-    // and damian_s_lrv2.json are byte-identical across all seven frames,
-    // differing only in title, reference_file, notes, target_weight, the
-    // hidden flag and one frame popup; Londonium's own notes say "This is
-    // identical to the LRv2 profile, but renamed to be easier to understand."
-    // The entries were merged (LRv2 now resolves to `londinium`, which carries
-    // the cited pressure-peak band it was always entitled to) and LRv3 — a
-    // genuinely different profile, eight frames at 90C with a 9-bar hold —
-    // was split out to `damians-lr-v2-v3`. So this bucket does not reappear by
+    // THREE. Design.md first measured a fourth, {damians-lr-v2-v3, londinium},
+    // and it was never a collision of two profiles — it was one profile
+    // carrying two KB entries. londonium.json and damian_s_lrv2.json are
+    // byte-identical across all seven frames, differing only in title,
+    // reference_file, notes, target_weight, the hidden flag and one frame
+    // popup; Londonium's own notes say "This is identical to the LRv2
+    // profile, but renamed to be easier to understand." The entries were
+    // merged (LRv2 now resolves to `londinium`, which carries the cited
+    // pressure-peak band it was always entitled to) and LRv3 — a genuinely
+    // different profile, eight frames at 90C with a 9-bar hold — was split
+    // out to `damians-lr-v2-v3`. So this bucket does not reappear by
     // widening the shape key; it disappeared because the KB stopped saying
     // one thing twice.
-    void shippedShapeCollisionsAreExactlyTheKnownTwo()
+    //
+    // {adaptive-v2, adaptive-v3} is the third, added when the de1app sync
+    // brought in Adaptive v3 (best_practice.tcl, KB entry `adaptive-v3`).
+    // Unlike LRv2/Londonium this is a real two-profile collision, not a
+    // duplicate: adaptive_v2.json and adaptive_v3.json share the identical
+    // 7-frame skeleton (Prefill/Fill/Compressing/Dripping/Pressurize/
+    // Extraction start/Extraction, same pump mode and duration per frame) —
+    // best-practice-light-roast's own prose says it "subsequently evolved
+    // into the Adaptive profile", and v2/v3 are two points on that lineage —
+    // but differ in setpoints (temperature, pressure/flow targets) and in
+    // KB facts (v3 has no expertBand; v3 carries channeling_expected for its
+    // near-zero-pressure Dripping step, v2 does not). Kept as a real bucket.
+    void shippedShapeCollisionsAreExactlyTheKnownThree()
     {
         const QMap<QString, QSet<QString>> buckets = shippedShapeBuckets();
 
@@ -2116,6 +2128,7 @@ private slots:
                   });
 
         QList<QStringList> expected{
+            {QStringLiteral("adaptive-v2"), QStringLiteral("adaptive-v3")},
             {QStringLiteral("d-flow"), QStringLiteral("d-flow-la-pavoni-variant")},
             {QStringLiteral("gentle-flat-long-preinfusion-family"),
              QStringLiteral("preinfuse-then-45ml-of-water")},
@@ -2186,19 +2199,26 @@ private slots:
             if (bandSets.size() > 1) ++bandDisagreements;
         }
 
-        QCOMPARE(bucketsSeen, 2);
-        // Measured: exactly one bucket disagrees on flags (flow_trend_ok, the
-        // safe direction the union rule handles); one disagrees on the band,
-        // which is why the band requires unanimity and is withheld otherwise.
+        QCOMPARE(bucketsSeen, 3);
+        // Measured: two buckets disagree on flags (flow_trend_ok, the safe
+        // direction the union rule handles); two disagree on the band, which
+        // is why the band requires unanimity and is withheld otherwise.
         //
-        // Was 3 buckets / 2 band disagreements. The third,
+        // Was 2 buckets / 1 flag / 1 band disagreement before the de1app sync
+        // added {adaptive-v2, adaptive-v3} (see
+        // shippedShapeCollisionsAreExactlyTheKnownThree) — that bucket
+        // disagrees on both: v3 carries channeling_expected and v2 does not,
+        // and v2 has an expertBand while v3 (no citation strong enough to
+        // pin one) does not.
+        //
+        // Before that, was 3 buckets / 2 band disagreements. The extra one,
         // {damians-lr-v2-v3, londinium}, was never two profiles — it was one
         // profile with two KB entries, and its "band disagreement" was the KB
         // describing the same extraction twice with different completeness.
         // Merging the entries removed a disagreement rather than resolving
-        // one; see shippedShapeCollisionsAreExactlyTheKnownTwo.
-        QCOMPARE(flagDisagreements, 1);
-        QCOMPARE(bandDisagreements, 1);
+        // one.
+        QCOMPARE(flagDisagreements, 2);
+        QCOMPARE(bandDisagreements, 2);
     }
 
     // === ProfileShapeIndex (change: resolve-profile-kb-by-shape, group 3) ===
@@ -2719,7 +2739,7 @@ private slots:
     // differ per fact rather than being one policy.
     //
     // The buckets used as fixtures are the real shipped ones, pinned by
-    // shippedShapeCollisionsAreExactlyTheKnownTwo above.
+    // shippedShapeCollisionsAreExactlyTheKnownThree above.
 
     // flow_trend_ok is carried by preinfuse-then-45ml-of-water and NOT by
     // gentle-flat-long-preinfusion-family — a real disagreement in a real
@@ -2921,7 +2941,7 @@ private slots:
         //
         // This fixture used to be londonium.json. That stopped being ambiguous
         // when LRv2 and Londonium were recognised as one profile and their KB
-        // entries merged — see shippedShapeCollisionsAreExactlyTheKnownTwo.
+        // entries merged — see shippedShapeCollisionsAreExactlyTheKnownThree.
         Profile p = loadShipped(QStringLiteral("d_flow_default.json"));
         p.setTitle(QStringLiteral("Zzz Unrelated Name"));
         const KbResolution r = resolveProfileKb(p);


### PR DESCRIPTION
## Summary
- de1app added a built-in profile Decenza never picked up: **Adaptive v3** (`de1plus/profiles/best_practice.tcl`). Ran `profile_sync` against the current de1app checkout (submodules at upstream tip) — 88/89 profiles already in sync, this was the only miss.
- Added `resources/profiles/adaptive_v3.json` (registered in `resources/profiles.qrc`).
- Added a matching KB entry (`resources/ai/profile_knowledge.json`, id `adaptive-v3`) so the AI dial-in advisor resolves it by title — same lineage as `best-practice-light-roast` and `adaptive-v2` (Brakel preinfusion + Rao Blooming + Gagné Adaptive flow-locking).
- Updated two pinned regression tests the new KB entry legitimately shifts: KB entry count (47 → 48, `tst_dialing_blocks`) and the known frame-shape collision set, now three pairs — `adaptive-v2`/`adaptive-v3` share an identical 7-frame skeleton but differ in setpoints and KB facts (`tst_shotsummarizer`).

Not new: 4 A-Flow plugin/base source conflicts `profile_sync` reported are pre-existing and already resolved by the tool (plugin copy wins) — tracked as de1app issue #350.

## Test plan
- [x] `mcp__qtcreator__build` — clean, 0 warnings
- [x] `mcp__qtcreator__run_tests` (scope: all) — 113/113 passed
- [x] `tools/validate_kb.py` — valid (1 pre-existing non-fatal lint warning, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)