### PR TITLE
ci: run the keep-1 cache dedupe ungated so releases stop evicting the nightly ccache

### DIFF
--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -21,32 +21,46 @@ name: Prune stale compiler caches
 # strands stale entries.
 #
 # That gate applies to three of the four steps. The keep-1 dedupe step runs
-# UNGATED, because waiting is what was costing us the thing the gate protects.
+# UNGATED, and the reason is a timing one, so state it precisely: the gate does
+# not stop the cleanup from happening, it delays it past the point where the
+# damage is already done and irreversible.
 #
-# Measured 2026-08-21. A release fires all six builds at once; each saves a
-# second copy of its prefix while the gate holds prune off, and the repo goes
-# over the 10 GB cap mid-release — 11.10 GB across 19 entries, of which 2.7 GB
-# was four duplicate pairs (macOS 1843+1777, Android 646+622, Windows sccache
-# 241+225, Linux arm64 77+63). Four prune runs fired during that window and all
-# four skipped: "5 build workflow(s) still active", then 4, 3, 2. GitHub evicts
-# to get back under the cap, and what it takes is the least recently used LIVE
-# entry — always `ccache-sanitizers-*`, because every other entry is tag-scoped
-# and rewritten on each release while the nightly's two are touched once every
-# 24 h. The 2026-08-20 release ran 20:25-20:33; by 04:57 the next morning the
-# ubsan leg restored "No cache found." and built cold at 9.45% hits (83/878,
-# 0 direct) against asan's 74.37%. There was no garbage to collect either — that
-# night's prune reported 0 superseded-tag and 0 main-scoped entries. The cleanup
-# was not failing to find stale caches; it was gated off exactly when the cap
-# was exceeded.
+# A release fires all six builds at once and each saves a SECOND copy of its
+# prefix. For the ~14 minutes until the last one finishes, the gate holds prune
+# off and the store carries every duplicate at once — over GitHub's 10 GB cap.
+# GitHub evicts to get back under it, and what it takes is the least recently
+# used LIVE entry. That is always a `ccache-sanitizers-*` entry: every other
+# entry is tag-scoped and rewritten on each release, while the nightly's two are
+# touched once every 24 h. Eviction is not undone by the prune that follows.
 #
-# Then it happened again while that was being written, on the opposite leg. The
-# v2.0.4 release fired 16:10-16:21 the same day; the store peaked at 11.10 GB,
-# GitHub evicted, and the ASAN entry (1199 MB) went while ubsan's survived. At
-# 16:30 the store held 9.98 GB with 3031 MB of collectable duplicates still in
-# it — android 593, iOS 470, linux-arm64 60, macOS 1694, Windows sccache 214 —
-# because one build was still in progress and the gate was still holding. The
-# duplicates and the eviction are the same event; which sanitizer leg pays is
-# arbitrary.
+# Two evictions, two different legs, on consecutive days:
+#
+#   2026-08-20  v2.0.4 builds created 20:20, finished 20:25-20:34 (run times,
+#               not cache save times). Prune 32414785391 fired at 20:34 once
+#               the last build was done, said "No build workflows active —
+#               pruning" and collected the duplicates — but by then the store
+#               had been over cap for fourteen minutes. Next morning at 04:57
+#               the nightly's UBSAN leg restored "No cache found." and built
+#               cold: 83/878 hits (9.45%, 0 direct) against asan's 653/878
+#               (74.37%). Nothing in THIS workflow removed it — the keep-1 step
+#               only collects an entry that has a newer sibling, and the
+#               main-scope step excludes `ccache-sanitizers-*` by name. It was
+#               evicted, and the over-cap window is the only thing that evicts.
+#
+#   2026-08-21  v2.0.4 re-tagged, builds created 16:10, finishing 16:14-16:21.
+#               Store peaked at 11.10 GB across 19 entries, 2.7 GB of it four
+#               duplicate pairs (macOS 1843+1777, Android 646+622, Windows
+#               sccache 241+225, Linux arm64 77+63). Four prunes fired inside
+#               the window and all four skipped: "5 build workflow(s) still
+#               active", then 4, 3, 2. This time ASAN's 1199 MB entry was
+#               evicted and ubsan's survived; which leg pays is arbitrary. At
+#               16:30, with one build still running, the store still held
+#               9.98 GB and 3031 MB of collectable duplicates.
+#
+# Neither night had any garbage to collect: those prunes reported 0 entries on
+# superseded tags and 0 main-scoped platform entries. The cleanup was not
+# failing to find stale caches. It was standing down for the fourteen minutes
+# in which the cap was exceeded, and cleaning up afterwards.
 #
 # Keep-1 is safe ungated because it is self-limiting: it deletes only where a
 # NEWER entry of the same (prefix, ref) already exists, so a build that has not
