### PR TITLE
Stop periodic log lines that report nothing; unslosh the water level

### DIFF
--- a/docs/CLAUDE_MD/LOGGING.md
+++ b/docs/CLAUDE_MD/LOGGING.md
@@ -108,6 +108,30 @@ are the same thing. (They were.)
 Anything genuinely model-specific — which characteristic, which extra notification —
 stays a literal at the call site.
 
+### A periodic line that says nothing must say nothing
+
+A line whose text is unchanged carries no more information an hour later than it did
+a minute later, so the question is not how often it may repeat — it is whether the
+repeat is worth a line at all. For a source reporting that things are normal, it is
+not. Route it through `LogCollapse` constructed with `LogCollapse::kChangesOnly`
+(`src/core/logcollapse.h`): a CHANGE prints at once and carries the count of
+identical lines it stood for, and nothing prints in between.
+
+Every periodic source in the tree is on it — the MMR charger keepalive, the memory
+sampler, the battery poll, the ShotServer request log, MQTT's retry ladder, and the
+two elided-write lines. A finite window is for the one case where the repeat is
+itself evidence: `BleGattQueue`'s dispatch line only speaks above a foreign-wait
+threshold, and a window is what separates two operations inside one stall.
+
+Two things to get right, both of which have been got wrong here:
+
+- **An episodic source must flush at its run end**, or its pending tally is stapled
+  onto the next run's first line hours later with a span dated to now. Periodic
+  sources need no flush — the tally rides out on the next line whose text differs.
+- **Key it by what makes two lines the same event.** The elided-write lines key on
+  the whole message, so a different CALLER eliding the same value still prints:
+  "who tried and was ignored" is the entire content of that line.
+
 ## Four failure modes to avoid
 
 These are the ones that actually happened, repeatedly.

--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -353,7 +353,7 @@ the `refresh()` / `rotateToken()` invokables.
 | Tool | Description | Category |
 |------|-------------|----------|
 | `machine_get_state` | Phase, connection, readiness, heating status, water level (ml + mm), firmware version, active profile name. Platform/OS info has moved to `app_get_info` (#988) to keep tight polling responses small. | read |
-| `app_get_info` | App and device info: appVersion, qtVersion, OS, kernel, architecture, deviceModel, screen size/DPI, devicePixelRatio. Diagnostics-grade — call once per session. | read |
+| `app_get_info` | App and device info: appVersion, **buildNumber**, qtVersion, OS, kernel, architecture, deviceModel, screen size/DPI, devicePixelRatio. Diagnostics-grade — call once per session. `buildNumber` (`versionCode()`) is what identifies a build: one `appVersion` can ship many, since pre-releases are re-cut against a rolling version — v2.0.4 shipped as 3552, 3553 and 3554. Ask for it before concluding whether a fix is present in a field report. | read |
 | `machine_get_telemetry` | Live pressure, flow, temp, weight, goal values. During a shot, also returns the current shot's time-series data so far (not just the latest sample) so the AI can detect channeling or stalling mid-shot. | read |
 | `steam_get_health` | Detailed steam-system health: baseline + current pressure/temperature, flow-restriction progress toward warn thresholds, status, and recommendation. Used for steam-wand cleaning / descaling guidance. | read |
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -193,6 +193,22 @@ void DE1Device::onTransportDisconnected() {
                     .arg(address, LogCollapse::suffix(collapsed)));
     }
 
+    // The water-level filter's run ends here too. Re-seeding on the next connect is what stops the
+    // reconnect showing the tank refilling from wherever the last session left the average, and
+    // clearing the log endpoints stops the first line of the new session claiming a delta measured
+    // against the old one.
+    m_waterLevelSeeded = false;
+    m_lastLoggedWaterLevelMm = -1000.0;
+    m_lastLoggedWaterLevelMl = -1;
+
+    // Elided-write runs end here as well. Keyed by the message text, which this function does not
+    // enumerate, so flushAll() — and the key IS the line to print, under its own tag.
+    const qint64 skipFlushMs = QDateTime::currentMSecsSinceEpoch();
+    for (const auto& [text, collapsed] : m_mmrSkipLog.flushAll(skipFlushMs))
+        MMR_LOG(text + LogCollapse::suffix(collapsed));
+    for (const auto& [text, collapsed] : m_shotSettingsSkipLog.flushAll(skipFlushMs))
+        SHOTSETTINGS_LOG(text + LogCollapse::suffix(collapsed));
+
     // Tier by whether the machine was BUSY, because that is what separates a
     // fault from a shutdown, and nothing else here can.
     //
