### PR TITLE
Fix the lower-mid band vanishing when a preset carousel opens

### DIFF
--- a/qml/components/layout/LayoutCenterZone.qml
+++ b/qml/components/layout/LayoutCenterZone.qml
@@ -130,20 +130,32 @@ Item {
                 Layout.maximumWidth: modelData.type === "shotPlan"
                     ? root.availableWidth : Number.POSITIVE_INFINITY
                 // Mirrors Layout.preferredWidth above: an auto-sized type sizes to its
-                // CONTENT in both axes. Only action buttons take the fixed cell.
+                // CONTENT in both axes, and anything outside isAutoSized takes the fixed
+                // cell. That is NOT the same as "only action buttons" — the quick-selects,
+                // doseWeight, milkWeight, profileName, lastShot, separator, discuss and the
+                // screensaver widgets are all outside the list too, so a zone holding only
+                // one of those still measures a full cell. Whether they belong in
+                // isAutoSized is a live question; the list governs width as well, so it is
+                // not a free change.
                 //
                 // This used to exempt "spacer" alone, so every readout — the shot plan,
-                // the clock, the temperature — claimed a full buttonHeight cell and
-                // painted a line or two of text centred in it. The leftover was invisible
-                // buffer that still counted as layout height, which made the zone, and the
-                // whole centre column, measure taller than anything on screen. Anything
-                // reasoning about where the column ENDS (see IdlePage's
-                // carouselOverlapsBand) was then reading padding rather than content, and
-                // hid the lower-mid band over a gap the user could plainly see was empty.
+                // the clock, the temperature — claimed a full buttonHeight cell and painted
+                // a line or two of text centred in it. The leftover was invisible buffer
+                // that still counted as layout height. A RowLayout takes the MAX over its
+                // children, so a zone containing any action button is unchanged; what
+                // shrinks is a readout-only zone, and that is enough to make the whole
+                // centre column measure taller than anything on screen. Anything reasoning
+                // about where the column ENDS — IdlePage's lowerMidBarCrowding, and the
+                // carouselOverlapsBand fallback behind it — was then reading padding rather
+                // than content, and hid the lower-mid band over a gap the user could
+                // plainly see was empty.
                 //
                 // isAutoSized already covers "spacer", so this subsumes the old case
                 // exactly rather than dropping it.
                 Layout.preferredHeight: root.isAutoSized(modelData.type) ? -1 : root.buttonHeight
+                // Stays spacer-only on purpose, despite the line above having just
+                // folded its spacer test into isAutoSized: a readout must size to its
+                // content, not expand to fill the row.
                 Layout.fillWidth: modelData.type === "spacer"
             }
         }

