### PR TITLE
See a cup lift on a shot that never reached 20 g

### DIFF
--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -195,7 +195,7 @@ After the gate has held *continuously* for `SETTLING_CLEAN_CAPTURE_MS = 250 ms` 
 
 ### Final-weight on cup removal
 
-If the user lifts the cup before settling completes, the cup-removal detector fires on a >20 g drop (single-step OR cumulative-from-peak). The handler **skips learning** (a corrupted weight stream can't teach the predictor) but the shot still needs a `finalWeightG` to persist.
+If the user lifts the cup before settling completes, the cup-removal detector fires on a >20 g drop below the settling peak, at any absolute weight. (It used to additionally require the weight to have exceeded 20 g, which hid the lift entirely on a ristretto or a small SAW target — a lift reads as the cup's tared-out mass, tens of grams negative, so the drop was never the marginal case that precondition guarded.) A lift that lands near *zero* on a small shot is still a sub-20 g drop and remains undetected. The handler **skips learning** (a corrupted weight stream can't teach the predictor) but the shot still needs a `finalWeightG` to persist.
 
 Before issue [#1280](https://github.com/Kulitorum/Decenza/issues/1280), `m_weight` was left at whatever value the last accepted sample had. In practice that was often a *cup-lift spike artifact* that squeaked past the 20 g cup-removal threshold — e.g. shot 5470 persisted `38.5 g` even though the cup had actually settled at `42.3 g` for ~700 ms and SAW had correctly stopped at `41.2 g`. The AI advisor then reasoned from `yield=38.5, target=42` and invented a "you stopped manually" narrative.
 

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -238,7 +238,7 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
         bool cupRemoved = (weight < m_settlingPeakWeight - CUP_REMOVED_DROP_G);
         if (cupRemoved) {
             SAWT_WARN(QStringLiteral("Cup removed during settling (sample: %1 g peak: %2 g) "
-                                     "- skipping learning, restoring finalWeight")
+                                     "- skipping learning")
                           .arg(weight, 0, 'f', 2).arg(m_settlingPeakWeight, 0, 'f', 2));
             // Cup removal corrupts weight data — bypass learning entirely
             // but still emit signals so the shot is saved.

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -213,33 +213,22 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             m_settlingPeakWeight = weight;
         }
 
-        // Detect cup removal during settling: any drop of CUP_REMOVED_DROP_G
-        // below the peak this settle has seen. Measuring from the PEAK rather
-        // than from the previous sample catches a multi-step removal where no
-        // single step is large enough.
+        // Detect cup removal during settling: any drop of CUP_REMOVED_DROP_G below
+        // the settling peak. Measuring from the peak catches a multi-step removal.
         //
-        // This used to additionally require the weight to have EXCEEDED 20 g
-        // (`m_weight > 20.0 && ...`), which is what made a cup lift invisible on
-        // any shot that never got there — a ristretto, a small SAW target. The
-        // reading a lift produces is the tared-out cup mass, tens of grams
-        // NEGATIVE (shot 5470 logged -28.0), so the drop clears 20 g easily and
-        // the precondition was blocking the detector on exactly the shots that
-        // most needed it. The scale then sat still at that value and the fast
-        // path settled there, persisting a negative finalWeightG. Nothing else
-        // during settling can subtract weight — drip only adds — so the drop
-        // test alone is the whole signal.
+        // This also required the weight to have EXCEEDED 20 g, which hid the lift
+        // entirely on a shot that never got there. A lift reads as the cup's
+        // tared-out mass, tens of grams negative (shot 5470 logged -28.0), so the
+        // drop was never marginal — the precondition just blinded the detector on
+        // small shots, which then settled at that negative value. Drip can only ADD
+        // weight, so the drop test alone is the signal. The single-step clause went
+        // with it as redundant, not as a policy change: m_settlingPeakWeight is
+        // updated just above and is >= m_weight, so a drop from the previous sample
+        // implies a drop from the peak.
         //
-        // SCOPE: this catches a lift that reads NEGATIVE, which is the shape the
-        // only real sample we have takes. A lift that lands near ZERO on a small
-        // shot is a sub-20 g drop and still goes undetected — closing that needs
-        // the threshold itself lowered against a corpus, and the settling corpus
-        // currently holds one shot with settling lines and no cup-lift at all.
-        // Learning is not exposed in the negative case (`m_weight < 0` below
-        // skips it); it IS exposed in the near-zero case, which remains open.
-        //
-        // The single-step clause is gone as redundant, not as a policy change:
-        // m_settlingPeakWeight is updated just above and is >= m_weight by
-        // construction, so `weight < m_weight - DROP` implies this test.
+        // Only catches a lift that reads NEGATIVE. One landing near ZERO on a small
+        // shot is a sub-20 g drop and still gets through; lowering the threshold
+        // needs a corpus, and the settling corpus has one shot and no cup-lift.
         //
         // NOTE: cup-removed detection AND the fallback chain below are
         // mirrored in tools/shot_eval/main.cpp `analyzeShotSettling()` for
@@ -374,15 +363,12 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             // ended one sample ago.
             //
             // What reaches here is any change of at least 0.1 g the cup-removed
-            // gate above did not claim — and that gate is narrower than it looks.
-            // It tests for DROPS only, so every INCREASE arrives here regardless
-            // of size (a second cup or a portafilter set on the drip tray), as
-            // does a cup lift whose drop stays under CUP_REMOVED_DROP_G — which a
-            // small shot can produce if the lift reads near zero rather than
-            // negative. An earlier draft claimed a real cup lift "cannot happen"
-            // here; it was wrong in both of those directions. (It was also gated
-            // on the weight having exceeded 20 g, which widened this hole further;
-            // that precondition is gone.) Found from a suite failure, not from
+            // gate above did not claim, and that gate tests for DROPS only. So
+            // every INCREASE arrives here regardless of size (a second cup, a
+            // portafilter on the drip tray), as does a cup lift whose drop stays
+            // under CUP_REMOVED_DROP_G — a small shot lifted to near zero. An
+            // earlier draft claimed a real cup lift "cannot happen" here; it was
+            // wrong in both directions. Found from a suite failure, not from
             // #1280 — that symptom is attributed to the cup-removed path.
             if (stableMs >= SETTLING_STABLE_MS / 2)
                 endedStillMs = stableMs;
@@ -743,10 +729,9 @@ void ShotTimingController::onSettlingComplete()
         return;
     }
 