@@ -599,10 +615,13 @@ void DE1Device::parseStateInfo(const QByteArray& data) {
     bool subStateChanged = (newSubState != m_subState);
 
     if (stateChanged) {
-        PHASE_LOG(QStringLiteral("%1 → %2 (water raw=%3 mm, displayed=%4 mm, %5 ml)")
+        // Water carried here so a phase change is self-contained. Only the corrected figure: the
+        // "raw" half was this same number minus the constant sensor offset, reconstructed inline
+        // rather than read from anywhere, which is as clear a demonstration as there could be that
+        // it carried nothing.
+        PHASE_LOG(QStringLiteral("%1 → %2 (water %3 mm, %4 ml)")
                       .arg(DE1::stateToString(m_state))
                       .arg(DE1::stateToString(newState))
-                      .arg(m_waterLevelMm - 5.0, 0, 'f', 1)
                       .arg(m_waterLevelMm, 0, 'f', 1)
                       .arg(m_waterLevelMl));
     }
@@ -682,7 +701,16 @@ void DE1Device::parseWaterLevel(const QByteArray& data) {
 
     // Apply sensor offset correction (sensor is mounted 5mm above water intake)
     constexpr double SENSOR_OFFSET = 5.0;
-    m_waterLevelMm = rawMm + SENSOR_OFFSET;
+    const double sampleMm = rawMm + SENSOR_OFFSET;
+
+    // Low-pass the sample before anything reads it. See WATER_LEVEL_SMOOTHING_ALPHA in the header
+    // for why this is a filter and not a bigger threshold.
+    if (!m_waterLevelSeeded) {
+        m_waterLevelMm = sampleMm;
+        m_waterLevelSeeded = true;
+    } else {
+        m_waterLevelMm += WATER_LEVEL_SMOOTHING_ALPHA * (sampleMm - m_waterLevelMm);
+    }
 
     // Lookup table from de1app CAD data (mm index → ml volume)
     static const int mmToMl[] = {
@@ -715,14 +743,41 @@ void DE1Device::parseWaterLevel(const QByteArray& data) {
     if (qAbs(m_waterLevel - m_lastEmittedWaterLevel) >= 0.5
         || m_waterLevelMl != m_lastEmittedWaterLevelMl) {
         // Log on a coarser gate than the emit — see m_lastLoggedWaterLevelMm. 2 mm is above the
-        // sensor's idle dither and below anything a person would call a change in level: a refill,
-        // a shot's worth of draw, or the tank running down all clear it within a line or two.
+        // smoothed signal's residual dither and below anything a person would call a change in
+        // level: a refill, a shot's worth of draw, or the tank running down all clear it.
         if (qAbs(m_waterLevelMm - m_lastLoggedWaterLevelMm) >= WATER_LEVEL_LOG_HYSTERESIS_MM) {
-            WATER_LOG(QStringLiteral("raw=%1 mm displayed=%2 mm %3 ml")
-                          .arg(rawMm, 0, 'f', 1)
-                          .arg(m_waterLevelMm, 0, 'f', 1)
-                          .arg(m_waterLevelMl));
+            // What the line has to answer is "what happened to the water", and neither a bare
+            // reading nor a pair of readings answers it — 564 ml is not a fact anyone can act on
+            // without knowing it was 732 ml a moment ago and that the machine was pulling a shot.
+            // So: the move, and the state that caused it.
+            //
+            // `raw` is deliberately gone. It was `displayed` minus a compile-time constant
+            // (SENSOR_OFFSET), so the two could never disagree and printing both doubled the width
+            // of every line to say one thing twice. The Phase line proved it by reconstructing raw
+            // as `m_waterLevelMm - 5.0` rather than reading a stored value.
+            //
+            // The state is the machine's, NOT a classification of the event. The tempting version
+            // of this line tags a large positive delta "[refill]" — but that is a guess with a
+            // threshold behind it, and a reader given "+616 ml [Idle]" can draw the same conclusion
+            // from evidence instead of being told it.
+            if (m_lastLoggedWaterLevelMl < 0) {
+                WATER_LOG(QStringLiteral("%1 ml (%2 mm) first reading [%3]")
+                              .arg(m_waterLevelMl)
+                              .arg(m_waterLevelMm, 0, 'f', 1)
+                              .arg(DE1::stateToString(m_state)));
+            } else {
+                const int deltaMl = m_waterLevelMl - m_lastLoggedWaterLevelMl;
+                WATER_LOG(QStringLiteral("%1 -> %2 ml (%3%4 ml, %5 -> %6 mm) [%7]")
+                              .arg(m_lastLoggedWaterLevelMl)
+                              .arg(m_waterLevelMl)
+                              .arg(deltaMl >= 0 ? QStringLiteral("+") : QString())
+                              .arg(deltaMl)
+                              .arg(m_lastLoggedWaterLevelMm, 0, 'f', 1)
+                              .arg(m_waterLevelMm, 0, 'f', 1)
+                              .arg(DE1::stateToString(m_state)));
+            }
             m_lastLoggedWaterLevelMm = m_waterLevelMm;
+            m_lastLoggedWaterLevelMl = m_waterLevelMl;
         }
         m_lastEmittedWaterLevel = m_waterLevel;
         m_lastEmittedWaterLevelMl = m_waterLevelMl;
@@ -1625,10 +1680,15 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
     const bool valueUnchanged = (it != m_lastMMRValues.constEnd() && it.value() == value);
 
     if (!force && valueUnchanged) {
-        MMR_LOG(QStringLiteral("write skipped: 0x%1 unchanged (%2)%3")
-                    .arg(address, 6, 16, QLatin1Char('0'))
-                    .arg(value)
-                    .arg(reasonSuffix));
+        // Once per distinct (register, value, caller) per session — see m_writeSkippedLog.
+        const QString text = QStringLiteral("write skipped: 0x%1 unchanged (%2)%3")
+                                 .arg(address, 6, 16, QLatin1Char('0'))
+                                 .arg(value)
+                                 .arg(reasonSuffix);
+        LogCollapse::Collapsed collapsed;
+        if (m_mmrSkipLog.shouldLog(text, text, QDateTime::currentMSecsSinceEpoch(), &collapsed)) {
+            MMR_LOG(text + LogCollapse::suffix(collapsed));
+        }
         return;
     }
 
@@ -1926,7 +1986,8 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     // attributes the elided call to its origin so we can see which convergent
     // signal fired.
     if (data == m_lastShotSettingsPayload) {
-        SHOTSETTINGS_LOG(QStringLiteral(
+        // Once per distinct (payload, caller) per session — see m_writeSkippedLog.
+        const QString text = QStringLiteral(
             "write skipped: payload unchanged "
             "(steam=%1C duration=%2s hotWater=%3C vol=%4ml groupTemp=%5C)%6")
             .arg(steamTemp, 0, 'f', 1)
@@ -1934,7 +1995,12 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
             .arg(hotWaterTemp, 0, 'f', 1)
             .arg(hotWaterVolume)
             .arg(groupTemp, 0, 'f', 2)
-            .arg(reasonSuffix));
+            .arg(reasonSuffix);
+        LogCollapse::Collapsed collapsed;
+        if (m_shotSettingsSkipLog.shouldLog(text, text, QDateTime::currentMSecsSinceEpoch(),
+                                            &collapsed)) {
+            SHOTSETTINGS_LOG(text + LogCollapse::suffix(collapsed));
+        }
         return;
     }
 

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -485,10 +485,34 @@ private:
     // Keepalive writes re-assert an unchanged value every 60 s forever (BatteryManager's USB-charger
     // refresh — the DE1 auto-disables the port after 10 minutes, so the re-assert is load-bearing
     // and cannot be dropped). Its LOG line, repeated 3,042 times in a 48-hour capture for 15% of the
-    // whole log, can be. One line per 10 minutes carrying the count; a value CHANGE still prints
-    // immediately, because that is the event worth seeing.
+    // whole log, can be, and now is not printed at all while the value holds. The events that remain
+    // are the ones that carry something: a value CHANGE, which prints at once with the count of
+    // re-asserts it stood for, and the disconnect flush. A 0 -> 1 or 1 -> 0 on this register is the
+    // charger actually being commanded, and it is the only thing here a reader has ever needed.
     // Episodic: a run is one connected session. Flushed in onTransportDisconnected().
-    LogCollapse m_keepaliveLog{10 * 60 * 1000};
+    LogCollapse m_keepaliveLog{LogCollapse::kChangesOnly};
+
+    // Elided writes — the MMR per-register cache and the ShotSettings payload compare, both above.
+    //
+    // The line has one real use, and it is worth keeping exactly once: it answers "I changed that
+    // setting and the machine ignored it" by showing the write was dropped as redundant and naming
+    // the caller. What has no use is the repeat. Convergent callers re-apply the same values at
+    // every phase transition and page activation, so one field session carried 65 of these, in
+    // bursts of four, every burst byte-identical to the last — the answer to a question nobody had
+    // asked yet, restated until it buried the writes that did go out.
+    //
+    // Keyed by the message TEXT, so the unit that prints once is the whole tuple (register or
+    // payload, value, calling reason). A different caller eliding the same value is a different
+    // line and still prints; the fortieth identical one does not.
+    //
+    // TWO instances, not one keyed across both. The key is the message text and the flush prints
+    // its keys, so a shared table would have to pick one helper for lines belonging to two
+    // different tags — sending [ShotSettings] text out under [MMR], which is precisely the
+    // "one grep returns the whole subsystem" invariant the marker gate exists to hold. Splitting
+    // the table is what keeps the flush able to name the right one.
+    // Episodic: a run is one connected session. Both flushed in onTransportDisconnected().
+    LogCollapse m_mmrSkipLog{LogCollapse::kChangesOnly};
+    LogCollapse m_shotSettingsSkipLog{LogCollapse::kChangesOnly};
     // Pending one-shot MMR reads keyed by address — covers both the
     // post-connect informational reads issued via issueMMRReadWithRetry().
     // Cleared when parseMMRResponse() sees a response for that address,
@@ -509,17 +533,45 @@ private:
     static constexpr int MMR_READ_TIMEOUT_MS = 4000;
     static constexpr int MMR_READ_MAX_RETRIES = 2;
     double m_waterLevel = 0.0;
-    double m_waterLevelMm = 0.0;  // Raw mm value (with sensor offset applied)
+    double m_waterLevelMm = 0.0;  // Smoothed mm value (sensor offset applied) — see parseWaterLevel
     int m_waterLevelMl = 0;       // Volume in ml (from CAD lookup table)
     double m_lastEmittedWaterLevel = -1.0;  // Throttle: only emit when change >= 0.5%
     int m_lastEmittedWaterLevelMl = -1;    // Throttle: also emit when ml changes (color thresholds)
-    // Last water level LOGGED, which is not the last one EMITTED. The signal has to follow the
-    // sensor closely (the refill warning and the tank colour band key off it), but the sensor
-    // dithers roughly +/-1 mm continuously and each 1 mm step is a ~28 ml step in the CAD table, so
-    // "changed" is true about twice a second forever: 2,828 log lines in a 48-hour capture, 14% of
-    // the whole log, describing a tank nobody touched. Logging gets its own hysteresis; emitting
-    // keeps the old behaviour.
+
+    // WHY THE LEVEL IS SMOOTHED AT ALL, and why a hysteresis alone was not enough.
+    //
+    // Two different disturbances ride on this sensor and only one of them was ever accounted for.
+    // The comment here used to describe "roughly +/-1 mm" of continuous dither, which is what the
+    // tank does at IDLE, and a 2 mm hysteresis is comfortably above it. Under the pump it sloshes,
+    // and a field log measured swings of 5.5 mm to 33.5 mm inside four seconds — every one of them
+    // clearing 2 mm, so during the only period anyone reads these lines the gate passed on
+    // essentially every sample. 220 lines in one 3.7-hour session, consecutive readings
+    // contradicting each other by 10 mm.
+    //
+    // Raising the threshold is the tempting fix and it is the wrong one: it would have to exceed
+    // the slosh amplitude, at which point it also swallows a slow drawdown, which is the one
+    // trend worth having. The disturbance differs from the signal in FREQUENCY, not amplitude —
+    // slosh is a second or two, a refill or a drawdown is not — so filter on that and leave the
+    // threshold where it was. An EMA at this alpha has a time constant near 3 s at the observed
+    // ~4 Hz sample rate: slosh is attenuated below the 2 mm gate, a refill still resolves within a
+    // few seconds, and a drawdown is untouched.
+    //
+    // The smoothed value feeds the PROPERTY as well as the log, deliberately. The refill warning
+    // and the tank colour band key off it, and both were being driven by a figure that swung a
+    // third of the tank twice a second while the machine ran. Stability is what they wanted; the
+    // cost is that a genuine step (tank lifted out) is reported ~3 s late, which no reading of a
+    // water tank depends on.
+    static constexpr double WATER_LEVEL_SMOOTHING_ALPHA = 0.08;
+    // Seeded from the first sample rather than ramped from zero — otherwise every connect shows the
+    // tank filling from empty over the filter's settling time.
+    bool m_waterLevelSeeded = false;
+
+    // Last water level LOGGED, which is not the last one EMITTED: the property follows every
+    // smoothed sample, the log speaks only on a 2 mm move. Both endpoints are kept so the line can
+    // state the DELTA it represents — a bare instantaneous reading cannot tell a reader whether
+    // 168 ml left the tank through the group or was never there.
     double m_lastLoggedWaterLevelMm = -1000.0;
+    int m_lastLoggedWaterLevelMl = -1;
     static constexpr double WATER_LEVEL_LOG_HYSTERESIS_MM = 2.0;
     QString m_firmwareVersion;
     int m_firmwareBuildNumber = 0;

--- a/src/core/batterymanager.h
+++ b/src/core/batterymanager.h
@@ -182,9 +182,11 @@ private:
     int  m_chargingMismatchCount = 0;
     bool m_chargingMismatch      = false;  // true while mismatch signal is active
 
-    // One line per window while the poll result is unchanged; a change emits at
-    // once. 15 min: the poll runs every ~60 s and a plugged-in tablet never
-    // varies, so the window only decides how often "still the same" is restated.
-    // Periodic: polls for the process lifetime, so there is no run end and nothing to flush.
-    LogCollapse m_pollCollapse{15 * 60 * 1000};
+    // Nothing while the poll result is unchanged; a change emits at once, carrying the count of
+    // identical polls it stood for. The poll runs every ~60 s and a plugged-in tablet never varies
+    // — the 643 byte-identical lines cited above were 2.5% of a user's log, and a window only chose
+    // how many of them survived rather than whether any of them said anything.
+    // Periodic: polls for the process lifetime, so there is no run end and nothing to flush. The
+    // pending tally is not lost by that: it rides out on the next line whose text differs.
+    LogCollapse m_pollCollapse{LogCollapse::kChangesOnly};
 };

--- a/src/core/logcollapse.h
+++ b/src/core/logcollapse.h
@@ -5,8 +5,13 @@
 #include <QPair>
 #include <QString>
 
-// Collapses a repeating log line to one entry per window, carrying the count of what it stood in
-// for.
+#include <limits>
+
+// Collapses a repeating log line, carrying the count of what it stood in for.
+//
+// Two modes, and kChangesOnly is the one a periodic source wants: an unchanged line never repeats,
+// however long it has been. A window (the other mode) is for a source already gated on a problem,
+// where the repeat is itself evidence. See kChangesOnly for which is which and why.
 //
 // WHY THIS EXISTS AS ONE CLASS
 // ----------------------------
@@ -52,9 +57,33 @@ public:
     // compiler said so (-Wunused-private-field). An enum nobody reads is a comment with a type, so
     // this is the comment.
 
+    // A window meaning "an unchanged line is never worth repeating, at any spacing".
+    //
+    // This is the DEFAULT for a periodic source, and every periodic caller in the tree uses it. A
+    // window was the original design and it was the wrong unit: it asks "how often may this line
+    // repeat" when the question is "does a repeat carry anything". For a source whose text is
+    // unchanged the answer does not improve with elapsed time — a byte-identical charger keepalive
+    // an hour after the last one tells a reader exactly what the last one did, and costs a line of
+    // a ring buffer that has to hold everything else. Six lines an hour is not noticeably better
+    // than six hundred when none of them say anything.
+    //
+    // What replaces the periodic reassurance is the pair that always did the work: a CHANGED line,
+    // which emits at once, and the run-end flush, which prints the tally. Between them the reader
+    // gets the transition and the count it stood for, and nothing in between. The cost is that
+    // silence no longer distinguishes "healthy" from "stopped" until the flush — accepted
+    // deliberately, because for all five callers a death is visible in lines this one does not own
+    // (a disconnect, a broker error, a server stop).
+    //
+    // A source that is already gated on a PROBLEM does not want this and must keep a real window:
+    // its repeats are evidence, not reassurance. BleGattQueue's dispatch line is the one such
+    // caller — it speaks only above a foreign-wait threshold, within episodes lasting under a
+    // second, so a window is what separates two operations inside one stall.
+    static constexpr qint64 kChangesOnly = std::numeric_limits<qint64>::max();
+
     // `windowMs` is the minimum spacing between emitted lines for a given key while the text is
-    // unchanged. A CHANGED text always emits immediately regardless of the window — a value that
-    // moved is the interesting event, and holding it back is how a collapser turns into a bug.
+    // unchanged, or kChangesOnly to never repeat one. A CHANGED text always emits immediately
+    // regardless of the window — a value that moved is the interesting event, and holding it back
+    // is how a collapser turns into a bug.
     explicit LogCollapse(qint64 windowMs) : m_windowMs(windowMs) {}
 
 
@@ -75,7 +104,12 @@ public:
     {
         Entry& e = m_entries[key];
         const bool changed = (e.text != text);
-        const bool windowElapsed = (nowMs - e.lastEmitMs) >= m_windowMs;
+        // Spelled as an explicit branch rather than leaning on kChangesOnly being unreachably
+        // large. The comparison would in fact never fire, but a sentinel that works by arithmetic
+        // accident is one refactor away from a subtraction that wraps, and this reads as what it
+        // means at no cost.
+        const bool windowElapsed =
+            (m_windowMs != kChangesOnly) && (nowMs - e.lastEmitMs) >= m_windowMs;
 
         if (!e.everEmitted || changed || windowElapsed) {
             if (out)

--- a/src/core/memorymonitor.h
+++ b/src/core/memorymonitor.h
@@ -75,10 +75,14 @@ private:
     int m_lastQObjectCount = 0;
     bool m_firstSample = true;
 
-    // Collapses the per-sample log line while a plateau holds — see onSampleTimerTick(). Sampling
-    // itself is untouched; this only decides whether the sample is worth a line.
-    // Periodic: samples for the process lifetime, so there is no run end and nothing to flush.
-    LogCollapse m_logCollapse{10 * 60 * 1000};
+    // Silences the per-sample log line while a plateau holds — see onSampleTimerTick(). Sampling
+    // itself is untouched; this only decides whether the sample is worth a line, and a plateau is
+    // not: an RSS figure identical to the last one is what "nothing is leaking" looks like, and it
+    // does not become news by being restated 60 times an hour.
+    // Periodic: samples for the process lifetime, so there is no run end and nothing to flush. That
+    // is not a lost tally under kChangesOnly — the count and span ride out on the next line whose
+    // text DIFFERS, which for a memory sampler is exactly the sample a reader came for.
+    LogCollapse m_logCollapse{LogCollapse::kChangesOnly};
     // RSS as of the last line PRINTED — the anchor the 5 MB band is measured from, so a value
     // sitting on a fixed bucket edge cannot oscillate across it. Negative until the first line.
     double m_lastLoggedRssMB = -1.0;

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -1302,7 +1302,8 @@ void McpServer::handleModernRequest(QTcpSocket* socket, const QJsonObject& reque
     resultMeta[QLatin1String(kMetaServerInfo)] =
         QJsonObject{{"name", "Decenza MCP Server"},
                     {"version", QString::fromLatin1(McpSurfaceVersion)},
-                    {"appVersion", QStringLiteral(VERSION_STRING)}};
+                    {"appVersion", QStringLiteral(VERSION_STRING)},
+                    {"buildNumber", versionCode()}};
     result[QLatin1String(kMetaKey)] = resultMeta;
 
     QJsonObject response{{"jsonrpc", "2.0"},
@@ -1696,6 +1697,7 @@ QJsonObject McpServer::handleInitialize(const QJsonObject& params, McpSession* s
     // identical across the change that halved its tool list.
     serverInfo["version"] = QString::fromLatin1(McpSurfaceVersion);
     serverInfo["appVersion"] = QStringLiteral(VERSION_STRING);
+    serverInfo["buildNumber"] = versionCode();
 
     // Negotiate protocol version — accept what the client requests if we support it,
     // otherwise return our preferred version (the first entry).

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -73,7 +73,11 @@ struct PendingConfirmation {
 // action added to a merged tool, an argument that changes meaning. It is not the app
 // version and does not follow it: 2.0.2 shipped a 97-tool server and then a 66-tool
 // one, and a client reporting the app version would have shown the same string for
-// both. `serverInfo.appVersion` carries the build alongside it.
+// both. `serverInfo.appVersion` carries the app version alongside it, and
+// `serverInfo.buildNumber` the build -- appVersion is NOT the build and never was:
+// v2.0.4 shipped as 3552, 3553 and 3554, because a pre-release is re-cut against a
+// rolling version. This comment used to say appVersion carried the build; a field
+// diagnosis was then unable to tell whether the fix it was chasing was present.
 //
 // This is a correctness obligation before it is anything else. The handshake is
 // where a server states what it is, and a server whose surface has changed while
@@ -93,7 +97,7 @@ struct PendingConfirmation {
 // scripts/check_mcp_tool_budget.py fingerprints the registered tools and their
 // actions and fails the PR if the surface moved without this string moving, so the
 // rule above is enforced rather than remembered.
-inline constexpr const char* McpSurfaceVersion = "1.2.0";
+inline constexpr const char* McpSurfaceVersion = "1.3.0";
 // Fingerprint of the tool surface this version was recorded against. Update it in
 // the same edit as the version; the check prints the value to paste.
 inline constexpr const char* McpSurfaceFingerprint = "8ada4d203b66";

--- a/src/mcp/mcptools_machine.cpp
+++ b/src/mcp/mcptools_machine.cpp
@@ -171,13 +171,20 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
     // unchanging fields per response (#988).
     registry->registerTool(
         "app_get_info",
-        "Get app and device info: appVersion, qtVersion, OS, kernel, architecture, "
-        "deviceModel, screen size/DPI, devicePixelRatio. Diagnostics-grade — call once "
-        "per session, not every poll. machine_get_state used to embed this block.",
+        "Get app and device info: appVersion, buildNumber, qtVersion, OS, kernel, "
+        "architecture, deviceModel, screen size/DPI, devicePixelRatio. buildNumber is "
+        "what identifies a build — one appVersion can ship many. Diagnostics-grade — "
+        "call once per session, not every poll.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
         [](const QJsonObject&) -> QJsonObject {
             QJsonObject platform;
             platform["appVersion"] = QString(VERSION_STRING);
+            // appVersion alone does not identify a build. v2.0.4 shipped three times
+            // (3552, 3553, 3554) with materially different code -- pre-releases are
+            // re-cut against a rolling version, and the release notes already carry a
+            // `Build:` line for exactly this reason. Without it, a field diagnosis over
+            // MCP cannot tell whether a fix under investigation is even present.
+            platform["buildNumber"] = versionCode();
             platform["qtVersion"] = QString(qVersion());
             platform["os"] = QSysInfo::prettyProductName().simplified();
             platform["osType"] = QSysInfo::productType();

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -165,13 +165,14 @@ private:
     // rather than every 15 minutes for as long as the broker stays away.
     bool m_slowRetryAnnounced = false;
 
-    // One line per window while a repeating message is unchanged; a changed
-    // message emits at once. 10 min: a broker that is down stays down for hours,
-    // and the retry ladder already has its own one-shot "backing off" warning, so
-    // this only decides how often "still down, same reason" is restated.
+    // Nothing while a repeating message is unchanged; a changed message emits at once. A broker
+    // that is down stays down for hours with one unvarying reason, and the retry ladder already has
+    // its own one-shot "backing off" warning — so restating "still down, same reason" on any
+    // cadence adds a line count, not a diagnosis. The first failure prints, the recovery prints,
+    // and the recovery carries how many attempts fell in between.
     // Episodic: a run is one connection attempt sequence. Flushed on a successful connect in
     // onConnected() — the only caller that got this right before the others were audited.
-    LogCollapse m_logCollapse{10 * 60 * 1000};
+    LogCollapse m_logCollapse{LogCollapse::kChangesOnly};
     // A stop the user asked for is not a fault, so it must not re-arm the retry loop.
     //
     // INVARIANT: this may only be true while a disconnect callback is actually pending.

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -149,11 +149,14 @@ private slots:
     void onThemeChanged();
 
 private:
-    // Collapses repeated identical request lines — see handleRequest(). One minute, not the ten
-    // used by the periodic samplers: a request is user-driven, so a path that has been quiet
-    // should log the moment it comes back.
-    // Episodic: a run is one server lifetime. Flushed in stop().
-    LogCollapse m_requestLog{60 * 1000};
+    // Collapses repeated identical request lines — see handleRequest(). Keyed BY the line, so a
+    // path is logged the first time it is requested in a server run and not again; a different
+    // path is a different key and prints at once. That is the whole value of the line — which
+    // endpoints this run touched — and a poller re-fetching one of them every 5 s adds nothing to
+    // it however long it keeps going.
+    // Episodic: a run is one server lifetime. Flushed in stop(), which is where the per-path counts
+    // are reported.
+    LogCollapse m_requestLog{LogCollapse::kChangesOnly};
 
     void handleRequest(QTcpSocket* socket, const QByteArray& request);
     void sendResponse(QTcpSocket* socket, int statusCode, const QString& contentType,

--- a/tests/tst_de1device_headless.cpp
+++ b/tests/tst_de1device_headless.cpp
@@ -17,6 +17,11 @@
 // Error_NoAC can pin the front-standby-switch warning up forever, even after
 // the switch is flipped back and the app reconnects. Same shape as the
 // headless reset above, different field.
+//
+// And the water-level filter, which is here rather than in a file of its own because a new test
+// TU costs ~1.4 s of every clean build forever while a slot in an existing one costs milliseconds
+// (see TESTING.md). It shares this file's fixture: a DE1Device on a MockTransport, driven by
+// feeding characteristic payloads.
 
 class tst_DE1DeviceHeadless : public QObject {
     Q_OBJECT
@@ -28,12 +33,83 @@ private:
         TestFixture() { device.setTransport(&transport); }
     };
 
+    // Build a WaterLevels payload reading `mm` at the sensor, i.e. before the +5 mm mount offset
+    // the parser adds. U16P8 big-endian.
+    static QByteArray waterPayload(double sensorMm) {
+        const uint16_t raw = static_cast<uint16_t>(sensorMm * 256.0 + 0.5);
+        QByteArray d;
+        d.append(static_cast<char>((raw >> 8) & 0xFF));
+        d.append(static_cast<char>(raw & 0xFF));
+        return d;
+    }
+
 private slots:
     void init() { QTest::failOnWarning(); }
     void defaultsToHeadless() {
         // A freshly constructed device (no GHC read yet) must allow app starts.
         DE1Device device;
         QCOMPARE(device.isHeadless(), true);
+    }
+
+    // ---- Water level filtering (see DE1Device::parseWaterLevel) ----
+
+    // The first sample IS the level. Without the seed the EMA ramps from zero and every connect
+    // shows the tank filling over the filter's settling time — visible on screen, not just in
+    // the log, because the property is driven from the same value.
+    void waterLevelSeedsFromFirstSample() {
+        TestFixture f;
+        f.device.parseWaterLevel(waterPayload(30.0));
+        QCOMPARE(f.device.waterLevelMm(), 35.0);  // 30 at the sensor + 5 mm offset
+    }
+
+    // The defect this whole change exists for: under the pump the tank sloshes, a field log showed
+    // 5.5 mm to 33.5 mm inside four seconds, and a 2 mm hysteresis on the INSTANTANEOUS reading
+    // passed on essentially every sample. Feed that waveform and nothing may reach the log.
+    //
+    // Deliberately asserted on m_lastLoggedWaterLevelMm rather than on captured output: it is the
+    // gate's own state, so the test fails if the gate is removed, widened past the slosh, or fed
+    // the raw sample again — and does not care how the line is worded.
+    void sloshDoesNotReachTheLog() {
+        TestFixture f;
+        f.device.parseWaterLevel(waterPayload(20.0));
+        const double afterFirst = f.device.m_lastLoggedWaterLevelMm;
+
+        // +/-10 mm about a level that is not actually changing, 60 samples (~15 s at 4 Hz).
+        for (int i = 0; i < 60; ++i)
+            f.device.parseWaterLevel(waterPayload(i % 2 == 0 ? 30.0 : 10.0));
+
+        QCOMPARE(f.device.m_lastLoggedWaterLevelMm, afterFirst);
+        // ...and the filtered level stayed at the true mean rather than chasing either extreme.
+        QVERIFY(qAbs(f.device.waterLevelMm() - 25.0) < 2.0);
+    }
+
+    // The other half, and the reason a bigger threshold was not the fix: a REAL move still has to
+    // arrive. A refill is a sustained step, so the filter must follow it and the gate must fire.
+    void aSustainedRefillStillLogs() {
+        TestFixture f;
+        f.device.parseWaterLevel(waterPayload(10.0));
+        const double afterFirst = f.device.m_lastLoggedWaterLevelMm;
+
+        for (int i = 0; i < 60; ++i)
+            f.device.parseWaterLevel(waterPayload(40.0));
+
+        QVERIFY(f.device.m_lastLoggedWaterLevelMm > afterFirst + 20.0);
+    }
+
+    // A reconnect must not measure its first delta against the previous session, nor ramp from the
+    // old average. Both endpoints are cleared with the seed.
+    void disconnectResetsTheWaterFilter() {
+        TestFixture f;
+        f.device.parseWaterLevel(waterPayload(40.0));
+        QVERIFY(f.device.m_waterLevelSeeded);
+
+        f.device.onTransportDisconnected();
+        QVERIFY(!f.device.m_waterLevelSeeded);
+        QCOMPARE(f.device.m_lastLoggedWaterLevelMl, -1);
+
+        // Re-seeds at the new level rather than easing across from 45 mm.
+        f.device.parseWaterLevel(waterPayload(10.0));
+        QCOMPARE(f.device.waterLevelMm(), 15.0);
     }
 
     void disconnectRestoresHeadless() {

--- a/tests/tst_logcollapse.cpp
+++ b/tests/tst_logcollapse.cpp
@@ -4,10 +4,15 @@
 
 #include "core/logcollapse.h"
 
-// LogCollapse decides whether a repeating log line is worth printing. Three periodic sources share
-// it (the MMR keepalive, the memory sampler, the ShotServer request log), which is exactly why the
-// rules are pinned here: a change that makes it slightly more eager to suppress would go unnoticed
-// in the app and quietly cost the next log reader the line they needed.
+// LogCollapse decides whether a repeating log line is worth printing. Every periodic source in the
+// tree shares it (the MMR keepalive, the memory sampler, the battery poll, the ShotServer request
+// log, MQTT's retry ladder), which is exactly why the rules are pinned here: a change that makes it
+// slightly more eager to suppress would go unnoticed in the app and quietly cost the next log
+// reader the line they needed.
+//
+// Two modes, and both are pinned. kChangesOnly is what those five use — an unchanged line never
+// repeats at any spacing — while a finite window remains for the one caller whose repeats are
+// themselves evidence (BleGattQueue's dispatch line, gated on a foreign-wait threshold).
 //
 // The clock is a parameter, not a QElapsedTimer, so every case below is exact and instant.
 class tst_LogCollapse : public QObject
@@ -44,6 +49,52 @@ private slots:
         // Count resets after being reported, so it is a per-window figure and never cumulative.
         QVERIFY(!c.shouldLog("k", "same", 61'000, &c2));
         QVERIFY(c.shouldLog("k", "same", 120'000, &c2));
+        QCOMPARE(c2.suppressed, 1);
+    }
+
+    // kChangesOnly: no elapsed time is ever enough to re-print an unchanged line. The failure this
+    // guards is a regression to window semantics via some "sensible maximum" clamp — which would
+    // look harmless, pass every other case here, and put a keepalive back in the log every N hours.
+    void changesOnlyNeverRepeatsAnUnchangedLine()
+    {
+        LogCollapse c(LogCollapse::kChangesOnly);
+        LogCollapse::Collapsed c2;
+        QVERIFY(c.shouldLog("k", "same", 0, &c2));
+
+        // Ten hours, a day, and a week later: still nothing.
+        QVERIFY(!c.shouldLog("k", "same", 10LL * 60 * 60 * 1000, &c2));
+        QVERIFY(!c.shouldLog("k", "same", 24LL * 60 * 60 * 1000, &c2));
+        QVERIFY(!c.shouldLog("k", "same", 7LL * 24 * 60 * 60 * 1000, &c2));
+    }
+
+    // ...and the tally is not lost by that silence. This is what makes kChangesOnly safe for the
+    // two callers that never flush (the memory sampler, the battery poll): the count and the span
+    // ride out on the next line whose text differs, which is the line a reader wanted anyway.
+    void changesOnlyStillReportsTheTallyOnTheNextChange()
+    {
+        LogCollapse c(LogCollapse::kChangesOnly);
+        LogCollapse::Collapsed c2;
+        QVERIFY(c.shouldLog("k", "before", 0, &c2));
+
+        constexpr qint64 kMinute = 60'000;
+        for (int i = 1; i <= 180; ++i)
+            QVERIFY(!c.shouldLog("k", "before", i * kMinute, &c2));
+
+        QVERIFY(c.shouldLog("k", "after", 181 * kMinute, &c2));
+        QCOMPARE(c2.suppressed, 180);
+        QCOMPARE(c2.spanMs, 181 * kMinute);
+    }
+
+    // The finite window still behaves exactly as it did. BleGattQueue depends on it, and the
+    // sentinel is a comparison against m_windowMs — get that branch wrong and every windowed caller
+    // silently becomes changes-only, which no case above would catch.
+    void finiteWindowIsUnaffectedByTheSentinel()
+    {
+        LogCollapse c(60'000);
+        LogCollapse::Collapsed c2;
+        QVERIFY(c.shouldLog("k", "same", 0, &c2));
+        QVERIFY(!c.shouldLog("k", "same", 59'999, &c2));
+        QVERIFY(c.shouldLog("k", "same", 60'000, &c2));
         QCOMPARE(c2.suppressed, 1);
     }
 

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -330,6 +330,12 @@ private slots:
         QVERIFY2(info["version"].toString() != info["appVersion"].toString()
                      || QString::fromLatin1(McpSurfaceVersion) == QString(VERSION_STRING),
                  "surface version and app version are separate facts");
+        // The build, which appVersion does NOT carry: v2.0.4 shipped as 3552, 3553 and
+        // 3554. Without this a client cannot tell which code it is talking to, and a
+        // field diagnosis cannot establish whether the fix under investigation is even
+        // present -- which is exactly what happened before this field existed.
+        QCOMPARE(info["buildNumber"].toInt(), versionCode());
+        QVERIFY2(info["buildNumber"].toInt() > 0, "buildNumber must be a real build");
     }
 
     // The server-level `instructions` field (#1162) is emitted unconditionally,

--- a/tests/tst_mmrwrite.cpp
+++ b/tests/tst_mmrwrite.cpp
@@ -1,6 +1,8 @@
 #include <QtTest>
 #include <QRegularExpression>
 
+#include <utility>
+
 #include "ble/de1device.h"
 #include "ble/protocol/de1characteristics.h"
 #include "mocks/MockTransport.h"
@@ -23,6 +25,44 @@ private:
         TestFixture() {
             device.setTransport(&transport);
         }
+    };
+
+    // Counts emitted debug lines containing `needle`, for the cases whose whole point is HOW MANY
+    // lines came out.
+    //
+    // QTest::ignoreMessage cannot express that. It consumes one message per call, so "exactly one"
+    // has to be written as one ignoreMessage plus a silent hope that a second never arrived —
+    // unhandled debug output is not a failure. burstDeduplication was written the other way round,
+    // queueing 29 ignoreMessages, and that shape only ever fails when TOO FEW lines arrive: it
+    // pinned the noisy behaviour as the expected one and would have passed unchanged had the count
+    // gone to 300. Counting fails in both directions.
+    class MessageCounter {
+    public:
+        explicit MessageCounter(QString needle) : m_needle(std::move(needle)) {
+            s_active = this;
+            m_prev = qInstallMessageHandler(&MessageCounter::handle);
+        }
+        ~MessageCounter() {
+            qInstallMessageHandler(m_prev);
+            s_active = nullptr;
+        }
+        MessageCounter(const MessageCounter&) = delete;
+        MessageCounter& operator=(const MessageCounter&) = delete;
+        int count() const { return m_count; }
+
+    private:
+        static void handle(QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
+            if (s_active && msg.contains(s_active->m_needle)) {
+                s_active->m_count++;
+                return;  // swallowed, so it cannot also read as unexpected output
+            }
+            if (s_active && s_active->m_prev)
+                s_active->m_prev(type, ctx, msg);
+        }
+        QString m_needle;
+        int m_count = 0;
+        QtMessageHandler m_prev = nullptr;
+        static inline MessageCounter* s_active = nullptr;
     };
 
 private slots:
@@ -87,21 +127,42 @@ private slots:
     }
 
     void burstDeduplication() {
-        // Emulate the applyFlushSettings burst: 30 identical calls should
-        // produce exactly 1 BLE write and 29 skip log lines. Suppress all 29
-        // — QTest::ignoreMessage matches only the next emission per call, so
-        // without a loop the remaining 28 would print as unexpected-debug
-        // noise.
+        // Emulate the applyFlushSettings burst: 30 identical calls, one BLE write.
+        //
+        // And ONE log line, not 29. The elided-write line answers "the machine ignored my setting
+        // because the value was already that" — true and useful the first time, and unchanged by
+        // being restated 28 more times in the same burst. A field session carried 65 of these in
+        // bursts of four, every burst byte-identical to the last.
+        //
+        // Both counts are asserted because the two failure modes are opposite and a test that
+        // checks one hides the other: collapsing too little puts the noise back, and collapsing
+        // the WRITE would break the machine.
         TestFixture f;
-        for (int i = 0; i < 29; ++i) {
-            QTest::ignoreMessage(QtDebugMsg,
-                QRegularExpression("\\[MMR\\] write skipped"));
-        }
+        MessageCounter skips(QStringLiteral("[MMR] write skipped"));
 
         for (int i = 0; i < 30; ++i) {
             f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);
         }
         QCOMPARE(f.transport.writes.size(), 1);
+        QCOMPARE(skips.count(), 1);
+    }
+
+    // The collapse is per (register, value, caller), not per register: a DIFFERENT caller eliding
+    // the same value is a different answer to "who tried and was ignored", and that is the whole
+    // content of the line. Losing it would make the surviving line name whichever caller happened
+    // to be first.
+    void skipLineDistinguishesCallers() {
+        TestFixture f;
+        MessageCounter skips(QStringLiteral("[MMR] write skipped"));
+
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150, QStringLiteral("applySteamSettings"));
+        for (int i = 0; i < 5; ++i)
+            f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150, QStringLiteral("applySteamSettings"));
+        for (int i = 0; i < 5; ++i)
+            f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150, QStringLiteral("steampage-activated"));
+
+        QCOMPARE(f.transport.writes.size(), 1);
+        QCOMPARE(skips.count(), 2);  // one per caller, not one per call and not one overall
     }
 
     // ===== Force path (USB charger keepalive semantics) =====


### PR DESCRIPTION
## Why

A 3.7-hour field session on the tablet produced 2,293 log lines. The DE1 subsystem's 436 broke down as:

| lines | % | source |
|---|---|---|
| 220 | 50% | `[DE1][WaterLevel]` |
| 65 | 15% | `write skipped: … unchanged` |
| 53 | 12% | `[DE1][BLEManager] Scanning / Scan complete` |
| 35 | 8% | `[DE1][MMR] keepalive` |

Only the keepalive was throttled at all, and none of these told a reader anything the previous copy of the same line had not. The log is a ring buffer that has to hold every other subsystem's history, and it is how device problems are diagnosed after the fact from a user's upload.

## `LogCollapse::kChangesOnly`

An unchanged line now never repeats, at any spacing. A window was the wrong unit: it asks how often a line may repeat, when the question is whether the repeat carries anything. A byte-identical charger keepalive an hour after the last one tells a reader exactly what the last one did.

A change still prints immediately, carrying the count of identical lines it stood for, so the transition and its tally both survive — only the reassurance in between is gone. The accepted cost is that silence no longer distinguishes "healthy" from "stopped" until the run-end flush; for all five callers a death is visible in lines this one does not own (a disconnect, a broker error, a server stop).

Five periodic callers move onto it: the MMR charger keepalive, the memory sampler, the battery poll, the ShotServer request log, and MQTT's retry ladder.

**`BleGattQueue`'s dispatch line deliberately keeps a finite window.** It only speaks above a foreign-wait threshold, so its repeats are evidence rather than reassurance, and its episodes last under a second — a window is what separates two operations inside one stall.

## Elided writes

The two `write skipped` lines are collapsed the same way, but **keyed by the whole message**, so a different caller eliding the same value still prints. "Who tried and was ignored" is the entire content of that line, and it is a real answer to "I changed that setting and the machine ignored it" — worth exactly once, not the 65 times a session produced it in byte-identical bursts of four.

Two collapser instances rather than one, because the key is the message text and the flush prints its keys: a shared table would have to send `[ShotSettings]` text out under `[MMR]`, breaking the one-grep-per-subsystem invariant the marker gate exists to hold.

## Water level

The 2 mm hysteresis was tuned for the sensor's idle dither, which is roughly ±1 mm and what the old comment described. Under the pump the tank sloshes — measured at 5.5 mm to 33.5 mm inside four seconds — so during the only period anyone reads these lines the gate passed on essentially every sample, with consecutive readings contradicting each other by 10 mm.

Raising the threshold is the tempting fix and the wrong one: it would have to exceed the slosh amplitude, at which point it also swallows a slow drawdown, which is the one trend worth having. The disturbance differs from the signal in **frequency**, not amplitude, so the filter goes there: an EMA with a ~3 s time constant at the observed ~4 Hz sample rate, seeded from the first sample (otherwise every connect shows the tank filling from empty) and reset on disconnect.

The smoothed value feeds the **property** as well as the log, deliberately. The refill warning and the tank colour band key off it, and both were being driven by a figure that swung a third of the tank twice a second while the machine ran. The cost is that a genuine step (tank lifted out) is reported ~3 s late.

Surviving lines carry the delta and the machine state:

```
[DE1][WaterLevel] 732 -> 564 ml (-168 ml, 27.3 -> 21.2 mm) [Espresso]
```

A bare reading cannot tell a reader whether 168 ml left through the group or was never there. The state is the machine's, **not** a classification of the event — the tempting version tags a large positive delta `[refill]`, but that is a guess with a threshold behind it, and a reader given `+616 ml [Idle]` can draw the same conclusion from evidence.

`raw` is dropped from the water and phase lines. It was the corrected value minus a compile-time `SENSOR_OFFSET`, so the two could never disagree; the phase line proved it by reconstructing raw as `m_waterLevelMm - 5.0` rather than reading a stored value.

## Also carried

The MCP build-number change, at the maintainer's request rather than as a separate PR: `serverInfo` gains `buildNumber`. `appVersion` is not the build and never was — v2.0.4 shipped as 3552, 3553 and 3554, because a pre-release is re-cut against a rolling version — and a field diagnosis was unable to tell whether the fix it was chasing was present. `McpSurfaceVersion` 1.2.0 → 1.3.0 with the fingerprint, per the budget check.

## Tests

`tst_mmrwrite::burstDeduplication` went red, and it deserved to: it asserted **29** skip lines, which pinned the noisy behaviour as the expected one and could only ever fail if too *few* lines arrived — it would have passed unchanged had the count gone to 300. It now counts emitted lines through a scoped message handler, so it fails in both directions, and a companion case pins that two different callers still produce two lines rather than one.

Four new cases cover the water filter (seeding, slosh rejection, that a sustained refill still logs, and the disconnect reset) and three cover `kChangesOnly` — including one asserting the finite window is unaffected, since the sentinel is a comparison against `m_windowMs` and getting that branch wrong would silently make every windowed caller changes-only.

All new assertions were verified by reverting the fix and watching them fail at exactly the pre-fix numbers: 29 skip lines, 10 for the caller case, and a logged water level chasing slosh to 15 mm instead of holding at 25.

Tests live in existing files. A new test TU costs ~1.4 s of every clean build forever while a slot in an existing one costs milliseconds.

**113/113 pass, no warnings.** Build clean. The three build-free gates (`check_log_markers`, `check_test_source_duplication`, `check_mcp_tool_budget`) all pass.

## Not in this PR

`[DE1][BLEManager] Scanning / Scan complete` cycles every 15 s while the DE1 is already connected — 53 lines a session. Deliberately **not** silenced: scanning while connected costs radio time during shots, so the lines are reporting something worth fixing rather than noise to suppress. Separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
