### PR TITLE
Retire the pre-shot zero offset when the shot is saved

### DIFF
--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -952,6 +952,11 @@ void WeightProcessor::setPreShotZeroOffset(double offsetG)
     emit preShotZeroOffsetChanged(offsetG);
 }
 
+void WeightProcessor::clearPreShotZeroOffset()
+{
+    setPreShotZeroOffset(0.0);
+}
+
 void WeightProcessor::markExtractionStart()
 {
     if (!m_active || m_extractionStartTime != 0) return;

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -63,6 +63,17 @@ public slots:
     // flow never began, which stopExtraction (gated on shotEnded) misses.
     void endShotCycle();
     void resetForRetare();  // Clear LSLR buffer after auto-tare during preheat
+    // Drop this shot's zero correction once the shot has been saved. The offset is a
+    // PER-SHOT number: it belongs to the pour it was measured at flow start, and every
+    // surface that mirrors it (live readout, MQTT, MCP, widget) keeps subtracting it
+    // from the idle scale until something clears it. Nothing did — startExtraction()
+    // was the only reset, so a shot's offset survived into idle, steam and dose
+    // weighing, and a manual tare could not shift it because the scale zeroed while
+    // the app kept subtracting. Restarting the app was the only cure.
+    // Called on shotProcessingReady, which is AFTER the SAW settle window and the
+    // save: clearing at espresso-cycle exit instead would jump the drip-settle
+    // samples (and so the saved finalWeightG) by the offset mid-capture.
+    void clearPreShotZeroOffset();
 
 #ifdef DECENZA_TESTING
 public:

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -70,9 +70,16 @@ public slots:
     // was the only reset, so a shot's offset survived into idle, steam and dose
     // weighing, and a manual tare could not shift it because the scale zeroed while
     // the app kept subtracting. Restarting the app was the only cure.
-    // Called on shotProcessingReady, which is AFTER the SAW settle window and the
-    // save: clearing at espresso-cycle exit instead would jump the drip-settle
-    // samples (and so the saved finalWeightG) by the offset mid-capture.
+    // Called on shotProcessingReady, which closes the SAW settle window and is what
+    // TRIGGERS the save — the clear lands after the save only because it is queued
+    // onto this worker while onShotEnded runs directly on the main thread. Do not
+    // move it to a direct same-thread site on that signal: it would then run before
+    // the shot has been read. Clearing at espresso-cycle exit instead is no fix
+    // either — that signal is emitted synchronously while shotEnded is queued, so it
+    // precedes the settle window and would jump the drip samples, and with them the
+    // saved finalWeightG, by the offset mid-capture. The one exit that does clear
+    // here is a mid-pour disconnect, which never reaches shotEnded at all (see the
+    // espressoCycleEnded wiring in main.cpp).
     void clearPreShotZeroOffset();
 
 #ifdef DECENZA_TESTING

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1653,7 +1653,7 @@ int main(int argc, char *argv[])
     // exit rather than the narrowest. Fires after the save path has read the
     // snapshot (which survives release by design), and is idempotent.
     QObject::connect(&machineState, &MachineState::espressoCycleEnded,
-                     [&weightProcessor, &mainController]() {
+                     [&weightProcessor, &mainController, &machineState]() {
                          mainController.profileManager()->releaseShotLatch();
                          // Disarm the SAW worker for the same reason and by the
                          // same asymmetry: startExtraction arms it at cycle
@@ -1664,6 +1664,27 @@ int main(int argc, char *argv[])
                          QMetaObject::invokeMethod(&weightProcessor, [&weightProcessor]() {
                              weightProcessor.endShotCycle();
                          }, Qt::QueuedConnection);
+                         // Same asymmetry, third time: the pre-shot zero is retired on
+                         // shotProcessingReady (above), which is reached only through
+                         // shotEnded. A mid-pour disconnect sets Phase::Disconnected,
+                         // emits THIS signal and returns before the queued shotEnded ever
+                         // fires (MachineState::updateFromDevice), so the offset a flowing
+                         // shot had already adopted would stay applied to the idle scale
+                         // for the rest of the session — the bug this fix exists to remove,
+                         // reached by a different road.
+                         //
+                         // Guarded on Disconnected rather than clearing unconditionally,
+                         // because this signal is emitted SYNCHRONOUSLY on the normal
+                         // Ending -> Idle exit while shotEnded is queued: an unguarded
+                         // clear here would land before the settle window and step the
+                         // drip samples, and so the saved finalWeightG, by the offset.
+                         // A disconnect has no such window — the shot is dead and nothing
+                         // further will be captured from it.
+                         if (machineState.phase() == MachineState::Phase::Disconnected) {
+                             QMetaObject::invokeMethod(&weightProcessor, [&weightProcessor]() {
+                                 weightProcessor.clearPreShotZeroOffset();
+                             }, Qt::QueuedConnection);
+                         }
                      });
 
     // Machine phase → WeightProcessor: extend scale-feed-liveness detection to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1626,6 +1626,22 @@ int main(int argc, char *argv[])
                          }, Qt::QueuedConnection);
                      });
 
