### PR TITLE
ci: pin Python 3.14 so aqtinstall can extract Qt archives

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -73,9 +73,26 @@ jobs:
       - name: Install minimal host dependencies
         run: sudo apt-get install -y --no-install-recommends libegl1 libgl1 ninja-build
 
+      # Pin the Python aqtinstall runs on. aqt 3.3.0 (latest, 2025-06-02) extracts
+      # Qt's .7z archives via zipfile.is_zipfile, which false-positives on some of
+      # them -- it then tries to read a 7z as a zip and dies with
+      # `BadZipFile: Bad offset for central directory`. It took out the Qt 6.11.2
+      # aarch64 qtdeclarative archive and with it every Linux ARM64 release build.
+      # The detection fix is python/cpython#72680, first shipped in Python 3.14, so
+      # 3.14 is the MINIMUM that works rather than merely the newest.
+      # Set on all six workflows deliberately: which Python aqt gets should be one
+      # answer, not six accidental ones. Remove when aqtinstall ships a fix --
+      # tracking https://github.com/miurahr/aqtinstall/issues/1042
+      - name: Pin Python for aqtinstall (aqtinstall#1042)
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
       - name: Install Qt for Android
         uses: jurplel/install-qt-action@v4
         with:
+          # aqt runs on the Python pinned above, not one this action installs.
+          setup-python: false
           version: ${{ env.QT_VERSION }}
           target: 'android'
           arch: 'android_arm64_v8a'

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -80,9 +80,26 @@ jobs:
           xcrun --sdk iphoneos clang --version | head -3
           echo "DEVELOPER_DIR=/Applications/Xcode_26.4.1.app/Contents/Developer" >> $GITHUB_ENV
 
+      # Pin the Python aqtinstall runs on. aqt 3.3.0 (latest, 2025-06-02) extracts
+      # Qt's .7z archives via zipfile.is_zipfile, which false-positives on some of
+      # them -- it then tries to read a 7z as a zip and dies with
+      # `BadZipFile: Bad offset for central directory`. It took out the Qt 6.11.2
+      # aarch64 qtdeclarative archive and with it every Linux ARM64 release build.
+      # The detection fix is python/cpython#72680, first shipped in Python 3.14, so
+      # 3.14 is the MINIMUM that works rather than merely the newest.
+      # Set on all six workflows deliberately: which Python aqt gets should be one
+      # answer, not six accidental ones. Remove when aqtinstall ships a fix --
+      # tracking https://github.com/miurahr/aqtinstall/issues/1042
+      - name: Pin Python for aqtinstall (aqtinstall#1042)
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          # aqt runs on the Python pinned above, not one this action installs.
+          setup-python: false
           version: '6.11.2'
           target: 'ios'
           arch: 'ios'

--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -72,9 +72,26 @@ jobs:
             fuse \
             libfuse2
 
+      # Pin the Python aqtinstall runs on. aqt 3.3.0 (latest, 2025-06-02) extracts
+      # Qt's .7z archives via zipfile.is_zipfile, which false-positives on some of
+      # them -- it then tries to read a 7z as a zip and dies with
+      # `BadZipFile: Bad offset for central directory`. It took out the Qt 6.11.2
+      # aarch64 qtdeclarative archive and with it every Linux ARM64 release build.
+      # The detection fix is python/cpython#72680, first shipped in Python 3.14, so
+      # 3.14 is the MINIMUM that works rather than merely the newest.
+      # Set on all six workflows deliberately: which Python aqt gets should be one
+      # answer, not six accidental ones. Remove when aqtinstall ships a fix --
+      # tracking https://github.com/miurahr/aqtinstall/issues/1042
+      - name: Pin Python for aqtinstall (aqtinstall#1042)
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          # aqt runs on the Python pinned above, not one this action installs.
+          setup-python: false
           version: '6.11.2'
           target: 'desktop'
           arch: 'linux_gcc_arm64'

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -72,9 +72,26 @@ jobs:
             fuse \
             libfuse2
 
+      # Pin the Python aqtinstall runs on. aqt 3.3.0 (latest, 2025-06-02) extracts
+      # Qt's .7z archives via zipfile.is_zipfile, which false-positives on some of
+      # them -- it then tries to read a 7z as a zip and dies with
+      # `BadZipFile: Bad offset for central directory`. It took out the Qt 6.11.2
+      # aarch64 qtdeclarative archive and with it every Linux ARM64 release build.
+      # The detection fix is python/cpython#72680, first shipped in Python 3.14, so
+      # 3.14 is the MINIMUM that works rather than merely the newest.
+      # Set on all six workflows deliberately: which Python aqt gets should be one
+      # answer, not six accidental ones. Remove when aqtinstall ships a fix --
+      # tracking https://github.com/miurahr/aqtinstall/issues/1042
+      - name: Pin Python for aqtinstall (aqtinstall#1042)
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          # aqt runs on the Python pinned above, not one this action installs.
+          setup-python: false
           version: '6.11.2'
           target: 'desktop'
           arch: 'linux_gcc_64'

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -55,9 +55,26 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
+      # Pin the Python aqtinstall runs on. aqt 3.3.0 (latest, 2025-06-02) extracts
+      # Qt's .7z archives via zipfile.is_zipfile, which false-positives on some of
+      # them -- it then tries to read a 7z as a zip and dies with
+      # `BadZipFile: Bad offset for central directory`. It took out the Qt 6.11.2
+      # aarch64 qtdeclarative archive and with it every Linux ARM64 release build.
+      # The detection fix is python/cpython#72680, first shipped in Python 3.14, so
+      # 3.14 is the MINIMUM that works rather than merely the newest.
+      # Set on all six workflows deliberately: which Python aqt gets should be one
+      # answer, not six accidental ones. Remove when aqtinstall ships a fix --
+      # tracking https://github.com/miurahr/aqtinstall/issues/1042
+      - name: Pin Python for aqtinstall (aqtinstall#1042)
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          # aqt runs on the Python pinned above, not one this action installs.
+          setup-python: false
           version: '6.11.2'
           target: 'desktop'
           arch: 'clang_64'

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -57,9 +57,26 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
+      # Pin the Python aqtinstall runs on. aqt 3.3.0 (latest, 2025-06-02) extracts
+      # Qt's .7z archives via zipfile.is_zipfile, which false-positives on some of
+      # them -- it then tries to read a 7z as a zip and dies with
+      # `BadZipFile: Bad offset for central directory`. It took out the Qt 6.11.2
+      # aarch64 qtdeclarative archive and with it every Linux ARM64 release build.
+      # The detection fix is python/cpython#72680, first shipped in Python 3.14, so
+      # 3.14 is the MINIMUM that works rather than merely the newest.
+      # Set on all six workflows deliberately: which Python aqt gets should be one
+      # answer, not six accidental ones. Remove when aqtinstall ships a fix --
+      # tracking https://github.com/miurahr/aqtinstall/issues/1042
+      - name: Pin Python for aqtinstall (aqtinstall#1042)
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
+          # aqt runs on the Python pinned above, not one this action installs.
+          setup-python: false
           version: '6.11.2'
           target: 'desktop'
           arch: 'win64_msvc2022_64'


### PR DESCRIPTION
## The failure

Linux ARM64 release builds have been failing at **Install Qt**, before any compilation, since Qt 6.11.2 landed. It took out the aarch64 AppImage for the v2.0.4 pre-release ([run 32404449612](https://github.com/Kulitorum/Decenza/actions/runs/32404449612/job/96540103935)):

```
WARNING : Caught BadZipFile, terminating installer workers
ERROR   : Bad offset for central directory
zipfile.BadZipFile: Bad offset for central directory
ERROR   : aqtinstall(aqt) v3.3.0 on Python 3.12.14
```

## Why it is not what it looks like

It reads like a corrupt download from a Qt mirror. It isn't. aqtinstall picks its extraction path with `zipfile.is_zipfile()`, which **false-positives on some of Qt's `.7z` archives** — aqt then tries to read a 7z as a zip and dies. The 6.11.2 aarch64 `qtdeclarative` archive trips it.

Diagnosis is not mine: it is in [miurahr/aqtinstall#1042](https://github.com/miurahr/aqtinstall/issues/1042), where another project hit the identical failure on `ubuntu-24.04-arm` four days ago. No new bug was filed — that one is open and better diagnosed than a fresh report would be.

## Why Python 3.14 specifically

The detection fix is [python/cpython#72680](https://github.com/python/cpython/issues/72680), first shipped in **Python 3.14**. So 3.14 is the *minimum version that works*, not merely the newest — 3.15 is still at `rc.1` and would add exposure without adding a fix.

Waiting for aqt is not an option: its latest release is **v3.3.0, 2025-06-02** — over a year old, and the version failing here.

## Why all six workflows

Only ARM64 has actually tripped, because the false positive depends on the archive bytes and that archive is downloaded nowhere else. But all six currently take the runner's default Python **by omission**, so they agree today by accident. Pinning one would leave five whose answer to "which Python does aqt run on?" is silently different — and the next platform to trip would present as a fresh mystery rather than a known one.

## Risk

Small and bounded: **nothing else in these workflows runs Python**, so this changes what aqt executes on and nothing else. `actions/setup-python@v7` is already used in this repo (`text-invariants.yml:127`), so the action version is proven here rather than taken from the upstream thread.

The honest caveat is that 3.14 is *newer* than the runners default to, so a known breakage is traded for a small unknown.

`actionlint` reports no YAML or action errors on the six edited files. Its remaining output is pre-existing shellcheck noise in `run:` blocks this PR does not touch. One of those, `SC2193` ("arguments can never be equal") on the `refs/tags/*` comparison, was checked and is a false positive — shellcheck does not understand `${{ }}` and reads the literal text.

## Removing this later

Each pin carries a comment naming aqtinstall#1042. It should come out when aqt ships a real fix, rather than outliving its reason.

## Verification

Not yet verified by a build — a `workflow_dispatch` test build of Linux ARM64 is the check, since the failure is entirely inside CI and cannot be reproduced locally.

**This does not recover v2.0.4's missing aarch64 AppImage.** That needs this merged and the tag force-moved again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