@@ -72,8 +86,13 @@ on:
       - 'Linux ARM64 AppImage Build'
       # Added when the sanitizer nightly gained a ccache: it now writes two
       # timestamped entries a night, so it needs pruning like any other. It is
-      # also in the gate regex below, so a prune cannot run while it is still
-      # building and miss the cache it is about to save.
+      # also in the gate regex below — which now covers only the three gated
+      # steps. The keep-1 dedupe step CAN run while the nightly is building, and
+      # is safe there for its own reason rather than the gate's: the two legs
+      # use distinct key prefixes (`sanitizers-asan-…`, `sanitizers-ubsan-…`),
+      # so a leg that has not saved yet has a single entry in its group and
+      # nothing is deleted for it. Do not restore "a prune cannot run while it
+      # is still building" here; it stopped being true.
       - 'Nightly sanitizers'
     types: [completed]
   # Nearly all builds run on TAG pushes, and GitHub's docs don't clearly
@@ -90,7 +109,15 @@ permissions:
 
 concurrency:
   group: prune-caches
-  cancel-in-progress: true
+  # NOT cancel-in-progress. That was right while every run during a release
+  # exited at the gate in ~2 s and the only pass that did work was the last one.
+  # The keep-1 dedupe step now runs on every trigger, and cancelling a run
+  # mid-delete-loop is exactly the pass that would have reclaimed space early —
+  # two builds finishing in the same minute (16:15 twice on 2026-08-21) is
+  # enough to lose one. Queueing instead serialises them, which also means two
+  # prunes never race to delete the same entry. Each pass is ~10 s and
+  # idempotent, so a queue of six during a release costs nothing.
+  cancel-in-progress: false
 
 jobs:
   prune:
@@ -147,6 +174,13 @@ jobs:
             echo "::error::Could not list caches — the keep-1 dedupe did NOT run."
             exit 1
           fi
