### PR TITLE
Fix Android FD diagnostics build

### DIFF
--- a/src/core/fddiagnostics.cpp
+++ b/src/core/fddiagnostics.cpp
@@ -96,7 +96,7 @@ QString ipv6Address(const QString& encoded)
 
 bool parseEndpoint(const QString& encoded, bool ipv6, QString* address, int* port)
 {
-    const int separator = encoded.indexOf(QLatin1Char(':'));
+    const qsizetype separator = encoded.indexOf(QLatin1Char(':'));
     if (separator <= 0 || separator == encoded.size() - 1)
         return false;
 


### PR DESCRIPTION
## Summary
- retain the qsizetype returned by QString::indexOf in FD endpoint parsing
- fix the Android Clang shortening-conversion warning promoted to an error

## Validation
- Qt Creator build succeeded
- tst_profilemanager passed