### PR TITLE
Fix Android socket descriptor census

### DIFF
--- a/src/core/fddiagnostics.cpp
+++ b/src/core/fddiagnostics.cpp
@@ -182,13 +182,20 @@ QHash<qulonglong, SocketDetails> socketDetailsByInode()
     return sockets;
 }
 
+QString kernelDescriptorTarget(const QString& target)
+{
+    static const QString procFdPrefix = QStringLiteral("/proc/self/fd/");
+    return target.startsWith(procFdPrefix) ? target.mid(procFdPrefix.size()) : target;
+}
+
 QString descriptorKind(const QString& target)
 {
-    if (target.startsWith(QStringLiteral("socket:[")))
+    const QString kernelTarget = kernelDescriptorTarget(target);
+    if (kernelTarget.startsWith(QStringLiteral("socket:[")))
         return QStringLiteral("socket");
-    if (target.startsWith(QStringLiteral("pipe:[")))
+    if (kernelTarget.startsWith(QStringLiteral("pipe:[")))
         return QStringLiteral("pipe");
-    if (target.startsWith(QStringLiteral("anon_inode:")))
+    if (kernelTarget.startsWith(QStringLiteral("anon_inode:")))
         return QStringLiteral("anon_inode");
     if (target.startsWith(QLatin1Char('/')))
         return QStringLiteral("file");
@@ -198,7 +205,7 @@ QString descriptorKind(const QString& target)
 bool socketInode(const QString& target, qulonglong* inode)
 {
     static const QRegularExpression pattern(QStringLiteral("^socket:\\[(\\d+)\\]$"));
-    const QRegularExpressionMatch match = pattern.match(target);
+    const QRegularExpressionMatch match = pattern.match(kernelDescriptorTarget(target));
     if (!match.hasMatch())
         return false;
     bool ok = false;


### PR DESCRIPTION
## Summary
- normalize Android procfs descriptor targets before classifying them
- restore socket, pipe, and anon-inode counts plus socket inode mapping

## Validation
- Qt Creator build succeeded
- tst_profilemanager passed
- live tablet snapshot reproduced the prefixed target form this fixes