--- a/qml/components/layout/LayoutCenterZone.qml
+++ b/qml/components/layout/LayoutCenterZone.qml
@@ -129,7 +129,21 @@ Item {
                 // past the screen edge; capped, the text wraps and elides inside.
                 Layout.maximumWidth: modelData.type === "shotPlan"
                     ? root.availableWidth : Number.POSITIVE_INFINITY
-                Layout.preferredHeight: modelData.type === "spacer" ? -1 : root.buttonHeight
+                // Mirrors Layout.preferredWidth above: an auto-sized type sizes to its
+                // CONTENT in both axes. Only action buttons take the fixed cell.
+                //
+                // This used to exempt "spacer" alone, so every readout — the shot plan,
+                // the clock, the temperature — claimed a full buttonHeight cell and
+                // painted a line or two of text centred in it. The leftover was invisible
+                // buffer that still counted as layout height, which made the zone, and the
+                // whole centre column, measure taller than anything on screen. Anything
+                // reasoning about where the column ENDS (see IdlePage's
+                // carouselOverlapsBand) was then reading padding rather than content, and
+                // hid the lower-mid band over a gap the user could plainly see was empty.
+                //
+                // isAutoSized already covers "spacer", so this subsumes the old case
+                // exactly rather than dropping it.
+                Layout.preferredHeight: root.isAutoSized(modelData.type) ? -1 : root.buttonHeight
                 Layout.fillWidth: modelData.type === "spacer"
             }
         }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -142,11 +142,17 @@ T.Page {
         Math.max(0, idlePage.height - Theme.statusBarHeight - Theme.bottomBarHeight - Theme.scaled(120))
 
     // Un-offset extents of the movable idle content (read raw so the test can't
-    // feed back into the offset it produces). lowerMidBar (when visible) reaches
-    // bottomBar.top; the center column's top is its own y.
+    // feed back into the offset it produces). The center column's top is its own y.
+    //
+    // The band's bottom is bottomBar.top plus the user's zone Y-offset, not
+    // bottomBar.top alone: its anchors.bottomMargin is the NEGATED offset (see the
+    // Rectangle), so a positive offset pushes the bottom edge down. Reading
+    // bottomBar.y flat under-measured the content by that offset and short-changed
+    // the clearance a picker popup asked for. Unaffected by the squeeze, which
+    // shrinks the band from the top.
     readonly property real _idleContentBottom: {
         var colBottom = centerContent.y + centerContent.height
-        var bandBottom = lowerMidBarVisible ? bottomBar.y : 0
+        var bandBottom = lowerMidBarVisible ? (bottomBar.y + idlePage.lowerMidBarYOffset) : 0
         return Math.max(colBottom, bandBottom)
     }
     readonly property real _idleContentTop: centerContent.y
@@ -178,19 +184,37 @@ T.Page {
     // Weather, …) off the screen for as long as the carousel stayed open.
     //
     // The BAND yields instead, and by exactly the amount it is actually crowded by
-    // (lowerMidBarCrowding, below). Nothing above the band ever moves or resizes,
-    // and the band itself keeps its full size until something genuinely needs the
-    // room, so a layout whose column never reaches it is untouched in both states.
+    // (lowerMidBarCrowding, below). The SQUEEZE moves nothing above the band: the
+    // band is bottom-anchored, so shrinking moves only its own top edge, and the
+    // centre column reads nothing from it. A layout whose column never reaches the
+    // band is untouched in both states. (Sizing centre-zone readouts to their
+    // content — LayoutCenterZone's Layout.preferredHeight — does re-flow the column,
+    // once and at rest. That is a separate change in this branch, not this one.)
     //
-    // Fallback for what the squeeze cannot recover (a very short viewport, a tall
-    // band, a tall preset row): the band is HIDDEN (faded out) rather than shoved
-    // down — it sits on bottomBar.top (modulo the user's zone Y-offset), so "down"
-    // runs it into the bottom action bar. One-way: reads the column's un-offset
-    // bottom against the band's static top.
+    // Fallback for the crowding the squeeze cannot absorb: the band is HIDDEN
+    // (faded out) rather than shoved down — it sits on bottomBar.top (modulo the
+    // user's zone Y-offset), so "down" runs it into the bottom action bar.
+    //
+    // Asks whether the squeeze has BOTTOMED OUT rather than comparing against the
+    // band's rendered top, and that is not a stylistic choice. lowerMidBar.height
+    // animates (Behavior, below) and so does the preset row that drives the column
+    // (Layout.preferredHeight, likewise), with independent lag. A predicate reading
+    // the rendered lowerMidBar.y therefore goes transiently true mid-animation while
+    // the band is still on its way down, which starts the very fade the squeeze
+    // exists to avoid — a flash on every carousel open. Comparing the two VALUES is
+    // lag-free, and says what is actually meant: fade only once the band cannot give
+    // up any more height.
+    //
+    // Still gated on an open carousel, which leaves one asymmetry worth knowing:
+    // lowerMidBarCrowding is not so gated, so a centre column tall enough to crowd
+    // the band with no preset row open squeezes it to the minimum and then simply
+    // overlaps, with no fade. Extending the fade there would change the resting idle
+    // screen, which this change deliberately does not touch.
     readonly property bool carouselOverlapsBand: {
         if (idlePage.activePresetFunction === "" || !idlePage.lowerMidBarVisible)
             return false
-        return (centerContent.y + centerContent.height + Theme.spacingMedium) > lowerMidBar.y
+        return idlePage.lowerMidBarCrowding
+            > (idlePage.lowerMidBarRestHeight - idlePage.lowerMidBarMinHeight)
     }
 
     Component.onCompleted: {
@@ -1481,12 +1505,25 @@ T.Page {
     readonly property int lowerMidBarYOffset: layoutConfig.offsets ? (layoutConfig.offsets.lowerMidBar || 0) : 0
     readonly property real lowerMidBarScale: layoutConfig.scales ? (layoutConfig.scales.lowerMidBar || 1.0) : 1.0
     readonly property bool lowerMidBarHasItems: idlePage.lowerMidBarItems.length > 0
-    // Auto-grow: the band fits its content (large item-size makes it taller),
-    // never smaller than the standard bar height. This is the band's size when
-    // nothing is crowding it, and the baseline everything below measures against.
+    // Auto-grow: the band fits its content (large item-size makes it taller). This
+    // is the band's size when nothing is crowding it, and the baseline every figure
+    // below measures against — NOT a floor on what it renders at, which is
+    // lowerMidBarMinHeight. The scaled(82) is this zone's own minimum and is not
+    // Theme.bottomBarHeight, which is scaled(70) (Theme.qml:1034) and is separately
+    // applied to lmbZone.implicitHeight by LayoutBarZone.qml:44.
     readonly property real lowerMidBarRestHeight: Math.max(Theme.scaled(82), lmbZone.implicitHeight)
-    // How far the band may be squeezed before the fade takes over instead.
-    readonly property real lowerMidBarMinHeight: Theme.scaled(44)
+    // Floor on the squeeze. Past this the band stops giving up height; with a
+    // carousel open carouselOverlapsBand then fades it, and with none open it simply
+    // overlaps (see that property for why the two differ).
+    //
+    // PROPORTIONAL, because the content scales with the height: a flat floor against
+    // a content-driven rest height means the scale bottoms out at floor/restHeight,
+    // which is ~0.5 for a default band but ~0.2 for a tall one (itemSize "large", or
+    // a user zone scale). That range is present-but-unreadable, with every tap target
+    // inside it well under Theme.touchTargetMin. Capping the squeeze at 40% of the
+    // band keeps it legible and lets the fade take over while it still is.
+    readonly property real lowerMidBarMinHeight: Math.max(
+        Theme.touchTargetMin, idlePage.lowerMidBarRestHeight * 0.6)
 
     // Where the band's top edge would sit at full size. anchors.bottomMargin is the
     // NEGATED zone Y-offset (see the Rectangle), so the offset adds to the bottom.
@@ -1500,31 +1537,43 @@ T.Page {
     // Loop-free by construction, and the constraint is tighter than it looks. Every
     // input is independent of the band's rendered size: the centre column does not
     // read the band at all, bottomBar is anchored to the page, and REST height comes
-    // from lmbZone.implicitHeight, which is content-driven (itemsRow is
-    // verticalCenter-anchored, so it never measures its parent). That last one is
-    // why the squeeze may NOT run through the zone's zoneScale, however natural that
-    // looks — zoneScale feeds implicitHeight, so scaling the content there would put
-    // the band's size on both sides of its own binding. It is applied as a render
-    // transform on the zone instead, which layout ignores.
+    // from lmbZone.implicitHeight, which is content-driven — LayoutBarZone.qml:44
+    // computes it from itemsRow.implicitHeight, and itemsRow anchors to its parent's
+    // verticalCenter/left/right (LayoutBarZone.qml:49-51), so it measures the
+    // parent's WIDTH but never its height.
+    //
+    // That is why the squeeze may NOT run through the zone's zoneScale, however
+    // natural that looks — zoneScale is the other factor in that same
+    // LayoutBarZone.qml:44 expression, so scaling the content there would put the
+    // band's size on both sides of its own binding. It is applied as a render
+    // transform on the zone instead: QQuickItem::setScale only marks BasicTransform
+    // dirty and emits no geometry change (qtdeclarative/src/quick/items/
+    // qquickitem.cpp:6442-6454), so anchors, width and height never see it.
     readonly property real lowerMidBarCrowding: {
         if (!idlePage.lowerMidBarVisible) return 0
         var columnBottom = centerContent.y + centerContent.height + Theme.spacingMedium
         return Math.max(0, columnBottom - idlePage.lowerMidBarRestTop)
     }
 
-    readonly property real lowerMidBarFullHeight: Math.max(
+    // NOT named "full height": LayoutPreview.qml carries a lowerMidFullHeight that
+    // means the UN-squeezed height, i.e. this file's lowerMidBarRestHeight. Two
+    // mirrored surfaces using one name for opposite quantities is how they drift.
+    readonly property real lowerMidBarCurrentHeight: Math.max(
         idlePage.lowerMidBarMinHeight,
         idlePage.lowerMidBarRestHeight - idlePage.lowerMidBarCrowding)
     // Render scale for the band's contents, so a squeezed band shrinks what it holds
     // instead of clipping it. 1.0 whenever nothing is crowding the band.
     readonly property real lowerMidBarContentScale: idlePage.lowerMidBarRestHeight > 0
-        ? idlePage.lowerMidBarFullHeight / idlePage.lowerMidBarRestHeight
+        ? idlePage.lowerMidBarCurrentHeight / idlePage.lowerMidBarRestHeight
         : 1.0
-    // Deliberately the REST height, not the squeezed one. Gating on the squeezed
-    // height would let a viewport too short for the band at rest pass the test the
-    // moment a carousel opened, so the band would appear only while a preset row
-    // was open — backwards. Whether the band exists is a property of the viewport,
-    // not of what the user has open.
+    // Deliberately the REST height, not the squeezed one, and that is a hard
+    // requirement rather than a preference: lowerMidBarCrowding reads
+    // lowerMidBarVisible, so gating this on the squeezed height closes the cycle
+    // fits → visible → crowding → fullHeight → fits and QML reports a binding loop
+    // with the values latching non-deterministically.
+    //
+    // It is also the right semantics. Whether the band exists at all is a property
+    // of the viewport, not of what the user happens to have open.
     readonly property bool lowerMidBarFits:
         (idlePage.height - Theme.statusBarHeight - Theme.bottomBarHeight - lowerMidBarRestHeight) >= Theme.scaled(220)
     readonly property bool lowerMidBarVisible: lowerMidBarHasItems && lowerMidBarFits
@@ -1537,7 +1586,7 @@ T.Page {
         // Negative offset (the editor's "up") lifts the band off the bottom bar.
         anchors.bottomMargin: -idlePage.lowerMidBarYOffset
         visible: idlePage.lowerMidBarVisible
-        height: visible ? idlePage.lowerMidBarFullHeight : 0
+        height: visible ? idlePage.lowerMidBarCurrentHeight : 0
         Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
         color: Theme.zoneBackgroundColor(idlePage.lowerMidBarOptions.style)
         // Fade out (rather than overlap the bottom action bar) when the center-zone
@@ -1560,8 +1609,12 @@ T.Page {
         // intent; do not rely on it alone to hide anything.
         //
         // `visible: false` is the only construct that genuinely removes a subtree
-        // from the accessibility tree, but it collapses the band's height (see the
-        // binding above) and so moves the layout.
+        // from the accessibility tree. It is not used here because it would collapse
+        // the band's painted area outright, where the fade keeps the band's place
+        // while it is unreachable. Note it would NOT disturb the rest of the page:
+        // nothing anchors to this Rectangle — carouselOverlapsBand's read is the
+        // only reference to it in the file — and the band's height already varies
+        // by design (lowerMidBarCurrentHeight) with nothing above it moving.
         Accessible.ignored: idlePage.carouselOverlapsBand
         Behavior on opacity { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
         // Slides UP with the center content to clear a bottom-zone picker popup.
@@ -1571,10 +1624,13 @@ T.Page {
         }
 
         // Laid out at the band's REST height and scaled down to whatever height the
-        // band currently has. Deliberately not anchors.fill: filling would make the
-        // zone's own geometry follow the squeezed height, and its implicitHeight is
-        // the baseline the squeeze is computed from. Scale is a render transform, so
-        // layout never sees it and the baseline stays put.
+        // band currently has, so scale alone carries the squeeze.
+        //
+        // Deliberately not anchors.fill, and the reason is double application rather
+        // than any feedback: filling would already size the zone to the squeezed
+        // height, itemsRow would centre its natural-size content in that, and the
+        // scale below would then shrink it a second time. (It would be harmless to
+        // implicitHeight, which never measures this item — see lowerMidBarCrowding.)
         LayoutBarZone {
             id: lmbZone
             anchors.left: parent.left
@@ -1586,7 +1642,18 @@ T.Page {
             scale: idlePage.lowerMidBarContentScale
             // Shrinks towards the bottom bar, so the band's top edge is what moves
             // and its contents stay put against the bar below them.
-            transformOrigin: Item.Bottom
+            //
+            // A uniform scale shrinks x as well as y, so the origin is pinned to the
+            // zone's ALIGNMENT edge — the same rule, and the same reason, as
+            // LayoutBarZone.qml:54-58 applies to its own zoneScale. With plain
+            // Item.Bottom a left- or right-aligned band's contents would slide inward
+            // by (1 - scale) * width / 2 as it squeezed.
+            transformOrigin: {
+                var a = idlePage.lowerMidBarOptions.alignment || "center"
+                if (a === "left") return Item.BottomLeft
+                if (a === "right") return Item.BottomRight
+                return Item.Bottom
+            }
             Behavior on scale { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
             zoneName: "lowerMidBar"
             items: idlePage.lowerMidBarItems

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -172,11 +172,27 @@ T.Page {
         idlePage.topPanelClearance = 0
     }
 
-    // Center-zone inline carousel: when the expanded center column would reach
-    // the bottom-anchored lower-mid band, the band is HIDDEN (faded out) rather
-    // than shoved down — the band sits on bottomBar.top (modulo the user's zone
-    // Y-offset), so "down" runs it into the bottom action bar. One-way: reads the column's
-    // un-offset bottom against the band's static top.
+    // Center-zone inline carousel: an open carousel grows the vertically-centred
+    // centre column until it reaches the bottom-anchored lower-mid band. SQUEEZE
+    // first — tighten the centre column's row spacing and let the band sit at its
+    // content height instead of its taller idle floor. On a 1280x800 tablet that
+    // recovers more than the overlap a carousel introduces, so the band (Grind,
+    // Weather, …) stays on screen instead of vanishing the moment a preset row
+    // opens. Only while a carousel is open: with none open the page keeps its
+    // roomier idle spacing.
+    //
+    // Deliberately geometry-free. A squeeze that measured the overlap it is
+    // correcting would feed back into the spacing and height it produces, which is
+    // a binding loop. carouselOverlapsBand below MAY read geometry because it
+    // drives opacity and enabled only, never a size.
+    readonly property bool squeezeForCarousel:
+        idlePage.activePresetFunction !== "" && idlePage.lowerMidBarHasItems
+
+    // Fallback for what the squeeze cannot recover (a very short viewport, a tall
+    // band, a tall preset row): the band is HIDDEN (faded out) rather than shoved
+    // down — it sits on bottomBar.top (modulo the user's zone Y-offset), so "down"
+    // runs it into the bottom action bar. One-way: reads the column's un-offset
+    // bottom against the band's static top.
     readonly property bool carouselOverlapsBand: {
         if (idlePage.activePresetFunction === "" || !idlePage.lowerMidBarVisible)
             return false
@@ -887,7 +903,11 @@ T.Page {
         anchors.verticalCenterOffset: Theme.scaled(50)
         anchors.leftMargin: Theme.standardMargin
         anchors.rightMargin: Theme.standardMargin
-        spacing: Theme.scaled(20)
+        // Tightens while a carousel is open so the expanded column stops crowding
+        // the lower-mid band off the screen. Animated over the same 200 ms the
+        // preset row itself expands in, so the rows above do not jump.
+        spacing: Theme.scaled(idlePage.squeezeForCarousel ? 8 : 20)
+        Behavior on spacing { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
         // Transient slide to clear a picker popup: up for a lower-half popup,
         // down for an upper-half one (restores to 0 on close).
         transform: Translate {
@@ -1473,7 +1493,14 @@ T.Page {
     readonly property bool lowerMidBarHasItems: idlePage.lowerMidBarItems.length > 0
     // Auto-grow: the band fits its content (large item-size makes it taller),
     // never smaller than the standard bar height.
-    readonly property real lowerMidBarFullHeight: Math.max(Theme.scaled(82), lmbZone.implicitHeight)
+    // scaled(82) is an idle-only floor that pads the band above its content. While a
+    // carousel is open the band gives that padding back and sits at its content
+    // height, moving its top edge down and out of the growing column's way.
+    // LayoutBarZone's own Theme.bottomBarHeight floor still applies underneath, so
+    // this never collapses the band below a normal bar.
+    readonly property real lowerMidBarFullHeight: idlePage.squeezeForCarousel
+        ? lmbZone.implicitHeight
+        : Math.max(Theme.scaled(82), lmbZone.implicitHeight)
     readonly property bool lowerMidBarFits:
         (idlePage.height - Theme.statusBarHeight - Theme.bottomBarHeight - lowerMidBarFullHeight) >= Theme.scaled(220)
     readonly property bool lowerMidBarVisible: lowerMidBarHasItems && lowerMidBarFits

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -177,19 +177,11 @@ T.Page {
     // used to simply fade out when they met — taking the widgets in it (Grind,
     // Weather, …) off the screen for as long as the carousel stayed open.
     //
-    // The BAND yields instead: while a carousel is open it scales its content down
-    // and drops to a shorter height, freeing the room the column needs. The centre
-    // column is not touched. That is the whole point — nothing above the band moves
-    // or resizes, so the button the user is reaching for stays exactly where it was
-    // and the idle screen at rest is unchanged.
+    // The BAND yields instead, and by exactly the amount it is actually crowded by
+    // (lowerMidBarCrowding, below). Nothing above the band ever moves or resizes,
+    // and the band itself keeps its full size until something genuinely needs the
+    // room, so a layout whose column never reaches it is untouched in both states.
     //
-    // Deliberately geometry-free. A squeeze that measured the overlap it is
-    // correcting would feed back into the height it produces, which is a binding
-    // loop. carouselOverlapsBand below MAY read geometry because it drives opacity
-    // and enabled only, never a size.
-    readonly property bool squeezeForCarousel:
-        idlePage.activePresetFunction !== "" && idlePage.lowerMidBarHasItems
-
     // Fallback for what the squeeze cannot recover (a very short viewport, a tall
     // band, a tall preset row): the band is HIDDEN (faded out) rather than shoved
     // down — it sits on bottomBar.top (modulo the user's zone Y-offset), so "down"
@@ -1490,22 +1482,44 @@ T.Page {
     readonly property real lowerMidBarScale: layoutConfig.scales ? (layoutConfig.scales.lowerMidBar || 1.0) : 1.0
     readonly property bool lowerMidBarHasItems: idlePage.lowerMidBarItems.length > 0
     // Auto-grow: the band fits its content (large item-size makes it taller),
-    // never smaller than the standard bar height.
-    // Squeezed height while a carousel is open. Set directly rather than read from
-    // lmbZone.implicitHeight, which floors at Theme.bottomBarHeight and so cannot
-    // express a band shorter than a normal bar — which is exactly what is wanted
-    // here. The band's content is scaled by lowerMidBarSqueeze to match, and
-    // itemsRow is verticalCenter-anchored inside the zone, so the shorter band
-    // keeps its contents centred instead of clipping them.
-    //
-    // Both constants are the tuning knobs for this feature: raise the scale for a
-    // more legible squeezed band, lower the height for more room for the column.
-    readonly property real lowerMidBarSqueeze: 0.72
-    readonly property real lowerMidBarSqueezedHeight: Theme.scaled(52)
+    // never smaller than the standard bar height. This is the band's size when
+    // nothing is crowding it, and the baseline everything below measures against.
     readonly property real lowerMidBarRestHeight: Math.max(Theme.scaled(82), lmbZone.implicitHeight)
-    readonly property real lowerMidBarFullHeight: idlePage.squeezeForCarousel
-        ? idlePage.lowerMidBarSqueezedHeight
-        : idlePage.lowerMidBarRestHeight
+    // How far the band may be squeezed before the fade takes over instead.
+    readonly property real lowerMidBarMinHeight: Theme.scaled(44)
+
+    // Where the band's top edge would sit at full size. anchors.bottomMargin is the
+    // NEGATED zone Y-offset (see the Rectangle), so the offset adds to the bottom.
+    readonly property real lowerMidBarRestTop:
+        bottomBar.y + idlePage.lowerMidBarYOffset - idlePage.lowerMidBarRestHeight
+
+    // How much the centre column actually intrudes on the band, in pixels. Zero
+    // whenever the column stops short of it, which is the normal case and the whole
+    // point: the band shrinks by what it is crowded by and not one pixel more.
+    //
+    // Loop-free by construction, and the constraint is tighter than it looks. Every
+    // input is independent of the band's rendered size: the centre column does not
+    // read the band at all, bottomBar is anchored to the page, and REST height comes
+    // from lmbZone.implicitHeight, which is content-driven (itemsRow is
+    // verticalCenter-anchored, so it never measures its parent). That last one is
+    // why the squeeze may NOT run through the zone's zoneScale, however natural that
+    // looks — zoneScale feeds implicitHeight, so scaling the content there would put
+    // the band's size on both sides of its own binding. It is applied as a render
+    // transform on the zone instead, which layout ignores.
+    readonly property real lowerMidBarCrowding: {
+        if (!idlePage.lowerMidBarVisible) return 0
+        var columnBottom = centerContent.y + centerContent.height + Theme.spacingMedium
+        return Math.max(0, columnBottom - idlePage.lowerMidBarRestTop)
+    }
+
+    readonly property real lowerMidBarFullHeight: Math.max(
+        idlePage.lowerMidBarMinHeight,
+        idlePage.lowerMidBarRestHeight - idlePage.lowerMidBarCrowding)
+    // Render scale for the band's contents, so a squeezed band shrinks what it holds
+    // instead of clipping it. 1.0 whenever nothing is crowding the band.
+    readonly property real lowerMidBarContentScale: idlePage.lowerMidBarRestHeight > 0
+        ? idlePage.lowerMidBarFullHeight / idlePage.lowerMidBarRestHeight
+        : 1.0
     // Deliberately the REST height, not the squeezed one. Gating on the squeezed
     // height would let a viewport too short for the band at rest pass the test the
     // moment a carousel opened, so the band would appear only while a preset row
@@ -1524,6 +1538,7 @@ T.Page {
         anchors.bottomMargin: -idlePage.lowerMidBarYOffset
         visible: idlePage.lowerMidBarVisible
         height: visible ? idlePage.lowerMidBarFullHeight : 0
+        Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
         color: Theme.zoneBackgroundColor(idlePage.lowerMidBarOptions.style)
         // Fade out (rather than overlap the bottom action bar) when the center-zone
         // carousel expands down into the band; `enabled:false` also stops the hidden
@@ -1555,21 +1570,31 @@ T.Page {
             Behavior on y { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
         }
 
+        // Laid out at the band's REST height and scaled down to whatever height the
+        // band currently has. Deliberately not anchors.fill: filling would make the
+        // zone's own geometry follow the squeezed height, and its implicitHeight is
+        // the baseline the squeeze is computed from. Scale is a render transform, so
+        // layout never sees it and the baseline stays put.
         LayoutBarZone {
             id: lmbZone
-            anchors.fill: parent
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
             anchors.leftMargin: Theme.spacingMedium
             anchors.rightMargin: Theme.spacingMedium
+            height: idlePage.lowerMidBarRestHeight
+            scale: idlePage.lowerMidBarContentScale
+            // Shrinks towards the bottom bar, so the band's top edge is what moves
+            // and its contents stay put against the bar below them.
+            transformOrigin: Item.Bottom
+            Behavior on scale { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
             zoneName: "lowerMidBar"
             items: idlePage.lowerMidBarItems
             distribution: idlePage.lowerMidBarOptions.distribution || "packed"
             alignment: idlePage.lowerMidBarOptions.alignment || "center"
             zoneStyle: idlePage.lowerMidBarOptions.style || "standard"
             itemSize: idlePage.lowerMidBarOptions.itemSize || "compact"
-            // Multiplies the user's own zone scale, so a squeeze is relative to
-            // whatever size they chose rather than overriding it.
             zoneScale: idlePage.lowerMidBarScale
-                * (idlePage.squeezeForCarousel ? idlePage.lowerMidBarSqueeze : 1.0)
         }
     }
 

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -173,18 +173,20 @@ T.Page {
     }
 
     // Center-zone inline carousel: an open carousel grows the vertically-centred
-    // centre column until it reaches the bottom-anchored lower-mid band. SQUEEZE
-    // first — tighten the centre column's row spacing and let the band sit at its
-    // content height instead of its taller idle floor. On a 1280x800 tablet that
-    // recovers more than the overlap a carousel introduces, so the band (Grind,
-    // Weather, …) stays on screen instead of vanishing the moment a preset row
-    // opens. Only while a carousel is open: with none open the page keeps its
-    // roomier idle spacing.
+    // centre column down towards the bottom-anchored lower-mid band, and the band
+    // used to simply fade out when they met — taking the widgets in it (Grind,
+    // Weather, …) off the screen for as long as the carousel stayed open.
+    //
+    // The BAND yields instead: while a carousel is open it scales its content down
+    // and drops to a shorter height, freeing the room the column needs. The centre
+    // column is not touched. That is the whole point — nothing above the band moves
+    // or resizes, so the button the user is reaching for stays exactly where it was
+    // and the idle screen at rest is unchanged.
     //
     // Deliberately geometry-free. A squeeze that measured the overlap it is
-    // correcting would feed back into the spacing and height it produces, which is
-    // a binding loop. carouselOverlapsBand below MAY read geometry because it
-    // drives opacity and enabled only, never a size.
+    // correcting would feed back into the height it produces, which is a binding
+    // loop. carouselOverlapsBand below MAY read geometry because it drives opacity
+    // and enabled only, never a size.
     readonly property bool squeezeForCarousel:
         idlePage.activePresetFunction !== "" && idlePage.lowerMidBarHasItems
 
@@ -903,11 +905,7 @@ T.Page {
         anchors.verticalCenterOffset: Theme.scaled(50)
         anchors.leftMargin: Theme.standardMargin
         anchors.rightMargin: Theme.standardMargin
-        // Tightens while a carousel is open so the expanded column stops crowding
-        // the lower-mid band off the screen. Animated over the same 200 ms the
-        // preset row itself expands in, so the rows above do not jump.
-        spacing: Theme.scaled(idlePage.squeezeForCarousel ? 8 : 20)
-        Behavior on spacing { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
+        spacing: Theme.scaled(20)
         // Transient slide to clear a picker popup: up for a lower-half popup,
         // down for an upper-half one (restores to 0 on close).
         transform: Translate {
@@ -1493,16 +1491,28 @@ T.Page {
     readonly property bool lowerMidBarHasItems: idlePage.lowerMidBarItems.length > 0
     // Auto-grow: the band fits its content (large item-size makes it taller),
     // never smaller than the standard bar height.
-    // scaled(82) is an idle-only floor that pads the band above its content. While a
-    // carousel is open the band gives that padding back and sits at its content
-    // height, moving its top edge down and out of the growing column's way.
-    // LayoutBarZone's own Theme.bottomBarHeight floor still applies underneath, so
-    // this never collapses the band below a normal bar.
+    // Squeezed height while a carousel is open. Set directly rather than read from
+    // lmbZone.implicitHeight, which floors at Theme.bottomBarHeight and so cannot
+    // express a band shorter than a normal bar — which is exactly what is wanted
+    // here. The band's content is scaled by lowerMidBarSqueeze to match, and
+    // itemsRow is verticalCenter-anchored inside the zone, so the shorter band
+    // keeps its contents centred instead of clipping them.
+    //
+    // Both constants are the tuning knobs for this feature: raise the scale for a
+    // more legible squeezed band, lower the height for more room for the column.
+    readonly property real lowerMidBarSqueeze: 0.72
+    readonly property real lowerMidBarSqueezedHeight: Theme.scaled(52)
+    readonly property real lowerMidBarRestHeight: Math.max(Theme.scaled(82), lmbZone.implicitHeight)
     readonly property real lowerMidBarFullHeight: idlePage.squeezeForCarousel
-        ? lmbZone.implicitHeight
-        : Math.max(Theme.scaled(82), lmbZone.implicitHeight)
+        ? idlePage.lowerMidBarSqueezedHeight
+        : idlePage.lowerMidBarRestHeight
+    // Deliberately the REST height, not the squeezed one. Gating on the squeezed
+    // height would let a viewport too short for the band at rest pass the test the
+    // moment a carousel opened, so the band would appear only while a preset row
+    // was open — backwards. Whether the band exists is a property of the viewport,
+    // not of what the user has open.
     readonly property bool lowerMidBarFits:
-        (idlePage.height - Theme.statusBarHeight - Theme.bottomBarHeight - lowerMidBarFullHeight) >= Theme.scaled(220)
+        (idlePage.height - Theme.statusBarHeight - Theme.bottomBarHeight - lowerMidBarRestHeight) >= Theme.scaled(220)
     readonly property bool lowerMidBarVisible: lowerMidBarHasItems && lowerMidBarFits
 
     Rectangle {
@@ -1556,7 +1566,10 @@ T.Page {
             alignment: idlePage.lowerMidBarOptions.alignment || "center"
             zoneStyle: idlePage.lowerMidBarOptions.style || "standard"
             itemSize: idlePage.lowerMidBarOptions.itemSize || "compact"
+            // Multiplies the user's own zone scale, so a squeeze is relative to
+            // whatever size they chose rather than overriding it.
             zoneScale: idlePage.lowerMidBarScale
+                * (idlePage.squeezeForCarousel ? idlePage.lowerMidBarSqueeze : 1.0)
         }
     }
 

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -188,6 +188,22 @@ T.Page {
     readonly property bool squeezeForCarousel:
         idlePage.activePresetFunction !== "" && idlePage.lowerMidBarHasItems
 
+    // The centre column is centred on the WHOLE page, so it ignores the
+    // bottom-anchored lower-mid band completely and an open carousel grows
+    // straight into it. Centre it in the space above the band instead: with the
+    // status and bottom bars the same height, that is exactly a lift of half the
+    // band's height. The column then has symmetric room and the two stay apart by
+    // construction, leaving the squeeze and the fade to cover only what an
+    // unusually tall preset row adds on top.
+    //
+    // Deliberately the UN-SQUEEZED band height. Keying this to the squeezed height
+    // would shift the whole column the moment a carousel opened — the jumping the
+    // squeeze exists to avoid — and would also put lowerMidBarFullHeight on both
+    // sides of its own binding.
+    readonly property real centerColumnBandLift: idlePage.lowerMidBarVisible
+        ? Math.max(Theme.scaled(82), lmbZone.implicitHeight) / 2
+        : 0
+
     // Fallback for what the squeeze cannot recover (a very short viewport, a tall
     // band, a tall preset row): the band is HIDDEN (faded out) rather than shoved
     // down — it sits on bottomBar.top (modulo the user's zone Y-offset), so "down"
@@ -900,7 +916,7 @@ T.Page {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: Theme.scaled(50)
+        anchors.verticalCenterOffset: Theme.scaled(50) - idlePage.centerColumnBandLift
         anchors.leftMargin: Theme.standardMargin
         anchors.rightMargin: Theme.standardMargin
         // Tightens while a carousel is open so the expanded column stops crowding

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -188,22 +188,6 @@ T.Page {
     readonly property bool squeezeForCarousel:
         idlePage.activePresetFunction !== "" && idlePage.lowerMidBarHasItems
 
-    // The centre column is centred on the WHOLE page, so it ignores the
-    // bottom-anchored lower-mid band completely and an open carousel grows
-    // straight into it. Centre it in the space above the band instead: with the
-    // status and bottom bars the same height, that is exactly a lift of half the
-    // band's height. The column then has symmetric room and the two stay apart by
-    // construction, leaving the squeeze and the fade to cover only what an
-    // unusually tall preset row adds on top.
-    //
-    // Deliberately the UN-SQUEEZED band height. Keying this to the squeezed height
-    // would shift the whole column the moment a carousel opened — the jumping the
-    // squeeze exists to avoid — and would also put lowerMidBarFullHeight on both
-    // sides of its own binding.
-    readonly property real centerColumnBandLift: idlePage.lowerMidBarVisible
-        ? Math.max(Theme.scaled(82), lmbZone.implicitHeight) / 2
-        : 0
-
     // Fallback for what the squeeze cannot recover (a very short viewport, a tall
     // band, a tall preset row): the band is HIDDEN (faded out) rather than shoved
     // down — it sits on bottomBar.top (modulo the user's zone Y-offset), so "down"
@@ -916,7 +900,7 @@ T.Page {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: Theme.scaled(50) - idlePage.centerColumnBandLift
+        anchors.verticalCenterOffset: Theme.scaled(50)
         anchors.leftMargin: Theme.standardMargin
         anchors.rightMargin: Theme.standardMargin
         // Tightens while a carousel is open so the expanded column stops crowding


### PR DESCRIPTION
## Problem

Opening an inline preset carousel on the idle page made the lower-mid band disappear — the Grind and Weather widgets in it were visible in the layout editor's preview but never on the idle screen while a preset row was open. Reported against 2.0.4 build 3556 on a Samsung SM-X210, and reproduced on the macOS desktop build.

The band is bottom-anchored above the bottom action bar; the vertically-centred centre column above it grows when a carousel opens. `carouselOverlapsBand` faded the band to `opacity: 0` as soon as the column's layout bottom reached the band's top. The preview mirrors the `lowerMidBarFits` height gate exactly but has no counterpart for that fade, which is why the two surfaces disagreed.

## Root cause

The overlap test was not measuring what was on the screen.

`LayoutCenterZone` gave every non-spacer delegate `Layout.preferredHeight: root.buttonHeight`, a fixed `Theme.scaled(120)` cell. A readout that paints one or two lines of text — the shot plan, the clock, the temperature — therefore claimed a full 120-tall box and centred its content in it. The remainder was invisible, but it still counted as layout height, so the zone and the whole centre column measured substantially taller than anything drawn.

On the reporter's layout (`centerMiddle: [shotPlan]`, `centerTop` offset `-125`) that put roughly 35 units of empty box below the last visible text. The fade fired against a gap the user could plainly see was empty:

| | logical units |
|---|---|
| visible text bottom | ~402 |
| layout bottom (text + invisible box) | ~437 |
| band top | ~428 |

437 + `spacingMedium` > 428, so the band vanished. Painted-to-painted it would have been 418 < 428.

## Changes

**`LayoutCenterZone.qml` — auto-sized widgets size to their content in height.**

```qml
Layout.preferredHeight: root.isAutoSized(modelData.type) ? -1 : root.buttonHeight
```

Previously this exempted `"spacer"` alone. Height now mirrors the `Layout.preferredWidth` rule directly above it, which has always exempted auto-sized types: an auto-sized widget sizes to its content in both axes, and only action buttons take the fixed cell. `isAutoSized` already lists `"spacer"`, so the new condition subsumes the case it replaces exactly rather than dropping it.

**`IdlePage.qml` — the band gives up exactly what crowds it.**

```qml
readonly property real lowerMidBarCrowding: {
    if (!idlePage.lowerMidBarVisible) return 0
    var columnBottom = centerContent.y + centerContent.height + Theme.spacingMedium
    return Math.max(0, columnBottom - idlePage.lowerMidBarRestTop)
}
readonly property real lowerMidBarFullHeight: Math.max(
    idlePage.lowerMidBarMinHeight,
    idlePage.lowerMidBarRestHeight - idlePage.lowerMidBarCrowding)
```

A column that stops short of the band leaves it at full size and scale 1.0. The band's contents scale by the same ratio as its height, so a squeezed band shrinks what it holds instead of clipping it. Both animate over the 200 ms the preset row itself expands in.

`lowerMidBarFits` keeps reading the **rest** height. Gating it on the squeezed height would let a viewport too short for the band at rest pass the test the moment a carousel opened, so the band would appear only while a preset row was open — backwards. Whether the band exists is a property of the viewport, not of what the user has open.

The opacity fade survives only for a band that has bottomed out at `lowerMidBarMinHeight` and is still overlapped.

## Why the squeeze is a render transform

The squeeze cannot be applied through the zone's `zoneScale`, which is where it naturally wants to go. `zoneScale` feeds `LayoutBarZone.implicitHeight`, and that implicitHeight is the rest height the requirement is measured against — routing the squeeze there puts the band's size on both sides of its own binding.

It is a `scale` on the zone instead, which layout ignores. The zone is laid out at the rest height and scaled from its bottom edge, so `implicitHeight` stays a stable baseline. Every other input is independent of the band's rendered size by construction: the centre column never reads the band, and `bottomBar` is anchored to the page. `carouselOverlapsBand` may still read geometry because it drives `opacity`, `enabled` and `Accessible.ignored` only, never a size.

## Behaviour change to be aware of

**Layouts with a readout in a centre zone will re-flow.** Those zones become as tall as their content instead of a fixed 120, so a vertically-centred column re-centres once. That is the invisible buffer going away, and it is what makes every measurement downstream describe what is actually on screen — but it is a visible change to the resting idle screen for anyone using `shotPlan`, `clock`, `temperature`, `waterLevel`, `scaleWeight`, `weather`, `machineStatus`, `steamTemperature`, `batteryLevel`, `scaleBattery` or `ghcSimulator` in a centre zone, and a hand-tuned zone Y-offset may want re-tuning.

## History in this branch

Two earlier approaches are in the commit history and were backed out, because both moved the centre column and the requirement was that nothing above the band move: a centre-column row-spacing squeeze, and a lift of the whole column by half the band's height (`67bdcf9f`, reverted in `c46a55a0`). They are kept rather than squashed away because they record what was ruled out and why. Squash-merge collapses them.

## Testing

- Qt Creator build: succeeded, 0 errors. The single warning is the pre-existing `__eh_frame section too large` linker warning present on `main`.
- All six blocking `text-invariants` gates pass locally.
- Verified on the macOS desktop build against the reporter's real layout: the band stays visible with a preset row open.
- QML has no test harness in this repo and is manual-test only, so there is no automated coverage for either change.
- **Not yet verified on Android**, where the original report came from.
