### PR TITLE
Make long-press reach the three tap-only bar widgets

### DIFF
--- a/qml/components/AccessibleTapHandler.qml
+++ b/qml/components/AccessibleTapHandler.qml
@@ -18,7 +18,17 @@ MouseArea {
     // The item to track for "tap again to activate" (defaults to parent)
     property var accessibleItem: parent
 
-    // Whether long-press is supported
+    // Whether long-press is supported. This is what makes accessibleLongPressed
+    // reachable AT ALL: false means the press timer below never starts, so the
+    // signal never fires and the release runs the ordinary tap instead. A handler
+    // declared without it is dead code that looks live -- three widgets shipped
+    // exactly that (gated now by tst_customwidgethtml).
+    //
+    // Widgets whose long press has a DESTINATION of its own set this true. A widget
+    // whose tap is the only route to its page gates it on a stored override instead
+    // (see the three tap-only layout widgets): with it unconditionally true, a slow
+    // press sets _longPressTriggered, onReleased returns early, and the tap that
+    // would have opened the page is swallowed.
     property bool supportLongPress: false
 
     // Whether double-tap is supported (adds delay to single taps)

--- a/qml/components/layout/LayoutActions.qml
+++ b/qml/components/layout/LayoutActions.qml
@@ -187,6 +187,33 @@ QtObject {
         return items
     }
 
+    // What TalkBack/VoiceOver says after the widget's name when a gesture carries an
+    // override. Action labels stay generic: a stored action string ("navigate:settings")
+    // has no human-readable label at this point.
+    //
+    // Lives here rather than on CustomItem for the reason the dispatch does — every
+    // built-in action widget needs the same sentence, and the dedicated items cannot
+    // reach a property on CustomItem. Three of them announced nothing at all, which
+    // matters most to the users who cannot see the widget: AccessibleTapHandler
+    // disables double-tap detection in accessibility mode, so long press is the ONLY
+    // secondary gesture a screen-reader user has.
+    // A stored kNoAction is an explicit silence, so it announces nothing: promising a
+    // secondary action that deliberately does nothing is worse than promising none.
+    // CustomItem's own hint used to count it as an action; this is that fix too.
+    function gestureHint(modelData) {
+        var lp = modelData ? modelData.longPressAction : ""
+        var dc = modelData ? modelData.doubleclickAction : ""
+        var hasLP = !!lp && lp !== layoutActions.kNoAction
+        var hasDC = !!dc && dc !== layoutActions.kNoAction
+        if (hasLP && hasDC)
+            return TranslationManager.translate("customitem.accessible.hint.both", "Long-press or double-tap for additional actions.")
+        if (hasLP)
+            return TranslationManager.translate("customitem.accessible.hint.longpress", "Long-press for additional action.")
+        if (hasDC)
+            return TranslationManager.translate("customitem.accessible.hint.doubletap", "Double-tap for additional action.")
+        return ""
+    }
+
     // Explicitly "do nothing on this gesture" — DISTINCT from unset. Unset ("")
     // means "whatever this widget does by default", which on most action widgets
     // is opening its page. A user who wants the gesture silenced needs a way to

--- a/qml/components/layout/items/AutoFavoritesItem.qml
+++ b/qml/components/layout/items/AutoFavoritesItem.qml
@@ -59,7 +59,14 @@ LayoutWidgetItem {
             supportDoubleClick: true
             onAccessibleClicked: root.goToAutoFavorites()
             // Tap already opens the page, so BOTH gestures are free to override.
-            // With nothing stored these do nothing, which is exactly today's behaviour.
+            //
+            // supportLongPress is what makes the handler below reachable AT ALL: with it
+            // false the press timer never starts, so a long press ran no override and the
+            // release opened the page instead -- the handler was declared and dead. It is
+            // gated on a stored override, matching the compiled CustomItem twin
+            // (CustomItem.qml): unset, the press falls through to the tap that opens this
+            // page, and a stored "none" is consumed so the gesture is silent.
+            supportLongPress: !!(root.modelData && root.modelData.longPressAction)
             onAccessibleLongPressed: LayoutActions.runGesture(root.modelData, "longPressAction", null)
             onAccessibleDoubleClicked: LayoutActions.runGesture(root.modelData, "doubleclickAction", null)
         }

--- a/qml/components/layout/items/AutoFavoritesItem.qml
+++ b/qml/components/layout/items/AutoFavoritesItem.qml
@@ -12,8 +12,11 @@ LayoutWidgetItem {
     id: root
 
 
-    implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
-    implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
+    // Compact only: in a centre zone this type is compiled to CustomItem
+    // (LayoutItemDelegate.isCompiled), so this file is never loaded with
+    // isCompact false. The full-mode branch it used to carry rendered nowhere.
+    implicitWidth: compactContent.implicitWidth
+    implicitHeight: compactContent.implicitHeight
 
     function goToAutoFavorites() {
             AppShell.autoFavoritesRequested()
@@ -22,7 +25,6 @@ LayoutWidgetItem {
     // --- COMPACT MODE ---
     Item {
         id: compactContent
-        visible: root.isCompact
         anchors.fill: parent
         implicitWidth: compactFavRow.implicitWidth + Theme.scaled(16)
         implicitHeight: Theme.bottomBarHeight
@@ -56,38 +58,20 @@ LayoutWidgetItem {
         AccessibleTapHandler {
             anchors.fill: parent
             accessibleName: TranslationManager.translate("idle.accessible.autofavorites.description", "Open auto-favorites list of recent bean and profile combinations")
+            accessibleDescription: LayoutActions.gestureHint(root.modelData)
             supportDoubleClick: true
             onAccessibleClicked: root.goToAutoFavorites()
             // Tap already opens the page, so BOTH gestures are free to override.
             //
-            // supportLongPress is what makes the handler below reachable AT ALL: with it
-            // false the press timer never starts, so a long press ran no override and the
-            // release opened the page instead -- the handler was declared and dead. It is
-            // gated on a stored override, matching the compiled CustomItem twin
-            // (CustomItem.qml): unset, the press falls through to the tap that opens this
-            // page, and a stored "none" is consumed so the gesture is silent.
+            // Gated, not `true`: this widget reserves no destination
+            // (gestureReservedDestination(), settings_network.cpp), so the release tap is
+            // the ONLY route to its page -- and a long press that starts the timer
+            // swallows that tap whether or not it dispatches anything. Unset therefore
+            // has to leave the timer alone. See AccessibleTapHandler.supportLongPress.
             supportLongPress: !!(root.modelData && root.modelData.longPressAction)
             onAccessibleLongPressed: LayoutActions.runGesture(root.modelData, "longPressAction", null)
             onAccessibleDoubleClicked: LayoutActions.runGesture(root.modelData, "doubleclickAction", null)
         }
     }
 
-    // --- FULL MODE ---
-    Item {
-        id: fullContent
-        visible: !root.isCompact
-        anchors.fill: parent
-        implicitWidth: Theme.scaled(150)
-        implicitHeight: Theme.scaled(120)
-
-        ActionButton {
-            anchors.fill: parent
-            translationKey: "idle.button.autofavorites"
-            translationFallback: "Favorites"
-            iconSource: "qrc:/icons/star.svg"
-            iconSize: Theme.scaled(43)
-            backgroundColor: Theme.actionButtonFillOn(Theme.primaryColor, root.zoneFillOverride)
-            onClicked: root.goToAutoFavorites()
-        }
-    }
 }

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -37,20 +37,11 @@ LayoutWidgetItem {
     readonly property bool hasEmoji: emoji !== ""
     readonly property bool emojiIsSvg: hasEmoji && emoji.indexOf("qrc:") === 0
 
-    // Accessibility hint describing configured secondary actions (for TalkBack/VoiceOver)
-    // Action labels are intentionally generic because action strings (e.g. "navigate:settings") have no associated human-readable label.
-    readonly property string _accessibleHint: {
-        var _ = TranslationManager.translationVersion  // re-evaluate on language change
-        var hasLP = root.longPressAction !== ""
-        var hasDC = root.doubleclickAction !== ""
-        if (hasLP && hasDC)
-            return TranslationManager.translate("customitem.accessible.hint.both", "Long-press or double-tap for additional actions.")
-        if (hasLP)
-            return TranslationManager.translate("customitem.accessible.hint.longpress", "Long-press for additional action.")
-        if (hasDC)
-            return TranslationManager.translate("customitem.accessible.hint.doubletap", "Double-tap for additional action.")
-        return ""
-    }
+    // Accessibility hint describing configured secondary actions (for TalkBack/VoiceOver).
+    // The sentence itself lives in LayoutActions, which is where the dedicated action
+    // widgets can reach it too -- they need the identical hint and cannot read a
+    // property on this file.
+    readonly property string _accessibleHint: LayoutActions.gestureHint(root.modelData)
 
     // Action tiles use Theme.actionTileColor (neutral over a custom background
     // image so they match the bars/cards, standard accent otherwise); an explicit

--- a/qml/components/layout/items/HistoryItem.qml
+++ b/qml/components/layout/items/HistoryItem.qml
@@ -60,7 +60,14 @@ LayoutWidgetItem {
             supportDoubleClick: true
             onAccessibleClicked: root.goToHistory()
             // Tap already opens the page, so BOTH gestures are free to override.
-            // With nothing stored these do nothing, which is exactly today's behaviour.
+            //
+            // supportLongPress is what makes the handler below reachable AT ALL: with it
+            // false the press timer never starts, so a long press ran no override and the
+            // release opened the page instead -- the handler was declared and dead. It is
+            // gated on a stored override, matching the compiled CustomItem twin
+            // (CustomItem.qml): unset, the press falls through to the tap that opens this
+            // page, and a stored "none" is consumed so the gesture is silent.
+            supportLongPress: !!(root.modelData && root.modelData.longPressAction)
             onAccessibleLongPressed: LayoutActions.runGesture(root.modelData, "longPressAction", null)
             onAccessibleDoubleClicked: LayoutActions.runGesture(root.modelData, "doubleclickAction", null)
         }

--- a/qml/components/layout/items/HistoryItem.qml
+++ b/qml/components/layout/items/HistoryItem.qml
@@ -12,8 +12,11 @@ LayoutWidgetItem {
     id: root
 
 
-    implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
-    implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
+    // Compact only: in a centre zone this type is compiled to CustomItem
+    // (LayoutItemDelegate.isCompiled), so this file is never loaded with
+    // isCompact false. The full-mode branch it used to carry rendered nowhere.
+    implicitWidth: compactContent.implicitWidth
+    implicitHeight: compactContent.implicitHeight
 
     function goToHistory() {
             AppShell.shotHistoryRequested({})
@@ -22,7 +25,6 @@ LayoutWidgetItem {
     // --- COMPACT MODE ---
     Item {
         id: compactContent
-        visible: root.isCompact
         anchors.fill: parent
         implicitWidth: compactHistoryRow.implicitWidth + Theme.scaled(16)
         implicitHeight: Theme.bottomBarHeight
@@ -57,38 +59,20 @@ LayoutWidgetItem {
         AccessibleTapHandler {
             anchors.fill: parent
             accessibleName: TranslationManager.translate("idle.accessible.history.description", "View and compare past shots")
+            accessibleDescription: LayoutActions.gestureHint(root.modelData)
             supportDoubleClick: true
             onAccessibleClicked: root.goToHistory()
             // Tap already opens the page, so BOTH gestures are free to override.
             //
-            // supportLongPress is what makes the handler below reachable AT ALL: with it
-            // false the press timer never starts, so a long press ran no override and the
-            // release opened the page instead -- the handler was declared and dead. It is
-            // gated on a stored override, matching the compiled CustomItem twin
-            // (CustomItem.qml): unset, the press falls through to the tap that opens this
-            // page, and a stored "none" is consumed so the gesture is silent.
+            // Gated, not `true`: this widget reserves no destination
+            // (gestureReservedDestination(), settings_network.cpp), so the release tap is
+            // the ONLY route to its page -- and a long press that starts the timer
+            // swallows that tap whether or not it dispatches anything. Unset therefore
+            // has to leave the timer alone. See AccessibleTapHandler.supportLongPress.
             supportLongPress: !!(root.modelData && root.modelData.longPressAction)
             onAccessibleLongPressed: LayoutActions.runGesture(root.modelData, "longPressAction", null)
             onAccessibleDoubleClicked: LayoutActions.runGesture(root.modelData, "doubleclickAction", null)
         }
     }
 
-    // --- FULL MODE ---
-    Item {
-        id: fullContent
-        visible: !root.isCompact
-        anchors.fill: parent
-        implicitWidth: Theme.scaled(150)
-        implicitHeight: Theme.scaled(120)
-
-        ActionButton {
-            anchors.fill: parent
-            translationKey: "idle.button.history"
-            translationFallback: "History"
-            iconSource: "qrc:/icons/history.svg"
-            iconSize: Theme.scaled(43)
-            backgroundColor: Theme.actionButtonFillOn(Theme.primaryColor, root.zoneFillOverride)
-            onClicked: root.goToHistory()
-        }
-    }
 }

--- a/qml/components/layout/items/SettingsItem.qml
+++ b/qml/components/layout/items/SettingsItem.qml
@@ -41,7 +41,14 @@ LayoutWidgetItem {
             supportDoubleClick: true
             onAccessibleClicked: root.goToSettings()
             // Tap already opens the page, so BOTH gestures are free to override.
-            // With nothing stored these do nothing, which is exactly today's behaviour.
+            //
+            // supportLongPress is what makes the handler below reachable AT ALL: with it
+            // false the press timer never starts, so a long press ran no override and the
+            // release opened the page instead -- the handler was declared and dead. It is
+            // gated on a stored override, matching the compiled CustomItem twin
+            // (CustomItem.qml): unset, the press falls through to the tap that opens this
+            // page, and a stored "none" is consumed so the gesture is silent.
+            supportLongPress: !!(root.modelData && root.modelData.longPressAction)
             onAccessibleLongPressed: LayoutActions.runGesture(root.modelData, "longPressAction", null)
             onAccessibleDoubleClicked: LayoutActions.runGesture(root.modelData, "doubleclickAction", null)
         }

--- a/qml/components/layout/items/SettingsItem.qml
+++ b/qml/components/layout/items/SettingsItem.qml
@@ -1,3 +1,10 @@
+// `layer.effect` declares an inline component, so this file's ids are not statically
+// resolvable inside it without this pragma -- the gear now colorizes with the zone's
+// contrast colour, which is a read of `root` from inside that component. No delegate in
+// this file takes an injected model role, so no `required property` is needed; the two
+// structural twins (HistoryItem, AutoFavoritesItem) carry the same header.
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Effects
 import Decenza
@@ -5,8 +12,11 @@ import Decenza
 LayoutWidgetItem {
     id: root
 
-    implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
-    implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
+    // Compact only: in a centre zone this type is compiled to CustomItem
+    // (LayoutItemDelegate.isCompiled), so this file is never loaded with
+    // isCompact false. The full-mode branch it used to carry rendered nowhere.
+    implicitWidth: compactContent.implicitWidth
+    implicitHeight: compactContent.implicitHeight
 
     function goToSettings() {
             AppShell.settingsRequested("")
@@ -15,7 +25,6 @@ LayoutWidgetItem {
     // --- COMPACT MODE ---
     Item {
         id: compactContent
-        visible: root.isCompact
         anchors.fill: parent
         implicitWidth: Theme.bottomBarHeight
         implicitHeight: Theme.bottomBarHeight
@@ -31,44 +40,27 @@ LayoutWidgetItem {
             layer.smooth: true
             layer.effect: MultiEffect {
                 colorization: 1.0
-                colorizationColor: Theme.textColor
+                colorizationColor: root.zoneTextColor
             }
         }
 
         AccessibleTapHandler {
             anchors.fill: parent
             accessibleName: TranslationManager.translate("layout.settings.accessible.open", "Settings. Open application settings")
+            accessibleDescription: LayoutActions.gestureHint(root.modelData)
             supportDoubleClick: true
             onAccessibleClicked: root.goToSettings()
             // Tap already opens the page, so BOTH gestures are free to override.
             //
-            // supportLongPress is what makes the handler below reachable AT ALL: with it
-            // false the press timer never starts, so a long press ran no override and the
-            // release opened the page instead -- the handler was declared and dead. It is
-            // gated on a stored override, matching the compiled CustomItem twin
-            // (CustomItem.qml): unset, the press falls through to the tap that opens this
-            // page, and a stored "none" is consumed so the gesture is silent.
+            // Gated, not `true`: this widget reserves no destination
+            // (gestureReservedDestination(), settings_network.cpp), so the release tap is
+            // the ONLY route to its page -- and a long press that starts the timer
+            // swallows that tap whether or not it dispatches anything. Unset therefore
+            // has to leave the timer alone. See AccessibleTapHandler.supportLongPress.
             supportLongPress: !!(root.modelData && root.modelData.longPressAction)
             onAccessibleLongPressed: LayoutActions.runGesture(root.modelData, "longPressAction", null)
             onAccessibleDoubleClicked: LayoutActions.runGesture(root.modelData, "doubleclickAction", null)
         }
     }
 
-    // --- FULL MODE ---
-    Item {
-        id: fullContent
-        visible: !root.isCompact
-        anchors.fill: parent
-        implicitWidth: Theme.scaled(150)
-        implicitHeight: Theme.scaled(120)
-
-        ActionButton {
-            anchors.fill: parent
-            translationKey: "idle.button.settings"
-            translationFallback: "Settings"
-            iconSource: "qrc:/icons/settings.svg"
-            enabled: true
-            onClicked: root.goToSettings()
-        }
-    }
 }

--- a/tests/tst_customwidgethtml.cpp
+++ b/tests/tst_customwidgethtml.cpp
@@ -51,6 +51,7 @@ private slots:
     void historyFilterKeysAreUnderstoodByTheStorageLayer();
     void gestureDestinationsAreDeclaredExactlyOnce();
     void everyGestureCapableTypeRoutesThroughTheSharedHelper();
+    void everyGestureHandlerCanActuallyFire();
 
 private:
     QJSEngine m_engine;
@@ -77,6 +78,17 @@ inline QString widgetItem(const QString &name) {
     return QStringLiteral("/qml/components/layout/items/%1.qml").arg(name);
 }
 }
+
+// The ten action widgets whose gestures a user can override, as their dedicated
+// items/<Type>Item.qml render format. One declaration, because two slots need it and
+// two hand-kept copies of the same ten names is the drift this file exists to prevent.
+// (kOneSlot/kTwoSlot below split the same set by whether the type RESERVES a
+// destination, which is a different question about the same widgets.)
+static const QStringList kGestureWidgetFiles{
+    QStringLiteral("RecipesItem"), QStringLiteral("BeansItem"), QStringLiteral("SteamItem"),
+    QStringLiteral("HotWaterItem"), QStringLiteral("FlushItem"), QStringLiteral("EspressoItem"),
+    QStringLiteral("EquipmentItem"), QStringLiteral("HistoryItem"),
+    QStringLiteral("AutoFavoritesItem"), QStringLiteral("SettingsItem") };
 
 
 // Lift the JS segmentsToHtml() out of the raw string literal it is served from. Brace-matched
@@ -528,11 +540,7 @@ void TestCustomWidgetHtml::gestureDestinationsAreDeclaredExactlyOnce()
 // except by using that widget in that zone.
 void TestCustomWidgetHtml::everyGestureCapableTypeRoutesThroughTheSharedHelper()
 {
-    static const QStringList kFiles{
-        QStringLiteral("RecipesItem"), QStringLiteral("BeansItem"), QStringLiteral("SteamItem"),
-        QStringLiteral("HotWaterItem"), QStringLiteral("FlushItem"), QStringLiteral("EspressoItem"),
-        QStringLiteral("EquipmentItem"), QStringLiteral("HistoryItem"),
-        QStringLiteral("AutoFavoritesItem"), QStringLiteral("SettingsItem") };
+    const QStringList &kFiles = kGestureWidgetFiles;
 
     QStringList problems;
     for (const QString &f : kFiles) {
@@ -574,43 +582,6 @@ void TestCustomWidgetHtml::everyGestureCapableTypeRoutesThroughTheSharedHelper()
                                        "added at any time: ")
                         + hardcoded.join(QStringLiteral("; "))));
 
-    // A declared onAccessibleLongPressed does NOTHING unless the same handler enables
-    // supportLongPress: AccessibleTapHandler gates its press timer on that flag, so
-    // without it the gesture never fires and the release opens the page instead. Three
-    // widgets shipped exactly that -- handler present, routed correctly through
-    // LayoutActions, and dead -- which every check above passes over, because they all
-    // read the handler and none of them ask whether it can run.
-    QStringList unreachable;
-    for (const QString &f : kFiles) {
-        const QString src = readSource(SrcPath::widgetItem(f));
-        if (src.isEmpty()) { unreachable << f + QStringLiteral(" (unreadable)"); continue; }
-        qsizetype at = 0;
-        while ((at = src.indexOf(QStringLiteral("onAccessibleLongPressed"), at)) >= 0) {
-            // The enclosing handler is the nearest AccessibleTapHandler above this line.
-            const qsizetype open = src.lastIndexOf(QStringLiteral("AccessibleTapHandler"), at);
-            // Declared, not merely MENTIONED: the block above each of these handlers
-            // explains supportLongPress in prose, so a substring match over the block
-            // passes on the very files this was written to catch. Only a line that
-            // assigns the property counts.
-            bool declared = false;
-            if (open >= 0) {
-                const QStringList lines = src.mid(open, at - open).split(QLatin1Char('\n'));
-                for (const QString &l : lines) {
-                    const QString t = l.trimmed();
-                    if (t.startsWith(QStringLiteral("supportLongPress:"))) { declared = true; break; }
-                }
-            }
-            if (!declared)
-                unreachable << f;
-            at += 1;
-        }
-    }
-    QVERIFY2(unreachable.isEmpty(),
-             qPrintable(QStringLiteral("onAccessibleLongPressed declared in a handler that "
-                                       "never enables supportLongPress, so the gesture can "
-                                       "never fire: ")
-                        + unreachable.join(QStringLiteral("; "))));
-
     // And the dispatch itself stays in one place: CustomItem must delegate, not carry a
     // second copy of the switch.
     const QString custom = readSource(SrcPath::kCustomItem);
@@ -618,6 +589,81 @@ void TestCustomWidgetHtml::everyGestureCapableTypeRoutesThroughTheSharedHelper()
              "CustomItem no longer delegates to the shared dispatch");
     QVERIFY2(!custom.contains(QStringLiteral("category === \"navigate\"")),
              "CustomItem has re-grown its own action dispatch");
+}
+
+// A gesture handler that cannot fire. AccessibleTapHandler gates its press timer on
+// supportLongPress and its tap delay on supportDoubleClick, so a handler declared
+// without the matching flag is dead code that reads as live: the gesture runs nothing
+// and the release performs the widget's ordinary tap action instead. Three widgets
+// shipped exactly that on long press, past a check that read the handler line and
+// never asked whether it could run.
+//
+// Its own slot rather than more assertions on the routing test: QVERIFY2 aborts the
+// slot, so a routing regression would hide a reachability one. A new slot in an
+// existing file costs milliseconds; only a new FILE is expensive (CLAUDE.md).
+void TestCustomWidgetHtml::everyGestureHandlerCanActuallyFire()
+{
+    // handler signal -> the flag that arms it, and the model key a conditional gate
+    // must read. Accepting the KEY, not just any expression, is what catches the
+    // realistic version of this bug: `modelData.longpressAction` (lower-case p) is a
+    // gate that is false forever and would otherwise pass as "declared".
+    struct Gesture { const char *handler; const char *flag; const char *key; };
+    static const Gesture kGestures[] = {
+        { "onAccessibleLongPressed",   "supportLongPress:",   "longPressAction" },
+        { "onAccessibleDoubleClicked", "supportDoubleClick:", "doubleclickAction" },
+    };
+
+    QStringList problems;
+    // CustomItem included: it is the render format EVERY one of these widgets takes in
+    // a centre zone, so deleting either of its two flags kills the gesture for all ten
+    // at once.
+    for (const QString &f : kGestureWidgetFiles + QStringList{ QStringLiteral("CustomItem") }) {
+        const QString src = readSource(SrcPath::widgetItem(f));
+        if (src.isEmpty()) { problems << f + QStringLiteral(" (unreadable)"); continue; }
+        for (const Gesture &g : kGestures) {
+            const QString handler = QLatin1String(g.handler);
+            qsizetype at = 0;
+            while ((at = src.indexOf(handler, at)) >= 0) {
+                // Anchor on the opening BRACE, not the bare type name: a comment that
+                // merely mentions AccessibleTapHandler would otherwise be taken for the
+                // handler's start and hide a flag declared above it. PageTitleItem.qml
+                // has such a comment today, so this is a live shape, not a hypothetical.
+                const qsizetype open =
+                    src.lastIndexOf(QStringLiteral("AccessibleTapHandler {"), at);
+                // Only the lines ABOVE the signal are scanned. QML does not care about
+                // order, this check does, and the failure message says so -- a window
+                // that ran past the signal would have to brace-match through comments
+                // and string literals to know where the handler ends.
+                bool armed = false;
+                if (open >= 0) {
+                    const QStringList lines = src.mid(open, at - open).split(QLatin1Char('\n'));
+                    for (const QString &l : lines) {
+                        const QString t = l.trimmed();
+                        // Declared, not merely MENTIONED: these handlers explain the flag
+                        // in prose directly above it, so a substring match over the block
+                        // passes on the very files this was written to catch.
+                        if (!t.startsWith(QLatin1String(g.flag)))
+                            continue;
+                        // And armed, not merely declared: `supportLongPress: false`, or a
+                        // gate on a misspelled key, is the shipped bug with a line of
+                        // code in front of it.
+                        armed = t.contains(QLatin1String("true")) || t.contains(QLatin1String(g.key));
+                        if (armed)
+                            break;
+                    }
+                }
+                if (!armed)
+                    problems << QStringLiteral("%1.%2").arg(f, handler);
+                at += 1;
+            }
+        }
+    }
+    QVERIFY2(problems.isEmpty(),
+             qPrintable(QStringLiteral("gesture handler with no armed support flag above it "
+                                       "in the same AccessibleTapHandler -- it can never fire "
+                                       "(declare supportLongPress/supportDoubleClick before "
+                                       "the handler, and not as a constant false): ")
+                        + problems.join(QStringLiteral("; "))));
 }
 
 QString TestCustomWidgetHtml::viaJs(const QVariantList &segments)

--- a/tests/tst_customwidgethtml.cpp
+++ b/tests/tst_customwidgethtml.cpp
@@ -574,6 +574,43 @@ void TestCustomWidgetHtml::everyGestureCapableTypeRoutesThroughTheSharedHelper()
                                        "added at any time: ")
                         + hardcoded.join(QStringLiteral("; "))));
 
+    // A declared onAccessibleLongPressed does NOTHING unless the same handler enables
+    // supportLongPress: AccessibleTapHandler gates its press timer on that flag, so
+    // without it the gesture never fires and the release opens the page instead. Three
+    // widgets shipped exactly that -- handler present, routed correctly through
+    // LayoutActions, and dead -- which every check above passes over, because they all
+    // read the handler and none of them ask whether it can run.
+    QStringList unreachable;
+    for (const QString &f : kFiles) {
+        const QString src = readSource(SrcPath::widgetItem(f));
+        if (src.isEmpty()) { unreachable << f + QStringLiteral(" (unreadable)"); continue; }
+        qsizetype at = 0;
+        while ((at = src.indexOf(QStringLiteral("onAccessibleLongPressed"), at)) >= 0) {
+            // The enclosing handler is the nearest AccessibleTapHandler above this line.
+            const qsizetype open = src.lastIndexOf(QStringLiteral("AccessibleTapHandler"), at);
+            // Declared, not merely MENTIONED: the block above each of these handlers
+            // explains supportLongPress in prose, so a substring match over the block
+            // passes on the very files this was written to catch. Only a line that
+            // assigns the property counts.
+            bool declared = false;
+            if (open >= 0) {
+                const QStringList lines = src.mid(open, at - open).split(QLatin1Char('\n'));
+                for (const QString &l : lines) {
+                    const QString t = l.trimmed();
+                    if (t.startsWith(QStringLiteral("supportLongPress:"))) { declared = true; break; }
+                }
+            }
+            if (!declared)
+                unreachable << f;
+            at += 1;
+        }
+    }
+    QVERIFY2(unreachable.isEmpty(),
+             qPrintable(QStringLiteral("onAccessibleLongPressed declared in a handler that "
+                                       "never enables supportLongPress, so the gesture can "
+                                       "never fire: ")
+                        + unreachable.join(QStringLiteral("; "))));
+
     // And the dispatch itself stays in one place: CustomItem must delegate, not carry a
     // second copy of the switch.
     const QString custom = readSource(SrcPath::kCustomItem);


### PR DESCRIPTION
## The bug

Reported on Android: a long press on the History widget in the bottom bar, configured to open Favorites, either did nothing or just opened History.

`AccessibleTapHandler` starts its long-press timer only when `supportLongPress` is true, and the property defaults to false. Three widgets declared `onAccessibleLongPressed` — routed correctly through `LayoutActions`, exactly as the other seven do — and never enabled the flag:

- `qml/components/layout/items/HistoryItem.qml`
- `qml/components/layout/items/SettingsItem.qml`
- `qml/components/layout/items/AutoFavoritesItem.qml`

So the press ran nothing on the way down, and the release took the ordinary tap path, which opens the widget's own page. Both halves of the report, from one missing line. All three share a copied comment block; the property was left out of every copy.

## Scope

Bar/compact rendering only, and only these three. The other seven gesture-capable widgets (Beans, Steam, Hot Water, Flush, Espresso, Equipment, Recipes) set `supportLongPress: true`. In centre/large zones these types compile to `CustomItem`, which gates the flag correctly, so that path was never affected. Double-click was fine everywhere — `supportDoubleClick: true` is already unconditional and pinned by a test.

## The fix

    supportLongPress: !!(root.modelData && root.modelData.longPressAction)

The same gate the compiled `CustomItem` twin uses, so the two render formats behave alike:

- unset — the press falls through to the tap that opens the page (today's behaviour, unchanged)
- an action stored — it runs
- `"none"` stored — consumed, gesture stays silent

## Test gap

`tst_customwidgethtml::everyGestureCapableTypeRoutesThroughTheSharedHelper` asserted that the handler exists and that it routes through `LayoutActions`. It never asked whether the handler could fire, which is why all three shipped dead through a check written for exactly this feature. It now also requires the enclosing `AccessibleTapHandler` to declare `supportLongPress`.

The first draft of that assertion was itself a pass-forever: the new comment above each handler names the property, so a substring match over the handler block passed with the assignment deleted. It now requires a line that *assigns* the property, and was confirmed to go red on all ten widget files with the assignment stripped.

## Verification

- Build clean (the usual `__eh_frame` sanitizer-build warning aside).
- Full suite via Qt Creator: 113 passed, 0 failed, 0 skipped, no test warnings.
- Every gesture-capable widget file audited for both gestures in both render formats, plus the delegate's stored-else-reserved merge and the `readoutOptionSchema` option keys for all ten types.
- Not exercised by hand in a running app; the on-device check belongs in the next Android beta.