+    // Retire the shot's zero correction once the shot has been saved. shotProcessingReady
+    // is the right edge: shotEnded fires while drip is still settling, and the settle
+    // samples run through the same correction, so clearing there would step the graph and
+    // the saved finalWeightG by the offset. Queued into the worker, and posted after the
+    // direct-connected onShotEnded above has already read the shot, so the record is safe.
+    // Without this the offset outlived its shot and every surface reading MachineState::
+    // scaleWeight (idle readout, steam, dose weighing, MQTT, MCP, widget) stayed skewed by
+    // it — and a manual tare could not fix it, because the scale zeroed while the app went
+    // on subtracting. Only an app restart cleared it.
+    QObject::connect(&timingController, &ShotTimingController::shotProcessingReady,
+                     [&weightProcessor]() {
+                         QMetaObject::invokeMethod(&weightProcessor, [&weightProcessor]() {
+                             weightProcessor.clearPreShotZeroOffset();
+                         }, Qt::QueuedConnection);
+                     });
+
     // Release the shot latch on espressoCycleEnded, NOT shotEnded: the latch is
     // armed at espressoCycleStarted, and only espressoCycleEnded is that
     // signal's pair. shotEnded is gated on flow having started, so a cycle

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -2367,6 +2367,16 @@ private slots:
 
         QSignalSpy cycleEnded(&f.machineState, &MachineState::espressoCycleEnded);
 
+        // The phase AS IT STANDS INSIDE the emission, which a spy cannot see. The
+        // pre-shot-zero clear in main.cpp hangs off this signal and is guarded on
+        // Phase::Disconnected precisely to tell this exit from the normal one, where
+        // clearing early would step the drip-settle samples. Assigning m_phase after
+        // the emit instead of before would leave that guard reading Pouring and
+        // silently stop it firing, with nothing else here failing.
+        MachineState::Phase phaseAtEmit = MachineState::Phase::Idle;
+        QObject::connect(&f.machineState, &MachineState::espressoCycleEnded,
+                         [&f, &phaseAtEmit]() { phaseAtEmit = f.machineState.phase(); });
+
         f.device.m_state = DE1::State::Espresso;
         f.device.m_subState = DE1::SubState::Pouring;
         f.machineState.updatePhase();
@@ -2387,6 +2397,7 @@ private slots:
 
         QCOMPARE(f.machineState.phase(), MachineState::Phase::Disconnected);
         QCOMPARE(cycleEnded.count(), 1);
+        QCOMPARE(phaseAtEmit, MachineState::Phase::Disconnected);
 
         // Idempotent: further disconnected updates must not re-fire it.
         f.machineState.updatePhase();

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -154,6 +154,24 @@ private slots:
         QCOMPARE(spy.last().at(0).toDouble(), 36.0);
     }
 
+    void theShotsZeroIsRetiredWhenTheShotIsSaved() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy offsets(&wp, &WeightProcessor::preShotZeroOffsetChanged);
+
+        armWithPreShotZero(wp, -0.4);
+        QVERIFY(!offsets.isEmpty());
+        QCOMPARE(offsets.last().at(0).toDouble(), -0.4);
+
+        wp.stopExtraction();
+        // The signal is the ONLY channel to the surfaces that mirror the offset --
+        // live readout, MQTT, MCP, widget. An offset dropped without notifying leaves
+        // them subtracting this shot's number from the idle scale until app restart,
+        // which no tare can undo (the scale zeroes, the app keeps subtracting).
+        wp.clearPreShotZeroOffset();
+        QCOMPARE(offsets.last().at(0).toDouble(), 0.0);
+    }
+
     // ==========================================
     // LSLR flow estimation
     // ==========================================


### PR DESCRIPTION
## The symptom

After a shot, the scale reads 0 and the app reads 0.2 g. Tapping the weight to tare does not help — the scale zeroes and the app still shows 0.2. Only restarting the app clears it.

Reproduced live: `scale_get_weight` returned 0.1 g with the scale sitting at -0.1 g, and the shot before it logged `[Scale] weight= "-0.8"` (raw) beside ScaleFeed's corrected `-0.6` — an offset of -0.2 g, exactly the discrepancy still on screen minutes later.

## The cause

`WeightProcessor` adopts a per-shot "pre-shot zero" offset at flow start (`markExtractionStart()`) — whatever the scale reads then, which after a tare is typically -0.1 to -0.5 g of residual and preheat drift. Every weight that shot has it subtracted, and `MachineState` mirrors it so the live readout, MQTT, MCP and the widget agree with what SAW stops on and what is saved as `finalWeightG`.

Nothing cleared it after the shot. `startExtraction()` and `resetForRetare()` were the only reset sites; neither `stopExtraction()` nor `endShotCycle()` touches it. So the offset outlived its shot and skewed every surface reading `MachineState::scaleWeight()` — idle readout, steam/milk weight, dose weighing in BrewDialog, MQTT, MCP, the home-screen widget — until the next shot armed or the app restarted. A manual tare could not shift it, because the tare moves the *scale's* zero while the app goes on subtracting the old number.

The invariant was already written down, on `m_preShotZeroOffset` itself: "every reset site must notify, or the surfaces mirroring it keep subtracting last shot's number." There simply was no reset site at the end of the shot.

## The fix

Clear the offset on `ShotTimingController::shotProcessingReady`.

That edge matters. `shotEnded` fires while drip is still settling, and the settle samples run through the same correction — clearing there, or at espresso-cycle exit, would step the graph and the saved `finalWeightG` by the offset in the middle of capture. `shotProcessingReady` is emitted after the SAW settle window, and the clear is queued into the worker thread, so it lands after the direct-connected `onShotEnded()` has already read the shot.

An aborted cycle that never flowed is unaffected: `startExtraction()` sets the offset to 0 and only `markExtractionStart()` (on `shotStarted`) ever adopts a non-zero one.

## Tests

Adds `tst_WeightProcessor::theShotsZeroIsRetiredWhenTheShotIsSaved`. No existing test asserted the offset is ever retired — the four existing pre-shot-zero tests all cover capture, not release. It asserts through `preShotZeroOffsetChanged`, which is the only channel to the mirroring surfaces: an offset dropped without notifying reproduces the bug exactly.

Verified it can fail: with `clearPreShotZeroOffset()` made a no-op the suite goes 112/1; restored, 113/113.

Full suite green locally (113 passed, 0 failed, 0 warnings), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)