-    // Extra cup-removal guard at completion time. Handles slow/multi-step cup
-    // removal paths that may not trigger single-sample bypass checks. Same
-    // predicate as the per-sample detector, and it carried the same 20 g
-    // precondition that hid a lift on a sub-20 g shot.
+    // Extra cup-removal guard at completion time, for slow/multi-step removals the
+    // per-sample check missed. Same predicate as that check, and it carried the
+    // same 20 g precondition.
     if (m_weight < m_settlingPeakWeight - CUP_REMOVED_DROP_G) {
         SAWT_WARN(QStringLiteral("Possible cup removal detected at settling complete "
                                  "(weight=%1 g peak=%2 g), skipping learning")

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -709,12 +709,13 @@ void ShotTimingController::onSettlingComplete()
         return;
     }
 
-    // Calculate how much weight came after we sent the stop command
-    double drip = m_weight - m_weightAtStop;
-    if (drip < 0) {
-        SAWT_WARN(QStringLiteral("Negative drip (%1 g), clamping to 0").arg(drip, 0, 'f', 2));
-        drip = 0;  // Weight can't decrease
-    }
+    // Calculate how much weight came after we sent the stop command. A negative
+    // drip is physically impossible — drip only adds — so it means the weight
+    // stream is corrupt, most often a cup lift whose drop stayed under
+    // CUP_REMOVED_DROP_G. This used to be clamped to 0 and then learned from,
+    // which laundered it past addSawLearningPoint's own `drip < 0` reject — the
+    // guard written for exactly this value. Left negative so that guard sees it.
+    const double drip = m_weight - m_weightAtStop;
 
     double overshoot = m_weight - m_targetWeightAtStop;
 

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -216,7 +216,7 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
         // Detect cup removal during settling: any drop of CUP_REMOVED_DROP_G below
         // the settling peak. Measuring from the peak catches a multi-step removal.
         //
-        // This also required the weight to have EXCEEDED 20 g, which hid the lift
+        // It used to ALSO require the weight to have EXCEEDED 20 g, which hid the lift
         // entirely on a shot that never got there. A lift reads as the cup's
         // tared-out mass, tens of grams negative (shot 5470 logged -28.0), so the
         // drop was never marginal — the precondition just blinded the detector on
@@ -237,8 +237,8 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
         // update the offline tool to match.
         bool cupRemoved = (weight < m_settlingPeakWeight - CUP_REMOVED_DROP_G);
         if (cupRemoved) {
-            SAWT_WARN(QStringLiteral("Cup removed during settling (weight: %1 g peak: %2 g) "
-                                     "- skipping learning")
+            SAWT_WARN(QStringLiteral("Cup removed during settling (sample: %1 g peak: %2 g) "
+                                     "- skipping learning, restoring finalWeight")
                           .arg(weight, 0, 'f', 2).arg(m_settlingPeakWeight, 0, 'f', 2));
             // Cup removal corrupts weight data — bypass learning entirely
             // but still emit signals so the shot is saved.
@@ -279,7 +279,7 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             // log records why finalWeight is what it is — without this the
             // four paths are indistinguishable at post-mortem.
             if (cleanAvgPlausible) {
-                SAWT_LOG(QStringLiteral("Cup-removed: restored finalWeight to clean avg %1 g "
+                SAWT_INFO(QStringLiteral("Cup-removed: restored finalWeight to clean avg %1 g "
                                         "(was %2 g)")
                              .arg(m_lastCleanSettlingAvg, 0, 'f', 1).arg(m_weight, 0, 'f', 1));
                 m_weight = m_lastCleanSettlingAvg;
@@ -300,12 +300,12 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
                               .arg(m_weightAtStop, 0, 'f', 1));
                 m_weight = m_weightAtStop;
             } else if (m_weightAtStop > 0.0 && m_weight < m_weightAtStop) {
-                SAWT_LOG(QStringLiteral("Cup-removed: floored finalWeight at SAW trigger %1 g "
+                SAWT_INFO(QStringLiteral("Cup-removed: floored finalWeight at SAW trigger %1 g "
                                         "(was %2 g, no clean avg captured)")
                              .arg(m_weightAtStop, 0, 'f', 1).arg(m_weight, 0, 'f', 1));
                 m_weight = m_weightAtStop;
             } else {
-                SAWT_LOG(QStringLiteral("Cup-removed: no fallback applied (m_weight=%1 g, "
+                SAWT_INFO(QStringLiteral("Cup-removed: no fallback applied (m_weight=%1 g, "
                                         "m_weightAtStop=%2 g, haveCleanAvg=%3)")
                              .arg(m_weight, 0, 'f', 1).arg(m_weightAtStop, 0, 'f', 1)
                              .arg(haveCleanAvg ? QStringLiteral("true")
@@ -729,9 +729,15 @@ void ShotTimingController::onSettlingComplete()
         return;
     }
 
-    // Extra cup-removal guard at completion time, for slow/multi-step removals the
-    // per-sample check missed. Same predicate as that check, and it carried the
-    // same 20 g precondition.
+    // Backstop for the one path that can break the per-sample gate's invariant.
+    // That gate leaves m_weight >= m_settlingPeakWeight - CUP_REMOVED_DROP_G after
+    // every accepted sample, so the fast path and both timer paths cannot arrive
+    // here violating it; only `m_weight = avg` can, and only if the window
+    // straddles the sample that raised the peak. NOT a multi-step-removal
+    // backstop, which is what this comment used to claim: the peak is sticky, so
+    // the per-sample check catches the step that crosses the threshold. Note the
+    // `m_weight < 0` guard above also claims the small-shot case first, so the
+    // 20 g precondition coming off here changed nothing on its own.
     if (m_weight < m_settlingPeakWeight - CUP_REMOVED_DROP_G) {
         SAWT_WARN(QStringLiteral("Possible cup removal detected at settling complete "
                                  "(weight=%1 g peak=%2 g), skipping learning")
@@ -747,7 +753,7 @@ void ShotTimingController::onSettlingComplete()
         return;
     }
 
-    SAWT_LOG(QStringLiteral("Learning: final=%1 g target=%2 g drip=%3 g flow=%4 g/s overshoot=%5 g")
+    SAWT_INFO(QStringLiteral("Learning: final=%1 g target=%2 g drip=%3 g flow=%4 g/s overshoot=%5 g")
                 .arg(m_weight, 0, 'f', 2).arg(m_targetWeightAtStop, 0, 'f', 2)
                 .arg(drip, 0, 'f', 2).arg(m_flowRateAtStop, 0, 'f', 2)
                 .arg(overshoot, 0, 'f', 2));

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -213,18 +213,40 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             m_settlingPeakWeight = weight;
         }
 
-        // Detect cup removal during settling:
-        // 1. Single-step dramatic drop (>20g decrease from current)
-        // 2. Cumulative drop >20g below peak weight (catches multi-step removal
-        //    where no single step exceeds 20g)
+        // Detect cup removal during settling: any drop of CUP_REMOVED_DROP_G
+        // below the peak this settle has seen. Measuring from the PEAK rather
+        // than from the previous sample catches a multi-step removal where no
+        // single step is large enough.
+        //
+        // This used to additionally require the weight to have EXCEEDED 20 g
+        // (`m_weight > 20.0 && ...`), which is what made a cup lift invisible on
+        // any shot that never got there — a ristretto, a small SAW target. The
+        // reading a lift produces is the tared-out cup mass, tens of grams
+        // NEGATIVE (shot 5470 logged -28.0), so the drop clears 20 g easily and
+        // the precondition was blocking the detector on exactly the shots that
+        // most needed it. The scale then sat still at that value and the fast
+        // path settled there, persisting a negative finalWeightG. Nothing else
+        // during settling can subtract weight — drip only adds — so the drop
+        // test alone is the whole signal.
+        //
+        // SCOPE: this catches a lift that reads NEGATIVE, which is the shape the
+        // only real sample we have takes. A lift that lands near ZERO on a small
+        // shot is a sub-20 g drop and still goes undetected — closing that needs
+        // the threshold itself lowered against a corpus, and the settling corpus
+        // currently holds one shot with settling lines and no cup-lift at all.
+        // Learning is not exposed in the negative case (`m_weight < 0` below
+        // skips it); it IS exposed in the near-zero case, which remains open.
+        //
+        // The single-step clause is gone as redundant, not as a policy change:
+        // m_settlingPeakWeight is updated just above and is >= m_weight by
+        // construction, so `weight < m_weight - DROP` implies this test.
         //
         // NOTE: cup-removed detection AND the fallback chain below are
         // mirrored in tools/shot_eval/main.cpp `analyzeShotSettling()` for
         // offline corpus replay. There is no compile-time link enforcing
         // parity — when changing thresholds or the fallback ordering here,
         // update the offline tool to match.
-        bool cupRemoved = (m_weight > 20.0 && weight < m_weight - 20.0) ||
-                          (m_settlingPeakWeight > 20.0 && weight < m_settlingPeakWeight - 20.0);
+        bool cupRemoved = (weight < m_settlingPeakWeight - CUP_REMOVED_DROP_G);
         if (cupRemoved) {
             SAWT_WARN(QStringLiteral("Cup removed during settling (weight: %1 g peak: %2 g) "
                                      "- skipping learning")
@@ -353,14 +375,15 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             //
             // What reaches here is any change of at least 0.1 g the cup-removed
             // gate above did not claim — and that gate is narrower than it looks.
-            // It tests for DROPS only (`weight < m_weight - 20.0`), and both of its
-            // clauses are additionally gated on the weight having exceeded 20 g. So
-            // every INCREASE arrives here regardless of size (a second cup or a
-            // portafilter set on the drip tray), as does a genuine cup lift on any
-            // shot whose weight never passed 20 g — a ristretto, a small SAW target.
-            // An earlier draft claimed a real cup lift "cannot happen" here; it was
-            // wrong in both of those directions. Found from a suite failure, not
-            // from #1280 — that symptom is attributed to the cup-removed path.
+            // It tests for DROPS only, so every INCREASE arrives here regardless
+            // of size (a second cup or a portafilter set on the drip tray), as
+            // does a cup lift whose drop stays under CUP_REMOVED_DROP_G — which a
+            // small shot can produce if the lift reads near zero rather than
+            // negative. An earlier draft claimed a real cup lift "cannot happen"
+            // here; it was wrong in both of those directions. (It was also gated
+            // on the weight having exceeded 20 g, which widened this hole further;
+            // that precondition is gone.) Found from a suite failure, not from
+            // #1280 — that symptom is attributed to the cup-removed path.
             if (stableMs >= SETTLING_STABLE_MS / 2)
                 endedStillMs = stableMs;
             stableMs = 0;
@@ -721,8 +744,10 @@ void ShotTimingController::onSettlingComplete()
     }
 
     // Extra cup-removal guard at completion time. Handles slow/multi-step cup
-    // removal paths that may not trigger single-sample bypass checks.
-    if (m_settlingPeakWeight > 20.0 && m_weight < m_settlingPeakWeight - 20.0) {
+    // removal paths that may not trigger single-sample bypass checks. Same
+    // predicate as the per-sample detector, and it carried the same 20 g
+    // precondition that hid a lift on a sub-20 g shot.
+    if (m_weight < m_settlingPeakWeight - CUP_REMOVED_DROP_G) {
         SAWT_WARN(QStringLiteral("Possible cup removal detected at settling complete "
                                  "(weight=%1 g peak=%2 g), skipping learning")
                       .arg(m_weight, 0, 'f', 2).arg(m_settlingPeakWeight, 0, 'f', 2));

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -189,6 +189,10 @@ private:
     // it onDisplayTimerTick's fires every 50 ms tick and onWeightSample's fires on
     // every sample (4-10 Hz depending on scale) — 100+ lines a shot either way.
     static constexpr int DRIP_ONGOING_LOG_THROTTLE_MS = 1000;
+    // A drop this far below the settling peak is a cup lift (or a bump, or a
+    // mid-settle tare) — never drip, which can only ADD weight. Mirrored in
+    // tools/shot_eval/main.cpp as CUP_REMOVED_DROP_G.
+    static constexpr double CUP_REMOVED_DROP_G = 20.0;
     double m_settlingWindow[SETTLING_WINDOW_SIZE] = {};
     int m_settlingWindowCount = 0;
     int m_settlingWindowIndex = 0;

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -189,9 +189,8 @@ private:
     // it onDisplayTimerTick's fires every 50 ms tick and onWeightSample's fires on
     // every sample (4-10 Hz depending on scale) — 100+ lines a shot either way.
     static constexpr int DRIP_ONGOING_LOG_THROTTLE_MS = 1000;
-    // A drop this far below the settling peak is a cup lift (or a bump, or a
-    // mid-settle tare) — never drip, which can only ADD weight. Mirrored in
-    // tools/shot_eval/main.cpp as CUP_REMOVED_DROP_G.
+    // A drop this far below the settling peak is a cup lift, never drip — drip only
+    // adds. Mirrored in tools/shot_eval/main.cpp under the same name.
     static constexpr double CUP_REMOVED_DROP_G = 20.0;
     double m_settlingWindow[SETTLING_WINDOW_SIZE] = {};
     int m_settlingWindowCount = 0;

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -610,6 +610,8 @@ private slots:
         tc.endShot();
         QVERIFY(tc.isSawSettling());
 
+        QSignalSpy learnSpy(&tc, &ShotTimingController::sawLearningComplete);
+
         QTest::ignoreMessage(QtWarningMsg,
             QRegularExpression("Cup removed during settling"));
 
@@ -623,7 +625,13 @@ private slots:
         QVERIFY2(tc.currentWeight() > 14.0 && tc.currentWeight() < 16.5,
                  qPrintable(QString("Expected ~15.2 g (the clean settled avg), got "
                                     "%1 g").arg(tc.currentWeight(), 0, 'f', 2)));
-        // Learning must be skipped, exactly as on a >20 g shot.
+        // A cup lift teaches the predictor nothing, so learning must be skipped --
+        // asserted on the signal, since wasSawTriggered() below cannot observe it.
+        QCOMPARE(learnSpy.count(), 0);
+        // #1161 invariant: the cup-removed branch clears m_sawTriggeredThisShot but
+        // must NOT clear m_stopAtWeightTriggered, which is what wasSawTriggered()
+        // reads -- otherwise MainController::onShotEnded misclassifies this as
+        // "profileEnd" instead of "weight".
         QVERIFY2(tc.wasSawTriggered(),
                  "Cup-removed path must preserve wasSawTriggered() == true");
     }
@@ -666,7 +674,7 @@ private slots:
         tc.onWeightSample(51.0, 0.5);  // delta +2.6; weightAboveAvg trips
         QCOMPARE(tc.m_lastCleanSettlingAvg, capturedAvg);
 
-        // Cup-removed via single-step drop from 51 to 20 (delta 31 > 20).
+        // Cup-removed: 51.0 -> 20.0 is a 31 g drop below the peak (> CUP_REMOVED_DROP_G).
         tc.onWeightSample(20.0, 0.5);
 
         QVERIFY(!tc.isSawSettling());

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -597,17 +597,11 @@ private slots:
     }
 
     void cupLiftDetectedOnShotThatNeverReached20g() {
-        // The cup-removal detector used to require the weight to have EXCEEDED
-        // 20 g before it would look at the drop at all. On a ristretto or a small
-        // SAW target that never happens, so lifting the cup mid-settle was not
-        // detected: the tared-out cup mass (tens of grams negative) went through
-        // as an ordinary sample, the scale then sat still at that value, and the
-        // fast path settled there, persisting a negative finalWeightG.
-        //
-        // 15 g target, so every weight here is under the old gate. -28.0 is the
-        // reading shot 5470 actually logged when its cup came off; it is the cup's
-        // tared-out mass, so it does not scale down with the target -- which is
-        // why the drop clears 20 g even though nothing in the shot ever did.
+        // Cup-removal used to require the weight to have EXCEEDED 20 g before it
+        // looked at the drop, so a lift on a ristretto went undetected and settling
+        // finished at the negative reading. 15 g target, so nothing here clears the
+        // old gate; -28.0 is what shot 5470 logged when its cup came off, and being
+        // the cup's tared-out mass it does not scale down with the target.
         DE1Device device;
         ShotTimingController tc(&device);
 

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -596,6 +596,44 @@ private slots:
         QCOMPARE(tc.currentWeight(), 44.0);
     }
 
+    void cupLiftDetectedOnShotThatNeverReached20g() {
+        // The cup-removal detector used to require the weight to have EXCEEDED
+        // 20 g before it would look at the drop at all. On a ristretto or a small
+        // SAW target that never happens, so lifting the cup mid-settle was not
+        // detected: the tared-out cup mass (tens of grams negative) went through
+        // as an ordinary sample, the scale then sat still at that value, and the
+        // fast path settled there, persisting a negative finalWeightG.
+        //
+        // 15 g target, so every weight here is under the old gate. -28.0 is the
+        // reading shot 5470 actually logged when its cup came off; it is the cup's
+        // tared-out mass, so it does not scale down with the target -- which is
+        // why the drop clears 20 g even though nothing in the shot ever did.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        tc.startShot();
+        tc.onSawTriggered(15.0, 2.5, 15.5);
+        tc.endShot();
+        QVERIFY(tc.isSawSettling());
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("Cup removed during settling"));
+
+        feedPlateauUntilCaptured(tc, 15.2, 0.5);
+
+        tc.onWeightSample(-28.0, 0.5);
+
+        QVERIFY2(!tc.isSawSettling(),
+                 "Cup-removed never fired on a sub-20 g shot, so settling ran on "
+                 "with a negative reading");
+        QVERIFY2(tc.currentWeight() > 14.0 && tc.currentWeight() < 16.5,
+                 qPrintable(QString("Expected ~15.2 g (the clean settled avg), got "
+                                    "%1 g").arg(tc.currentWeight(), 0, 'f', 2)));
+        // Learning must be skipped, exactly as on a >20 g shot.
+        QVERIFY2(tc.wasSawTriggered(),
+                 "Cup-removed path must preserve wasSawTriggered() == true");
+    }
+
     void cleanAvgSurvivesPostCaptureGateFailure_1280() {
         // Regression guard for the "captured then disturbed" sequence
         // Mark's shot 5470 actually had: settling plateau holds for

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -865,10 +865,14 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
                 r.stopWeight = w;
                 r.hasSawTrigger = true;
                 curWeight = 0.0;
-                // Production seeds m_settlingPeakWeight from the weight at settling
-                // start, not from 0. Seeding 0 here made the first settling sample
-                // test `weight < -20` instead of `weight < stopWeight - 20`, which
-                // misses a small-shot lift landing on that sample.
+                // Seeding 0 made the first settling sample test `weight < -20`
+                // instead of `weight < stopWeight - 20`, missing a small-shot lift
+                // that lands on that sample. The trigger weight is the closest seed
+                // the log offers, but it is NOT what production uses: production
+                // seeds from m_weight at endShot, which is higher by whatever drip
+                // accrued during the stop latency. So this still under-detects a
+                // first-sample lift by that margin — conservative, not equivalent.
+                // curWeight above keeps the 0 seed and the same asymmetry.
                 peakWeight = w;
                 continue;
             }

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -741,7 +741,7 @@ EvaluatedShot evaluate(const LoadedShot& s)
 //   SETTLING_WINDOW_SIZE = 6
 //   SETTLING_AVG_THRESHOLD = 0.3 g
 //   SETTLING_ABOVE_AVG_MARGIN = 0.2 g
-//   cup-removal: >20 g single-step drop OR >20 g cumulative drop from peak
+//   cup-removal: >20 g drop below the settling peak, at any absolute weight
 //   SETTLING_CLEAN_CAPTURE_MS = 250 ms (mirrored here as
 //     MIN_CONSECUTIVE_STABLE_FIRES = 3 — sample-count approximation, see
 //     comment at the declaration for the trade-off vs scale-rate variation)
@@ -880,9 +880,10 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
 
         // Mirror cup-removal trigger (before m_weight updates) — if it fires
         // here, the production code would early-return; stop sampling.
-        const bool wouldFireRemoval =
-            (curWeight > CUP_REMOVED_DROP_G && weight < curWeight - CUP_REMOVED_DROP_G) ||
-            (peakWeight > CUP_REMOVED_DROP_G && weight < peakWeight - CUP_REMOVED_DROP_G);
+        // Mirrors ShotTimingController: a drop of CUP_REMOVED_DROP_G below the
+        // settling peak, with no precondition on the weight having reached 20 g.
+        // That precondition used to hide cup lifts on sub-20 g shots entirely.
+        const bool wouldFireRemoval = (weight < peakWeight - CUP_REMOVED_DROP_G);
         if (wouldFireRemoval) {
             cupRemovedFired = true;
             r.cupRemoved = true;

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -865,7 +865,11 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
                 r.stopWeight = w;
                 r.hasSawTrigger = true;
                 curWeight = 0.0;
-                peakWeight = 0.0;
+                // Production seeds m_settlingPeakWeight from the weight at settling
+                // start, not from 0. Seeding 0 here made the first settling sample
+                // test `weight < -20` instead of `weight < stopWeight - 20`, which
+                // misses a small-shot lift landing on that sample.
+                peakWeight = w;
                 continue;
             }
         }


### PR DESCRIPTION
The cup-removal detector required the weight to have EXCEEDED 20 g before it would look at the drop at all:

```cpp
(m_weight > 20.0 && weight < m_weight - 20.0) ||
(m_settlingPeakWeight > 20.0 && weight < m_settlingPeakWeight - 20.0)
```

On a ristretto or a small stop-at-weight target that never happens, so lifting the cup mid-settle was not detected. The reading a lift produces is the cup's tared-out mass — tens of grams *negative*; shot 5470 logged `-28.0` — so it does not scale down with the target and the drop clears 20 g easily. The precondition was never guarding a marginal drop; it blinded the detector on exactly the shots that most needed it. The negative reading went through as an ordinary sample, the scale sat still at it, and the fast path settled there, persisting a negative `finalWeightG`.

Drip can only ADD weight, so the drop test alone is the whole signal. Four terms become one, and the same collapse applies to the completion-time guard and to the offline replay in `shot_eval`, which the detector's own NOTE requires be kept in lockstep.

The single-step clause goes as **redundant, not as a policy change**: `m_settlingPeakWeight` is updated immediately above the check and only ever grows, so `peak >= m_weight` always holds and a drop from the previous sample implies a drop from the peak.

## Also here: a negative drip no longer launders past its own guard

`onSettlingComplete` clamped a negative drip to 0 and carried on, and `addSawLearningPoint`'s own `drip < 0` reject then never saw it — two places encode the same invariant and one repaired the value so the other could not fire. The clamp is deleted; nothing is added in its place. No threshold, no noise band.

Worth being accurate about the size of this: the batched accumulator commits the median of 3 shots, so a single lift is normally outvoted. The case that survives is a user who habitually lifts early — the same small-shot population as the rest of the branch. It also mattered more than it looked, because a lift's large negative overshoot marks it an auto-reset candidate, and that path deliberately *skips* outlier rejection.

## Scope — this is a partial fix

It catches a lift that reads **negative**, the shape the only real sample we have takes. A lift landing near **zero** on a small shot is a sub-20 g drop and still goes undetected; closing that means lowering the threshold itself against a corpus.

| Lift reads | `finalWeightG` | SAW learning |
|---|---|---|
| Negative | was persisted negative — **fixed** | was already skipped by the `m_weight < 0` guard |
| Near zero | still wrong | still exposed — **open** |

## Verification

Built clean and **113 passed, 0 failed, 0 skipped**, no tests with warnings.

The regression test was also proven able to fail rather than assumed to be: reverting the predicate to its pre-fix form and rebuilding produces

```
FAIL!  : tst_Settling::cupLiftDetectedOnShotThatNeverReached20g()
'!tc.isSawSettling()' returned FALSE.
(Cup-removed never fired on a sub-20 g shot, so settling ran on with a negative reading)
```

and it is the *only* failure in the suite — which is the evidence that the removed single-step clause was redundant rather than load-bearing.

What is **not** established: this could not be corpus-validated. Replaying old-vs-new over `tests/data/shots/` gives zero verdict changes, but only 1 of 23 shots has settling lines and none has a cup removal, so that result carries almost no weight. The false-positive argument ("drip only adds") is physical reasoning, not measurement, and `-28.0` generalises from a single shot.

## Review findings folded in

Four review agents plus two solo passes over the diff. Beyond the above:

- The completion-time guard's comment claimed it caught "slow/multi-step removals the per-sample check missed" — false, and false before this branch: the peak is sticky, so the per-sample check catches the crossing step. Its one real seam (`m_weight = avg` straddling the peak-setting sample) is now stated. Guard kept, rationale corrected.
- `sawlogging.h` puts "what the shot actually settled at" at INFO. Three of the four cup-removed fallback branches decide exactly that and sat at DEBUG while the fault above them was WARN, so at the default INFO a reader saw the alarming raw sample and nothing saying it had been repaired. Promoted, along with the `Learning:` line — every refusal was WARN and the one line saying learning *proceeded* was DEBUG.
- The offline mirror seeded `peakWeight` at 0, missing a first-sample small-shot lift — the exact case this branch is about, in the tool whose output would be used to argue about it.
- The new test asserted learning was skipped via `wasSawTriggered()`, which nothing in the test can clear. Now spied on `sawLearningComplete`.

Follow-up to #1854, whose description recorded this gap as known and not fixed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