+          # --limit 500 is gh's ceiling and truncation is invisible. The listing
+          # is ordered by last-accessed descending, so what falls off the end is
+          # precisely the superseded copies this step collects — it would report
+          # a clean store while the duplicates sat below the cut.
+          if [ "$(printf '%s' "$RAW" | jq length)" -ge 500 ]; then
+            echo "::warning::Cache listing hit the 500-entry limit; this dedupe may be partial."
+          fi
           ROWS=$(printf '%s' "$RAW" | jq -r --argjson keep "$KEEP" --arg ts "$TS" '
                    map(select(.key | test($ts)))
                    | group_by((.key | sub($ts; "")) + "@@" + .ref)
@@ -182,6 +216,14 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
       # Compiler caches left behind by release tags that have SHIPPED.
+      #
+      # `!cancelled()` on this and the two steps below, not a bare skip check:
+      # the keep-1 step above is ungated and exits 1 if it cannot list the
+      # cache, and a step that fails would otherwise skip everything after it.
+      # These three collect different things and depend on nothing that step
+      # produces, so one transient `gh cache list` failure during a release must
+      # not also stand down the superseded-tag, main-scope and dead-ref passes.
+      # `!cancelled()` rather than `always()` so a cancelled job still stops.
       #
       # The step above keeps one copy per (prefix, ref) and is right to. What it
       # cannot see is that a shipped tag stops being a ref anyone builds: the
@@ -221,7 +263,7 @@ jobs:
       # shape. The newest tag is still fully protected, stable keys included:
       # those are what make a re-tag's Qt install fast.
       - name: Drop caches for superseded release tags
-        if: ${{ steps.gate.outputs.skip == 'false' }}
+        if: ${{ !cancelled() && steps.gate.outputs.skip == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -347,7 +389,7 @@ jobs:
       # exists to fix. Stable-key entries (qt-*, openssl-*, gradle-*) carry no
       # timestamp and are excluded by TS, as everywhere else here.
       - name: Drop main-scoped platform compiler caches
-        if: ${{ steps.gate.outputs.skip == 'false' }}
+        if: ${{ !cancelled() && steps.gate.outputs.skip == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -422,7 +464,7 @@ jobs:
       #     step deletes on a liveness signal and a tag is always live, so a
       #     misfire here would be silent.
       - name: Drop caches for deleted branches and closed PRs
-        if: ${{ steps.gate.outputs.skip == 'false' }}
+        if: ${{ !cancelled() && steps.gate.outputs.skip == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -19,6 +19,47 @@ name: Prune stale compiler caches
 # is already saved when we prune, so keeping exactly 1 copy per (prefix, ref)
 # group is safe. The last build to finish re-triggers us, so the skip never
 # strands stale entries.
+#
+# That gate applies to three of the four steps. The keep-1 dedupe step runs
+# UNGATED, because waiting is what was costing us the thing the gate protects.
+#
+# Measured 2026-08-21. A release fires all six builds at once; each saves a
+# second copy of its prefix while the gate holds prune off, and the repo goes
+# over the 10 GB cap mid-release — 11.10 GB across 19 entries, of which 2.7 GB
+# was four duplicate pairs (macOS 1843+1777, Android 646+622, Windows sccache
+# 241+225, Linux arm64 77+63). Four prune runs fired during that window and all
+# four skipped: "5 build workflow(s) still active", then 4, 3, 2. GitHub evicts
+# to get back under the cap, and what it takes is the least recently used LIVE
+# entry — always `ccache-sanitizers-*`, because every other entry is tag-scoped
+# and rewritten on each release while the nightly's two are touched once every
+# 24 h. The 2026-08-20 release ran 20:25-20:33; by 04:57 the next morning the
+# ubsan leg restored "No cache found." and built cold at 9.45% hits (83/878,
+# 0 direct) against asan's 74.37%. There was no garbage to collect either — that
+# night's prune reported 0 superseded-tag and 0 main-scoped entries. The cleanup
+# was not failing to find stale caches; it was gated off exactly when the cap
+# was exceeded.
+#
+# Then it happened again while that was being written, on the opposite leg. The
+# v2.0.4 release fired 16:10-16:21 the same day; the store peaked at 11.10 GB,
+# GitHub evicted, and the ASAN entry (1199 MB) went while ubsan's survived. At
+# 16:30 the store held 9.98 GB with 3031 MB of collectable duplicates still in
+# it — android 593, iOS 470, linux-arm64 60, macOS 1694, Windows sccache 214 —
+# because one build was still in progress and the gate was still holding. The
+# duplicates and the eviction are the same event; which sanitizer leg pays is
+# arbitrary.
+#
+# Keep-1 is safe ungated because it is self-limiting: it deletes only where a
+# NEWER entry of the same (prefix, ref) already exists, so a build that has not
+# saved yet leaves its prefix with a single entry and nothing is deleted for it.
+# Deleting macOS's previous copy once macOS has saved its new one cannot strand
+# a restore — and a build still running restored at its start, before this
+# workflow was even triggered. The gate's own comment justifies itself against
+# the OLD keep-2 heuristic ("it had to keep 2 copies per group"), which did need
+# to know whether a save was outstanding. Keep-1 does not.
+#
+# The other three steps stay gated. They delete on a liveness signal — a tag
+# being superseded, a branch being gone, a ref nothing seeds — and none of those
+# facts is self-limiting the way "a newer copy already exists" is.
 
 on:
   workflow_run:
@@ -79,8 +120,12 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Deliberately NOT gated on steps.gate — see the header. This is the step
+      # that has to run DURING a release, because that is when the duplicates
+      # exist and when the cap is exceeded. It deletes only entries that already
+      # have a newer sibling in the same (prefix, ref) group, so it cannot take
+      # the copy a still-running build will restore from next time.
       - name: Prune stale ccache/sccache entries
-        if: ${{ steps.gate.outputs.skip == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -93,23 +138,48 @@ jobs:
           # --argjson, so pipe to real jq.
           KEEP=1
           TS='-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$'
-          gh cache list --repo "$GITHUB_REPOSITORY" --limit 500 \
-            --json id,key,createdAt,ref \
-            | jq -r --argjson keep "$KEEP" --arg ts "$TS" '
-                map(select(.key | test($ts)))
-                | group_by((.key | sub($ts; "")) + "@@" + .ref)
-                | map(sort_by(.createdAt) | reverse | .[$keep:])
-                | flatten
-                | .[] | "\(.id)\t\(.key)"
-              ' \
-            | while IFS=$'\t' read -r id key; do
+
+          # Listing checked separately from "found nothing", like the three
+          # steps below. This step now carries the load during a release, so
+          # "Reclaimed 0 MB" has to be distinguishable from "never looked".
+          if ! RAW=$(gh cache list --repo "$GITHUB_REPOSITORY" --limit 500 \
+                       --json id,key,createdAt,ref,sizeInBytes); then
+            echo "::error::Could not list caches — the keep-1 dedupe did NOT run."
+            exit 1
+          fi
+          ROWS=$(printf '%s' "$RAW" | jq -r --argjson keep "$KEEP" --arg ts "$TS" '
+                   map(select(.key | test($ts)))
+                   | group_by((.key | sub($ts; "")) + "@@" + .ref)
+                   | map(sort_by(.createdAt) | reverse | .[$keep:])
+                   | flatten
+                   | .[] | "\(.id)\t\(.sizeInBytes)\t\(.key)"
+                 ')
+          if [ -z "$ROWS" ]; then
+            echo "Listed $(printf '%s' "$RAW" | jq length) caches; no duplicate (prefix, ref) groups."
+            exit 0
+          fi
+
+          # Here-string, not a pipe: the loop must run in this shell or the
+          # counters accumulate in a subshell and are discarded. That trap is
+          # already recorded on the dead-ref step below; this step had the same
+          # pipe and got away with it only because nothing read a counter.
+          freed=0
+          deleted=0
+          candidates=$(printf '%s\n' "$ROWS" | grep -c . || true)
+          while IFS=$'\t' read -r id size key; do
                 [ -n "$id" ] || continue
-                if gh cache delete "$id" --repo "$GITHUB_REPOSITORY"; then
-                  echo "- deleted \`$key\` (id $id)" >> "$GITHUB_STEP_SUMMARY"
+                mb=$(( size / 1024 / 1024 ))
+                if err=$(gh cache delete "$id" --repo "$GITHUB_REPOSITORY" 2>&1); then
+                  echo "- deleted \`$key\` (${mb} MB) — superseded by a newer copy of the same prefix" \
+                    >> "$GITHUB_STEP_SUMMARY"
+                  freed=$(( freed + mb ))
+                  deleted=$(( deleted + 1 ))
                 else
-                  echo "::warning::Failed to delete cache $key (id $id)"
+                  echo "::warning::Failed to delete cache $key (id $id): $err"
                 fi
-              done
+          done <<< "$ROWS"
+          echo "Reclaimed ${freed} MB from ${deleted}/${candidates} duplicate entries." \
+            >> "$GITHUB_STEP_SUMMARY"
 
       # Compiler caches left behind by release tags that have SHIPPED.
       #


### PR DESCRIPTION
## What

`prune-caches.yml` skips its whole job while any build workflow is queued or running. This moves the **keep-1 dedupe step** out from behind that gate. The other three steps stay gated.

## Why

The gate does not prevent the cleanup. It delays it past the point where the damage is already done and cannot be undone.

A release fires all six builds at once and each saves a **second** copy of its prefix. For the ~14 minutes until the last one finishes, the gate holds prune off and the store carries every duplicate at once — over GitHub's 10 GB cap. GitHub evicts to get back under it and takes the least recently used **live** entry. That is always a `ccache-sanitizers-*` entry: every other entry is tag-scoped and rewritten each release, while the nightly's two are touched once every 24 h.

Two evictions, two different legs, on consecutive days:

**2026-08-20** — v2.0.4 builds created 20:20, finished 20:25–20:34. Prune [`32414785391`](https://github.com/Kulitorum/Decenza/actions/runs/32414785391) fired at 20:34 once the last build was done, reported `No build workflows active — pruning`, and collected the duplicates — but the store had been over cap for fourteen minutes. Next morning at 04:57 the nightly's **ubsan** leg restored `No cache found.` and built cold:

```
ubsan:  Hits  83/878 ( 9.45%)   Direct 0
asan:   Hits 653/878 (74.37%)   Direct 593
```

Nothing in this workflow removed it: keep-1 only collects an entry that has a newer sibling, and the main-scope step excludes `ccache-sanitizers-*` by name. It was evicted.

**2026-08-21** — v2.0.4 re-tagged, builds created 16:10, finishing 16:14–16:21. Store peaked at 11.10 GB across 19 entries, 2.7 GB of it four duplicate pairs (macOS 1843+1777, Android 646+622, Windows sccache 241+225, Linux arm64 77+63). Four prunes fired inside the window and all four skipped:

```
16:15  5 build workflow(s) still active — skipping prune.
16:18  4 ...   16:19  3 ...   16:22  2 build workflow(s) still active — skipping prune.
```

This time **asan's** 1199 MB entry was evicted and ubsan's survived; which leg pays is arbitrary. At 16:30, with one build still running, the store still held 9.98 GB and 3031 MB of collectable duplicates.

Neither night had any garbage to collect — both prunes reported `0 entr(y|ies) on older tags` and no main-scoped platform entries. **The cleanup was not failing to find stale caches. It was standing down for the fourteen minutes in which the cap was exceeded, and cleaning up afterwards.**

## Why ungating keep-1 is safe

It is self-limiting: it deletes only where a **newer** entry of the same `(prefix, ref)` already exists. A build that has not saved yet leaves its prefix with a single entry, so nothing is deleted for it. Deleting macOS's previous copy once macOS has saved its new one cannot strand a restore, and a build still running restored at its start.

The gate's own comment justifies itself against the **old keep-2 heuristic** ("it had to keep 2 copies per group"), which genuinely needed to know whether a save was outstanding. Keep-1 does not.

The other three steps stay gated — they delete on a liveness signal (a tag superseded, a branch gone, a ref nothing seeds), and none is self-limiting the way "a newer copy already exists" is.

No workflow saves two entries under one prefix in a single run: the sanitizer matrix legs use distinct keys (`sanitizers-asan-…` / `sanitizers-ubsan-…`), and every other workflow saves once.

## Also in this change

The dedupe step becomes load-bearing, so it is brought up to the pattern its three siblings already use, plus three fixes from review:

- listing checked separately from "found nothing", so `Reclaimed 0 MB` cannot be confused with "never looked"
- the 500-entry truncation warning the superseded-tag step already carries — the listing is last-accessed descending, so truncation drops precisely the superseded copies this step collects
- delete loop fed by a here-string, not a pipe, so its counters survive
- the three gated steps now use `!cancelled() && skip == 'false'`: the ungated step exits 1 if it cannot list the cache, and a failed step would otherwise skip every step after it, standing down the other three passes over one transient `gh` failure
- `concurrency: cancel-in-progress: false`. Cancelling was harmless while every run during a release exited at the gate in ~2 s; now the cancelled pass is exactly the one that would have reclaimed space early, and two builds finishing in the same minute (16:15 twice on 08-21) is enough to lose one. Queueing also means two prunes never race to delete the same entry.

## Known risks

- **A restore in flight when its entry is deleted.** Job B starts before job A saves, begins downloading the older copy; A saves; prune deletes the older copy mid-download. Under the gate this could not happen. Worst case is a failed restore, which `actions/cache` treats as a miss — one cold build, not a broken one.
- **A failed build's cache can supersede a good one sooner.** `ccache-action` saves in a post-job step regardless of conclusion, so a degraded entry can become the newest of its group. Not new — the gated prune kept the same entry for the same reason, only later.
- **This reduces the failure rate, it does not remove it.** Steady state after a clean prune is 9.01 GB / 10 with zero garbage. The working set does not fit with much margin — `ccache-macos-universal` alone is 1.84 GB, 18% of the cap. If this proves insufficient the next lever is shrinking that entry, not raising a `max_size`.

## Testing

The step body was executed against the live cache listing with `gh` stubbed. It selected exactly the five superseded duplicates, 3031 MB, with counters surviving the loop:

```
593 MB  ccache-android-arm64-2026-08-20T20:25:48.893Z
470 MB  ccache-ios-arm64-xcode26.4.1-s2-2026-08-20T20:33:49.093Z
 60 MB  ccache-linux-arm64-2026-08-20T20:26:08.926Z
1694 MB ccache-macos-universal-2026-08-20T20:33:08.868Z
214 MB  sccache-sccache-windows-x64-qt6.11.2-vs2026-2026-08-20T20:27:26.505Z
Reclaimed 3031 MB from 5/5 duplicate entries.
```

No `qt-*`, `gradle-*`, `openssl-*` or `ccache-sanitizers-*` entry selected. Edge cases exercised: single-entry and empty listings both report "no duplicate groups" and exit 0; a 500-entry listing emits the truncation warning; a failing `gh cache list` emits the error and exits 1. All five run blocks pass `bash -n`; YAML parses and step gating is gate / ungated / gated / gated / gated.

Workflow-only change — no C++ or QML touched, so the local suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)