### PR TITLE
Wait on the outcome, not the clock, in two timer-raced tests

### DIFF
--- a/tests/tst_blegattqueue.cpp
+++ b/tests/tst_blegattqueue.cpp
@@ -212,18 +212,21 @@ private slots:
         pump();
         QCOMPARE(rec.issued.size(), 1);
 
+        // A reissue arrives on a singleShot(retryDelayMs), so these wait on the
+        // reissue itself. A fixed pump() asserts that a timer fired inside a
+        // wall-clock budget, which is a race the parallel sanitizer build loses
+        // often enough to be seen.
         q.noteFailed(de1());
-        pump();
-        QCOMPARE(rec.issued.size(), 2);
+        QTRY_COMPARE(rec.issued.size(), 2);
         QVERIFY(q.isBusy());          // slot held across the retry
         QVERIFY(rec.abandoned.isEmpty());
 
         q.noteFailed(de1());
-        pump();
-        QCOMPARE(rec.issued.size(), 3);
+        QTRY_COMPARE(rec.issued.size(), 3);
         QVERIFY(rec.abandoned.isEmpty());
 
-        // Budget spent.
+        // Budget spent: the count must STAY at 3, so this one waits out the
+        // retry delay rather than polling — QTRY would pass on the first look.
         q.noteFailed(de1());
         pump();
         QCOMPARE(rec.issued.size(), 3);

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -1234,9 +1234,11 @@ private slots:
 
         QVERIFY(scale.isConnected());
 
-        // Setup commands are sent from a 100ms singleShot after discovery.
-        QTest::qWait(200);
-        QVERIFY(!transport->m_writes.isEmpty());
+        // Setup commands are sent from a 100ms singleShot after discovery. Wait
+        // on the outcome, not the clock: a fixed qWait races that timer whenever
+        // the machine is loaded, which under the parallel sanitizer build is
+        // routine rather than exceptional.
+        QTRY_VERIFY(!transport->m_writes.isEmpty());
         QCOMPARE(transport->m_lastWriteService, Scale::DiFluid::SERVICE_TI);
         QCOMPARE(transport->m_lastNotifyService, Scale::DiFluid::SERVICE_TI);
 


### PR DESCRIPTION
Two tests assert a timer-driven result after a fixed `QTest::qWait`, and each names the timer in its own comment:

- `tst_blegattqueue::anOperationWithARetryBudgetIsReissuedUpToThatBudget` — the retry arrives on a `singleShot(retryDelayMs)` ([blegattqueue.cpp:267](https://github.com/Kulitorum/Decenza/blob/81db0900/src/ble/blegattqueue.cpp#L266-L268)), checked after `pump()` = `qWait(30)`.
- `tst_scaleprotocol::difluidTiCommandsUseTiService` — "Setup commands are sent from a 100ms singleShot after discovery", checked after `qWait(200)`.

A fixed wait asserts that a timer fired inside a wall-clock budget. That holds on an idle machine and stops holding when the suite runs its targets in parallel under ASan and UBSan, which is the normal local case. Both were observed failing during unrelated work and passing on re-run.

`QTRY_COMPARE` / `QTRY_VERIFY` poll until a generous timeout — robust under load, no slower when idle.

One assertion deliberately keeps `pump()`: the post-budget check that the reissue count *stays* at 3. `QTRY` would satisfy that on its first look, before the retry delay it exists to outlast, so waiting is the right primitive there.

Found while working on #1857; unrelated to it, so it is separate.

113 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)