### PR TITLE
fix(ble): split coalesced DiFluid BLE frames instead of dropping them

### DIFF
--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -468,39 +468,65 @@ void DiFluidR2::onCharacteristicChanged(const QBluetoothUuid& /*characteristicUu
 void DiFluidR2::handlePacket(const QByteArray& packet) {
     // Official DiFluid protocol: DF DF <Func> <Cmd> <DataLen> <Data0..DataN> <Checksum>
     // Minimum packet: header(2) + func(1) + cmd(1) + datalen(1) + checksum(1) = 6 bytes
-    if (packet.size() < PACKET_MIN_LENGTH) {
-        // A runt is at least as alarming as the bad-header case logged below — BLE
-        // fragmentation, an MTU change, a firmware emitting a shape we do not know —
-        // and it used to be the one malformed packet that left no evidence at all.
-        R2_LOG(QString("Runt packet (%1 bytes, minimum %2): %3")
-                   .arg(packet.size()).arg(PACKET_MIN_LENGTH)
-                   .arg(QString(packet.toHex(' '))));
-        return;
-    }
+    //
+    // One onCharacteristicChanged delivery is not guaranteed to hold exactly one frame:
+    // the R2 sends notifications back-to-back and the BLE stack has been observed
+    // (Android, live log) to coalesce two into a single characteristic-value update.
+    // DataLen (byte 4) delimits each frame reliably, so walk the delivery one frame at
+    // a time and checksum only that frame — checksumming the whole delivery as one blob
+    // means two individually-valid frames fail together and both get dropped. Confirmed
+    // on a captured "Checksum failed" packet that was exactly two valid 12-byte
+    // serial-number-part frames back to back, each checksumming clean (0xDD, 0xC1) on
+    // its own and only failing as a concatenated pair.
+    qsizetype offset = 0;
+    while (offset < packet.size()) {
+        const QByteArray remaining = packet.mid(offset);
 
-    // Validate header (0xDF 0xDF)
-    if (static_cast<uint8_t>(packet[0]) != PACKET_HEADER ||
-        static_cast<uint8_t>(packet[1]) != PACKET_HEADER) {
-        R2_LOG(QString("Non-protocol packet (%1 bytes): %2")
-            .arg(packet.size()).arg(QString(packet.left(8).toHex(' '))));
-        return;
-    }
+        if (remaining.size() < PACKET_MIN_LENGTH) {
+            // A runt is at least as alarming as the bad-header case logged below — BLE
+            // fragmentation, an MTU change, a firmware emitting a shape we do not know —
+            // and it used to be the one malformed packet that left no evidence at all.
+            R2_LOG(QString("Runt packet (%1 bytes, minimum %2): %3")
+                       .arg(remaining.size()).arg(PACKET_MIN_LENGTH)
+                       .arg(QString(remaining.toHex(' '))));
+            return;
+        }
 
-    if (!validateChecksum(packet)) {
-        R2_WARN(QString("Checksum failed: %1").arg(QString(packet.toHex(' '))));
-        return;
-    }
+        // Validate header (0xDF 0xDF)
+        if (static_cast<uint8_t>(remaining[0]) != PACKET_HEADER ||
+            static_cast<uint8_t>(remaining[1]) != PACKET_HEADER) {
+            R2_LOG(QString("Non-protocol packet (%1 bytes): %2")
+                .arg(remaining.size()).arg(QString(remaining.left(8).toHex(' '))));
+            return;
+        }
 
+        // Data starts at byte 5, length = dataLen. Frame length = 2×header + func +
+        // cmd + datalen (5) + dataLen data bytes + 1 checksum byte.
+        const uint8_t dataLen = static_cast<uint8_t>(remaining[4]);
+        const qsizetype frameLen = 5 + dataLen + 1;
+        if (remaining.size() < frameLen) {
+            R2_WARN(QString("Packet too short for declared data length: %1")
+                        .arg(QString(remaining.toHex(' '))));
+            return;
+        }
+
+        // Sliced to exactly this frame's declared length, so a second frame appended
+        // after it cannot pollute this checksum — only this frame's own bytes count.
+        const QByteArray frame = remaining.left(frameLen);
+        if (!validateChecksum(frame)) {
+            R2_WARN(QString("Checksum failed: %1").arg(QString(frame.toHex(' '))));
+            return;
+        }
+
+        processFrame(frame);
+        offset += frameLen;
+    }
+}
+
+void DiFluidR2::processFrame(const QByteArray& packet) {
     uint8_t func = static_cast<uint8_t>(packet[2]);
     uint8_t cmd = static_cast<uint8_t>(packet[3]);
     uint8_t dataLen = static_cast<uint8_t>(packet[4]);
-
-    // Data starts at byte 5, length = dataLen
-    // Verify packet length: 5 (2×header + func + cmd + datalen) + dataLen + 1 (checksum)
-    if (packet.size() < 5 + dataLen + 1) {
-        R2_WARN(QString("Packet too short for declared data length"));
-        return;
-    }
 
     // Func 0 = Device Info: decode the model/firmware strings for instrumentation.
     // Model "DFT-R102" == genuine R2 Extract (transmits coffee TDS); anything else is a

--- a/src/ble/refractometers/difluidr2.h
+++ b/src/ble/refractometers/difluidr2.h
@@ -68,6 +68,11 @@ private slots:
 
 private:
     void handlePacket(const QByteArray& packet);
+    // One already-delimited, checksum-valid frame (header, func, cmd, dataLen, its
+    // declared data bytes, checksum — exactly, no more, no less). handlePacket() is
+    // the only caller, split out because a single BLE delivery can hold more than
+    // one frame back-to-back (see handlePacket's comment).
+    void processFrame(const QByteArray& frame);
     // The R2 sends its serial number as SERIAL_PART_COUNT packets, each carrying a
     // part index in Data0 followed by SERIAL_PART_BYTES bytes. Parts are spliced at
     // their indicated offset, so arrival order does not matter — BLE notification

--- a/src/ble/scales/difluidscale.cpp
+++ b/src/ble/scales/difluidscale.cpp
@@ -182,36 +182,52 @@ void DifluidScale::onCharacteristicChanged(const QBluetoothUuid& characteristicU
     // reached only when the weight was exactly zero, and then it was parsing the
     // timer bytes. The comment already said "bytes 5-8" (four bytes); the code
     // took a character count for a byte count.
-    // Sensor frames only. This characteristic also carries the device's echoes of our
-    // own settings writes (Func 1), which are 6-7 bytes — warning about those would
-    // describe healthy traffic as malformed, and at 5Hz a mismatched format would
-    // evict the whole 1000-entry scale log, destroying the artifact a diagnostician
-    // asks for. Anything that is not a sensor frame is logged quietly and dropped.
-    if (!value.startsWith(QByteArray::fromHex("dfdf0300"))) {
-        DIFLUID_LOG(QString("Non-sensor notification: %1").arg(QString(value.toHex(' '))));
-        return;
-    }
-    if (value.size() < 19) {
-        DIFLUID_WARN(QString("Sensor frame too short (%1 bytes, need 19): %2")
-                         .arg(value.size()).arg(QString(value.toHex(' '))));
-        return;
-    }
+    //
+    // One onCharacteristicChanged delivery is not guaranteed to hold exactly one
+    // 19-byte frame: the sibling DiFluidR2 driver — same ScaleBleTransport, same
+    // vendor DF-DF-framed protocol — was confirmed via a captured log to have two
+    // back-to-back notifications coalesced by the BLE stack into a single
+    // delivery (see difluidr2.cpp's handlePacket). The single-shot version here
+    // only ever looked at the first 19 bytes, so a second weight sample riding
+    // along in the same delivery was silently discarded past byte 18 with no log
+    // line at all. Walk the delivery one 19-byte sensor frame at a time instead.
+    qsizetype offset = 0;
+    while (offset < value.size()) {
+        const QByteArray remaining = value.mid(offset);
 
-    // Signed: the field goes negative after a tare drift, and reading it unsigned
-    // turned −0.5 g into 4294967291, which the range gate below then discarded —
-    // freezing the displayed weight at its last non-negative value.
-    const qint32 weightRaw = static_cast<qint32>(
-          (static_cast<quint32>(static_cast<quint8>(value[5])) << 24)
-        | (static_cast<quint32>(static_cast<quint8>(value[6])) << 16)
-        | (static_cast<quint32>(static_cast<quint8>(value[7])) << 8)
-        |  static_cast<quint32>(static_cast<quint8>(value[8])));
+        // Sensor frames only. This characteristic also carries the device's echoes of our
+        // own settings writes (Func 1), which are 6-7 bytes — warning about those would
+        // describe healthy traffic as malformed, and at 5Hz a mismatched format would
+        // evict the whole 1000-entry scale log, destroying the artifact a diagnostician
+        // asks for. Anything that is not a sensor frame is logged quietly and dropped.
+        if (!remaining.startsWith(QByteArray::fromHex("dfdf0300"))) {
+            DIFLUID_LOG(QString("Non-sensor notification: %1").arg(QString(remaining.toHex(' '))));
+            return;
+        }
+        if (remaining.size() < 19) {
+            DIFLUID_WARN(QString("Sensor frame too short (%1 bytes, need 19): %2")
+                             .arg(remaining.size()).arg(QString(remaining.toHex(' '))));
+            return;
+        }
 
-    if (weightRaw <= -20000 || weightRaw >= 20000) {
-        DIFLUID_WARN(QString("Weight out of range: raw=%1 (%2 g) — ignoring")
-                         .arg(weightRaw).arg(weightRaw / 10.0));
-        return;
+        // Signed: the field goes negative after a tare drift, and reading it unsigned
+        // turned −0.5 g into 4294967291, which the range gate below then discarded —
+        // freezing the displayed weight at its last non-negative value.
+        const qint32 weightRaw = static_cast<qint32>(
+              (static_cast<quint32>(static_cast<quint8>(remaining[5])) << 24)
+            | (static_cast<quint32>(static_cast<quint8>(remaining[6])) << 16)
+            | (static_cast<quint32>(static_cast<quint8>(remaining[7])) << 8)
+            |  static_cast<quint32>(static_cast<quint8>(remaining[8])));
+
+        if (weightRaw <= -20000 || weightRaw >= 20000) {
+            DIFLUID_WARN(QString("Weight out of range: raw=%1 (%2 g) — ignoring")
+                             .arg(weightRaw).arg(weightRaw / 10.0));
+        } else {
+            setWeight(weightRaw / 10.0);
+        }
+
+        offset += 19;
     }
-    setWeight(weightRaw / 10.0);
 }
 
 void DifluidScale::sendCommand(const QByteArray& cmd) {


### PR DESCRIPTION
## What

Android's BLE stack was observed coalescing two back-to-back DiFluid
notifications into a single `onCharacteristicChanged` delivery. Both
DiFluid drivers assumed one delivery == one frame, so the second frame
in a coalesced pair got silently lost:

- **`DiFluidR2::handlePacket()`** checksummed the whole delivery as one
  blob. Two individually-valid frames failed checksum together and
  both were dropped. Confirmed on a captured `Checksum failed` log
  line that was exactly two valid 12-byte serial-number-part frames
  back to back — each checksums clean alone (0xDD, 0xC1 respectively),
  only failing as a concatenated pair.
- **`DifluidScale::onCharacteristicChanged()`** (sibling driver, same
  transport, same `DF DF`-framed protocol) read only the first 19-byte
  sensor frame at fixed offsets, silently discarding any second weight
  sample in the same delivery — no warning, no log line at all.

## Fix

Both now walk the delivery frame by frame instead of treating it as one:

- `DiFluidR2::handlePacket()` loops, slicing each frame by its declared
  `DataLen` byte and checksumming only that slice. Per-frame parsing
  logic moved unchanged into a new `processFrame()`.
- `DifluidScale::onCharacteristicChanged()` loops in 19-byte strides,
  matching the fixed-frame-size assumption the code already made — no
  new parsing logic, just applied per-frame instead of once. A bad
  frame no longer aborts the whole delivery; it now skips just that
  frame and keeps walking.

## Testing

Local build clean, full suite green (113/113 test binaries, including
`tst_difluidr2` and `tst_scaleprotocol`).

**Known gap, not addressed here:** no test yet drives the actual
multi-frame-per-delivery path in `tst_difluidr2.cpp` — every existing
call feeds `handlePacket()` one frame at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)