### PR TITLE
Add HDS firmware update handoff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,6 +693,9 @@ set(SOURCES
     src/core/profilestorage.cpp
     src/core/translationmanager.cpp
     src/core/updatechecker.cpp
+    src/core/githubreleaseclient.cpp
+    src/core/hdsfirmwarecatalog.cpp
+    src/core/hdsfirmwareupdatecontroller.cpp
     src/core/firmwareassetcache.cpp
     src/core/fileshare.cpp
     src/ble/protocol/binarycodec.cpp
@@ -930,6 +933,9 @@ set(HEADERS
     src/core/profilestorage.h
     src/core/translationmanager.h
     src/core/updatechecker.h
+    src/core/githubreleaseclient.h
+    src/core/hdsfirmwarecatalog.h
+    src/core/hdsfirmwareupdatecontroller.h
     src/ble/protocol/binarycodec.h
     src/ble/protocol/de1characteristics.h
     src/ble/protocol/decentscaleprotocol.h

--- a/openspec/changes/add-hds-firmware-update/.openspec.yaml
+++ b/openspec/changes/add-hds-firmware-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/add-hds-firmware-update/design.md
+++ b/openspec/changes/add-hds-firmware-update/design.md
@@ -57,6 +57,6 @@ A future OpenScale capability can accept a requested semantic version and emit s
 ## Migration Plan
 
 1. Release Decenza with the conditional availability control and existing HDS command handoff.
-2. Validate on Bluetooth and USB HDS devices that the current on-device picker remains unchanged and update failure leaves the installed firmware running.
+2. After the next compatible HDS firmware release is public, validate on Bluetooth and USB HDS devices that the current on-device picker remains unchanged and update failure leaves the installed firmware running.
 3. In a later OpenScale release, add remote update capability/version reporting and progress events.
 4. Extend Decenza only after that capability is available; retain the current device-display flow for older HDS firmware.

--- a/openspec/changes/add-hds-firmware-update/design.md
+++ b/openspec/changes/add-hds-firmware-update/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The OpenScale HDS firmware already implements signed WiFi pull OTA. Its Bluetooth and USB command protocol has a WiFi-update trigger, but its current updater reads the scale's physical buttons for release selection and confirmation. Decenza already has a shared network manager and GitHub release-note retrieval logic, while scale firmware versions arrive from existing HDS transport packets.
+
+See proposal.md and the hds-firmware-update spec for the behavioral contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make an available HDS update discoverable without adding normal-state Connections UI.
+- Fetch only at launch and on real application resume; reuse a successful manifest for all scale changes in the session.
+- Give the user release notes and an explicit confirmation before dispatching the existing HDS command.
+- Preserve the HDS as the cryptographic and hardware-compatibility authority.
+
+**Non-Goals:**
+
+- Downloading, proxying, or validating HDS firmware assets in Decenza.
+- Adding a recurring polling timer, persisted availability state, or an update banner.
+- Blocking this feature on remote version selection, confirmation, or progress support from a future HDS firmware.
+
+## Decisions
+
+### Use the HDS manifest for availability and the release API for prose
+
+Read the same `releases/latest/download/manifest.json` catalog URL that the HDS reads. It supplies the eligible release versions and compatibility metadata. Fetch the selected release's GitHub release body through shared release-client code for the dialog, because the manifest supplies a release-notes URL but not the Markdown itself.
+
+The scale independently retrieves and verifies the manifest signature and assets when it starts OTA. Decenza's manifest read is an advisory UI input, not the authorization to install firmware.
+
+### Tie requests to lifecycle edges, not an interval
+
+Start one manifest request during app initialization and another only after a Suspended → Active lifecycle transition. Retain the last good result in memory. Scale selection and connection changes only re-evaluate that cached catalog, which avoids network traffic when the user changes scales.
+
+The existing app updater's hourly cadence is too frequent, and the DE1 firmware updater's startup-plus-weekly cadence is too infrequent. Reuse their shared network and lifecycle infrastructure rather than either schedule.
+
+### Add an explicit HDS update capability to the active scale surface
+
+Expose the existing HDS firmware version and a capability-safe `startFirmwareUpdate` operation from the active Bluetooth and USB HDS drivers. A controller follows the active scale and clears its state immediately on target or connection changes. This avoids treating generic scale names or raw command bytes as QML-facing behavior.
+
+### Keep the current HDS interaction as the initial completion path
+
+After Decenza dispatches the existing trigger, it explains that the HDS display owns release selection and hold-to-confirm. No acknowledgement currently proves completion over the host transport, so reconnecting on the target version is the only positive outcome Decenza can infer.
+
+The alternate design—using Decenza to emulate the HDS's physical buttons—is not viable: the OTA picker reads device GPIO directly and suppresses normal transport input while running.
+
+### Treat remote GUI control as a separate OpenScale protocol follow-up
+
+A future OpenScale capability can accept a requested semantic version and emit state/progress over Bluetooth/USB. It must have the HDS fetch its own signed catalog, locate the exact compatible release, and validate all assets; Decenza must never provide URLs, hashes, or firmware bytes. Keep the physical-button path for compatibility. This work is deliberately recorded as a dependency-free follow-up rather than a prerequisite.
+
+## Risks / Trade-offs
+
+- [Manifest and release notes can be stale for the session] → HDS rechecks its signed catalog at installation time; a stale Decenza offer cannot bypass device validation.
+- [Network errors leave no visible result] → This is intentional: the normal Connections surface stays quiet. Log diagnostics and try again on the next launch or resume.
+- [Current HDS firmware gives no end-to-end host progress] → Use precise handoff copy and re-evaluate installed version after reconnection; defer rich progress to the OpenScale protocol follow-up.
+- [Future hardware metadata may outgrow the host's eligibility view] → Treat HDS validation as final and keep the host's presentation constrained to manifest candidates it can identify.
+
+## Migration Plan
+
+1. Release Decenza with the conditional availability control and existing HDS command handoff.
+2. Validate on Bluetooth and USB HDS devices that the current on-device picker remains unchanged and update failure leaves the installed firmware running.
+3. In a later OpenScale release, add remote update capability/version reporting and progress events.
+4. Extend Decenza only after that capability is available; retain the current device-display flow for older HDS firmware.

--- a/openspec/changes/add-hds-firmware-update/proposal.md
+++ b/openspec/changes/add-hds-firmware-update/proposal.md
@@ -28,3 +28,4 @@ Half Decent Scale owners can already run a signed WiFi update from the scale, bu
 - `SettingsConnectionsTab.qml` gains only a conditional action and dialog; no new normal-state page content.
 - Uses the existing application `QNetworkAccessManager` and the OpenScale public manifest and release APIs.
 - Follow-up coordination with `../openscale` is documented but does not gate this Decenza change or require a new HDS firmware release.
+- Manual UI and Bluetooth/USB hardware verification of an actually available update is deferred until the next compatible HDS firmware release is public; this does not block merging the availability and handoff implementation.

--- a/openspec/changes/add-hds-firmware-update/proposal.md
+++ b/openspec/changes/add-hds-firmware-update/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Half Decent Scale owners can already run a signed WiFi update from the scale, but Decenza does not tell them when one is available or offer a convenient entry point. Surface the compatible published update beside the selected HDS so an owner can start the existing safe device-side flow without routinely visiting the scale's setup menu.
+
+## What Changes
+
+- Fetch the same OpenScale release manifest the HDS uses when Decenza launches and after a genuine app resume; retain it in memory for the session rather than polling.
+- When the current connected scale is an HDS over Bluetooth or USB, compare its known firmware version against the manifest's eligible published releases.
+- Leave Settings → Connections visually unchanged when there is no update, no applicable HDS, or no usable manifest.
+- Show an **Update** action beside **Forget** only when an update is available. Its confirmation dialog shows the selected release's GitHub release notes and explains the handoff.
+- Start the existing HDS WiFi OTA command over the selected Bluetooth or USB transport. The initial release retains the HDS's on-device version selection and confirmation; Decenza must not claim that installation completed until the scale reconnects on the selected version.
+- Record, but do not block this feature on, a follow-up OpenScale capability for GUI-driven version selection, confirmation, and OTA-progress reporting. The scale must continue to fetch and validate its own signed manifest and assets.
+
+## Capabilities
+
+### New Capabilities
+
+- `hds-firmware-update`: Discover and present compatible HDS firmware releases, hand the existing OTA flow to the selected scale, and define the non-blocking follow-up for remote OTA controls.
+
+### Modified Capabilities
+
+- `settings-ui`: Add the conditional HDS update action and confirmation dialog to Settings → Connections.
+
+## Impact
+
+- New Qt/C++ update controller, manifest parser, GitHub release-notes client reuse, and tests.
+- `ScaleDevice` / HDS Bluetooth and USB drivers expose the existing firmware-version and OTA-trigger capability to the controller.
+- `SettingsConnectionsTab.qml` gains only a conditional action and dialog; no new normal-state page content.
+- Uses the existing application `QNetworkAccessManager` and the OpenScale public manifest and release APIs.
+- Follow-up coordination with `../openscale` is documented but does not gate this Decenza change or require a new HDS firmware release.

--- a/openspec/changes/add-hds-firmware-update/specs/hds-firmware-update/spec.md
+++ b/openspec/changes/add-hds-firmware-update/specs/hds-firmware-update/spec.md
@@ -1,0 +1,56 @@
+## Purpose
+
+Lets Decenza identify and present signed, compatible Half Decent Scale firmware releases and hand the existing WiFi update flow to the selected scale without adding noise to normal Connections use.
+
+## ADDED Requirements
+
+### Requirement: HDS release availability is lifecycle-driven
+
+Decenza SHALL retrieve the OpenScale release manifest used by HDS at application launch and after each genuine return from suspension. It SHALL retain the latest successfully parsed manifest for the app session and SHALL NOT run a periodic HDS-update polling timer. When a connected Bluetooth or USB HDS is the selected scale, Decenza SHALL compare its known installed firmware version with releases eligible for that scale.
+
+#### Scenario: Selected HDS has a newer eligible release
+
+- **WHEN** a current-session manifest contains an eligible release newer than the selected connected HDS firmware
+- **THEN** Decenza marks that release as available for the selected scale
+- **AND** it makes the release version and release-notes reference available to the Connections UI
+
+#### Scenario: HDS has no newer eligible release
+
+- **WHEN** the selected connected HDS already runs the newest eligible release
+- **THEN** Decenza SHALL expose no update action or availability notice
+
+#### Scenario: Manifest check cannot complete
+
+- **WHEN** the launch or resume manifest request fails and no prior valid session manifest is available
+- **THEN** Decenza SHALL log the failure without showing an update error or changing the Connections page
+
+#### Scenario: Resume check ignores focus flickers
+
+- **WHEN** the application becomes active without first entering the suspended state
+- **THEN** Decenza SHALL NOT issue another HDS manifest request
+
+### Requirement: Existing HDS OTA is handed off safely
+
+When the user confirms an available HDS update, Decenza SHALL send the existing HDS WiFi-update command over the selected Bluetooth or USB scale transport. The scale SHALL remain responsible for retrieving and verifying its signed manifest and update assets. Decenza SHALL describe this as an update handoff and SHALL NOT report successful installation merely because the command was sent.
+
+#### Scenario: User starts an update on current firmware
+
+- **WHEN** the user confirms the available update for a connected HDS that supports the existing WiFi-update command
+- **THEN** Decenza sends that command over the active scale transport
+- **AND** instructs the user to continue version selection and confirmation on the HDS display
+
+#### Scenario: HDS rejects or cannot complete its update
+
+- **WHEN** the HDS cannot connect to WiFi, cannot verify its manifest, or rejects the selected release
+- **THEN** the HDS retains responsibility for reporting the failure and preserving its installed firmware
+- **AND** Decenza SHALL NOT represent the earlier command dispatch as a completed update
+
+### Requirement: GUI-driven HDS OTA remains non-blocking future work
+
+Decenza SHALL ship this availability and handoff feature without waiting for a future HDS remote-OTA protocol. A future protocol MAY allow Decenza to select a release, confirm installation, and display scale-reported progress, but it MUST preserve the HDS as the authority that independently selects compatible releases and verifies signed update assets.
+
+#### Scenario: Current HDS supports only device-side selection
+
+- **WHEN** a connected HDS exposes only the existing WiFi-update command
+- **THEN** Decenza SHALL still offer the available-update handoff
+- **AND** it SHALL require the user to complete selection and confirmation on the HDS display

--- a/openspec/changes/add-hds-firmware-update/specs/settings-ui/spec.md
+++ b/openspec/changes/add-hds-firmware-update/specs/settings-ui/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Conditional HDS update action in Connections
+
+Settings → Connections SHALL remain visually unchanged unless a newer eligible HDS firmware release is available for the currently selected connected Bluetooth or USB HDS. In that case, the selected-scale actions SHALL show an **Update** button immediately beside **Forget**. Activating it SHALL open an accessible confirmation dialog that displays the installed and available versions, the GitHub release notes for the available version, and an explicit action to start the update.
+
+#### Scenario: No HDS update is available
+
+- **WHEN** no selected connected HDS has a newer eligible release
+- **THEN** Settings → Connections SHALL show no HDS update control, placeholder, banner, or error state
+
+#### Scenario: HDS update is available
+
+- **WHEN** the selected connected Bluetooth or USB HDS has a newer eligible release
+- **THEN** an **Update** button SHALL appear immediately beside the selected scale's **Forget** button
+
+#### Scenario: User reviews and confirms the update
+
+- **WHEN** the user activates the HDS **Update** button
+- **THEN** an accessible modal dialog SHALL present the installed version, available version, and GitHub release notes
+- **AND** the dialog SHALL offer Cancel and Start update actions
+
+#### Scenario: Selected scale changes while dialog is open
+
+- **WHEN** the selected scale changes or the HDS disconnects before Start update is confirmed
+- **THEN** the confirmation dialog SHALL close without sending an update command

--- a/openspec/changes/add-hds-firmware-update/tasks.md
+++ b/openspec/changes/add-hds-firmware-update/tasks.md
@@ -7,13 +7,13 @@
 ## 2. Connections experience
 
 - [x] 2.1 Wire the controller to the active-scale lifecycle so only the selected connected Bluetooth or USB HDS can expose an eligible release, and verify target changes or disconnects clear availability without a stale command.
-- [ ] 2.2 Add the conditional Update button beside Forget and its accessible confirmation dialog, and verify no-update, available-update, Cancel, and selected-scale-change flows in QML-focused tests or manual UI checks.
+- [ ] 2.2 Add the conditional Update button beside Forget and its accessible confirmation dialog, and verify no-update, available-update, Cancel, and selected-scale-change flows in QML-focused tests or manual UI checks. Deferred until the next compatible published HDS firmware release makes the available-update path testable.
 - [x] 2.3 Dispatch the existing HDS WiFi-update command only after dialog confirmation and present accurate device-display handoff copy, and verify a command send is never represented as install success.
 
 ## 3. Verification and documentation
 
 - [x] 3.1 Add concise Settings manual guidance for the HDS update handoff and its requirement to finish selection and confirmation on the scale display; verify the wiki entry follows the project’s short-form manual convention.
-- [ ] 3.2 Run the relevant Qt Creator test targets and the full test suite, then manually verify the Connections page is unchanged when no HDS update is available and the dialog works over both Bluetooth and USB.
+- [ ] 3.2 Run the relevant Qt Creator test targets and the full test suite, then manually verify the Connections page is unchanged when no HDS update is available and the dialog works over both Bluetooth and USB. Automated Qt Creator coverage is complete; Bluetooth/USB hardware verification is deferred until the next compatible published HDS firmware release.
 
 ## Deferred follow-up — not part of this change
 

--- a/openspec/changes/add-hds-firmware-update/tasks.md
+++ b/openspec/changes/add-hds-firmware-update/tasks.md
@@ -1,0 +1,20 @@
+## 1. HDS update data and transport capability
+
+- [x] 1.1 Expose the selected Bluetooth and USB HDS firmware version plus an explicit WiFi-update capability/trigger, and verify focused protocol tests cover version decoding and the existing update command packet on both transports.
+- [x] 1.2 Add the HDS manifest catalog model and eligibility parser for the OpenScale release-manifest shape, and verify fixture tests cover newer, current, incompatible, and `min_from`-blocked releases.
+- [x] 1.3 Implement the session-scoped HDS update controller using the shared network manager and GitHub release-note client, and verify launch, genuine suspend/resume, cache reuse, cancellation, and network-failure behavior in unit tests.
+
+## 2. Connections experience
+
+- [x] 2.1 Wire the controller to the active-scale lifecycle so only the selected connected Bluetooth or USB HDS can expose an eligible release, and verify target changes or disconnects clear availability without a stale command.
+- [ ] 2.2 Add the conditional Update button beside Forget and its accessible confirmation dialog, and verify no-update, available-update, Cancel, and selected-scale-change flows in QML-focused tests or manual UI checks.
+- [x] 2.3 Dispatch the existing HDS WiFi-update command only after dialog confirmation and present accurate device-display handoff copy, and verify a command send is never represented as install success.
+
+## 3. Verification and documentation
+
+- [x] 3.1 Add concise Settings manual guidance for the HDS update handoff and its requirement to finish selection and confirmation on the scale display; verify the wiki entry follows the project’s short-form manual convention.
+- [ ] 3.2 Run the relevant Qt Creator test targets and the full test suite, then manually verify the Connections page is unchanged when no HDS update is available and the dialog works over both Bluetooth and USB.
+
+## Deferred follow-up — not part of this change
+
+The OpenScale repository will later define a remote HDS OTA protocol for GUI-driven release selection, confirmation, and progress. It must preserve device-side signed-manifest and asset verification. This does not gate implementation, testing, completion, or release of the Decenza handoff feature above.

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -17,6 +17,116 @@ Item {
     // USB is not supported on iOS (no USB host mode)
     readonly property bool usbAvailable: Qt.platform.os !== "ios"
 
+    DecenzaDialog {
+        id: hdsFirmwareUpdateDialog
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        modal: true
+        title: TranslationManager.translate("connections.hdsUpdateTitle", "Update Half Decent Scale")
+        closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+        width: Math.min((parent ? parent.width : Theme.scaled(460)) * 0.9, Theme.scaled(460))
+        padding: Theme.scaled(20)
+        onOpened: MainController.hdsFirmwareUpdate.loadReleaseNotes()
+
+        contentItem: ColumnLayout {
+            spacing: Theme.scaled(12)
+            // DecenzaDialog is a Popup, so attach the dialog semantics to its Item content.
+            Accessible.role: Accessible.Dialog
+            Accessible.name: hdsFirmwareUpdateDialog.title
+
+            Text {
+                Layout.fillWidth: true
+                text: TranslationManager.translate("connections.hdsUpdateVersions",
+                                                   "Version %1 is available (installed: %2).")
+                    .arg(MainController.hdsFirmwareUpdate.availableVersion)
+                    .arg(MainController.hdsFirmwareUpdate.installedVersion)
+                color: Theme.textColor
+                wrapMode: Text.Wrap
+                Accessible.ignored: true
+            }
+
+            Text {
+                Layout.fillWidth: true
+                visible: !MainController.hdsFirmwareUpdate.handoffStarted
+                text: TranslationManager.translate("connections.hdsUpdateHandoff",
+                                                   "Decenza will start the update handoff. Choose the version and hold to confirm on the scale display.")
+                color: Theme.textSecondaryColor
+                wrapMode: Text.Wrap
+                Accessible.ignored: true
+            }
+
+            Text {
+                Layout.fillWidth: true
+                visible: MainController.hdsFirmwareUpdate.handoffStarted
+                text: TranslationManager.translate("connections.hdsUpdateStarted",
+                                                   "The update was handed to the scale. Continue version selection and confirmation on its display. Decenza will not report installation complete until the scale reconnects on the new version.")
+                color: Theme.textSecondaryColor
+                wrapMode: Text.Wrap
+                Accessible.ignored: true
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: TranslationManager.translate("connections.hdsReleaseNotes", "Release notes")
+                color: Theme.textColor
+                font.bold: true
+                Accessible.ignored: true
+            }
+
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.scaled(160)
+                clip: true
+
+                TextArea {
+                    readOnly: true
+                    wrapMode: TextEdit.Wrap
+                    text: MainController.hdsFirmwareUpdate.releaseNotesLoading
+                        ? TranslationManager.translate("connections.hdsReleaseNotesLoading", "Loading release notes…")
+                        : (MainController.hdsFirmwareUpdate.releaseNotes ||
+                           TranslationManager.translate("connections.hdsReleaseNotesUnavailable", "Release notes are unavailable right now."))
+                    color: Theme.textColor
+                    Accessible.role: Accessible.EditableText
+                    Accessible.name: TranslationManager.translate("connections.hdsReleaseNotes", "Release notes")
+                    Accessible.focusable: true
+                }
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignRight
+                spacing: Theme.scaled(8)
+
+                AccessibleButton {
+                    text: MainController.hdsFirmwareUpdate.handoffStarted
+                        ? TranslationManager.translate("common.button.close", "Close")
+                        : TranslationManager.translate("common.cancel", "Cancel")
+                    accessibleName: text
+                    subtle: true
+                    onClicked: hdsFirmwareUpdateDialog.close()
+                }
+
+                AccessibleButton {
+                    visible: !MainController.hdsFirmwareUpdate.handoffStarted
+                    text: TranslationManager.translate("connections.hdsStartUpdate", "Start update")
+                    accessibleName: TranslationManager.translate("connections.hdsStartUpdate", "Start update")
+                    primary: true
+                    onClicked: MainController.hdsFirmwareUpdate.startUpdate()
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: MainController.hdsFirmwareUpdate
+        function onUpdateAvailableChanged() {
+            if (!MainController.hdsFirmwareUpdate.updateAvailable)
+                hdsFirmwareUpdateDialog.close()
+        }
+        function onActiveScaleChanged() {
+            hdsFirmwareUpdateDialog.close()
+        }
+    }
+
     // Share Log Dialog
     DecenzaDialog {
         id: shareLogDialog
@@ -1425,6 +1535,15 @@ Item {
                                         }
                                     }
                                 }
+                            }
+
+                            AccessibleButton {
+                                visible: MainController.hdsFirmwareUpdate.updateAvailable
+                                text: TranslationManager.translate("connections.hdsUpdate", "Update")
+                                accessibleName: TranslationManager.translate("connections.hdsUpdateScale",
+                                                                             "Update Half Decent Scale")
+                                primary: true
+                                onClicked: hdsFirmwareUpdateDialog.open()
                             }
                         }
 

--- a/src/ble/protocol/decentscaleprotocol.h
+++ b/src/ble/protocol/decentscaleprotocol.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QByteArray>
+#include <QString>
 #include <cstdint>
 
 // Decent Scale 7-byte binary packet protocol, shared by BLE and USB paths.
@@ -14,6 +15,17 @@ inline uint8_t calculateXor(const QByteArray& data) {
         result ^= static_cast<uint8_t>(data[i]);
     }
     return result;
+}
+
+// HDS LED responses carry the firmware triple in their last two bytes: the
+// major version is BCD packed and the minor and patch values occupy one nibble
+// each. Keep this transport-neutral because USB and Bluetooth receive the same
+// packet shape.
+inline QString decodeHdsFirmwareVersion(uint8_t packedMajor, uint8_t packedMinorPatch) {
+    const int major = ((packedMajor >> 4) & 0x0F) * 10 + (packedMajor & 0x0F);
+    const int minor = (packedMinorPatch >> 4) & 0x0F;
+    const int patch = packedMinorPatch & 0x0F;
+    return QStringLiteral("%1.%2.%3").arg(major).arg(minor).arg(patch);
 }
 
 } // namespace DecentScaleProtocol

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -19,6 +19,8 @@ class ScaleDevice : public QObject {
     Q_PROPERTY(double flowRate READ flowRate NOTIFY flowRateChanged)
     Q_PROPERTY(int batteryLevel READ batteryLevel NOTIFY batteryLevelChanged)
     Q_PROPERTY(bool charging READ charging NOTIFY chargingChanged)
+    Q_PROPERTY(QString firmwareVersion READ firmwareVersion NOTIFY firmwareVersionChanged)
+    Q_PROPERTY(bool supportsFirmwareUpdate READ supportsFirmwareUpdate NOTIFY firmwareVersionChanged)
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(bool isFlowScale READ isFlowScale CONSTANT)
     Q_PROPERTY(bool isSimulated READ isSimulated CONSTANT)
@@ -34,6 +36,8 @@ public:
     double flowRate() const { return m_flowRate; }
     int batteryLevel() const { return m_batteryLevel; }
     bool charging() const { return m_charging; }
+    virtual QString firmwareVersion() const { return {}; }
+    virtual bool supportsFirmwareUpdate() const { return false; }
     virtual QString name() const { return QString(); }
     virtual QString type() const { return QString(); }
     virtual bool isFlowScale() const { return false; }
@@ -78,6 +82,7 @@ public slots:
     virtual void wake() {}   // Wake scale from sleep (enable LCD)
     virtual void disableLcd() {}  // Turn off LCD but keep scale powered (for screensaver)
     virtual void sendKeepAlive() {}  // Override to send BLE keepalive (e.g., re-enable notifications)
+    virtual void startFirmwareUpdate() {}
     virtual void disconnectFromScale();  // Disconnect BLE from scale
     void resetFlowCalculation();  // Call after tare to avoid flow rate spikes
 
@@ -103,6 +108,7 @@ signals:
     void flowRateChanged(double rate);
     void batteryLevelChanged(int level);
     void chargingChanged(bool charging);
+    void firmwareVersionChanged();
     void buttonPressed(int button);
     void errorOccurred(const QString& error);
     void simulationModeChanged();

--- a/src/ble/scaledeviceproxy.cpp
+++ b/src/ble/scaledeviceproxy.cpp
@@ -30,6 +30,7 @@ void ScaleDeviceProxy::setTarget(ScaleDevice* target)
         connect(m_target, &ScaleDevice::flowRateChanged, this, &ScaleDeviceProxy::flowRateChanged);
         connect(m_target, &ScaleDevice::batteryLevelChanged, this, &ScaleDeviceProxy::batteryLevelChanged);
         connect(m_target, &ScaleDevice::chargingChanged, this, &ScaleDeviceProxy::chargingChanged);
+        connect(m_target, &ScaleDevice::firmwareVersionChanged, this, &ScaleDeviceProxy::firmwareVersionChanged);
         connect(m_target, &ScaleDevice::buttonPressed, this, &ScaleDeviceProxy::buttonPressed);
         connect(m_target, &ScaleDevice::errorOccurred, this, &ScaleDeviceProxy::errorOccurred);
         connect(m_target, &ScaleDevice::simulationModeChanged, this, &ScaleDeviceProxy::simulationModeChanged);
@@ -46,6 +47,7 @@ void ScaleDeviceProxy::setTarget(ScaleDevice* target)
     emit flowRateChanged(flowRate());
     emit batteryLevelChanged(batteryLevel());
     emit chargingChanged(charging());
+    emit firmwareVersionChanged();
     emit simulationModeChanged();
 }
 
@@ -62,6 +64,7 @@ void ScaleDeviceProxy::resetTimer()          { if (m_target) m_target->resetTime
 void ScaleDeviceProxy::wake()                { if (m_target) m_target->wake(); }
 void ScaleDeviceProxy::disableLcd()          { if (m_target) m_target->disableLcd(); }
 void ScaleDeviceProxy::sendKeepAlive()       { if (m_target) m_target->sendKeepAlive(); }
+void ScaleDeviceProxy::startFirmwareUpdate() { if (m_target) m_target->startFirmwareUpdate(); }
 void ScaleDeviceProxy::disconnectFromScale() { if (m_target) m_target->disconnectFromScale(); }
 void ScaleDeviceProxy::resetFlowCalculation() { if (m_target) m_target->resetFlowCalculation(); }
 

--- a/src/ble/scaledeviceproxy.h
+++ b/src/ble/scaledeviceproxy.h
@@ -63,6 +63,8 @@ class ScaleDeviceProxy : public QObject {
     Q_PROPERTY(double flowRate READ flowRate NOTIFY flowRateChanged)
     Q_PROPERTY(int batteryLevel READ batteryLevel NOTIFY batteryLevelChanged)
     Q_PROPERTY(bool charging READ charging NOTIFY chargingChanged)
+    Q_PROPERTY(QString firmwareVersion READ firmwareVersion NOTIFY firmwareVersionChanged)
+    Q_PROPERTY(bool supportsFirmwareUpdate READ supportsFirmwareUpdate NOTIFY firmwareVersionChanged)
     Q_PROPERTY(QString name READ name NOTIFY targetChanged)
     Q_PROPERTY(bool isFlowScale READ isFlowScale NOTIFY targetChanged)
     Q_PROPERTY(bool isSimulated READ isSimulated NOTIFY targetChanged)
@@ -84,6 +86,8 @@ public:
     // proxy with no scale attached is at least as unknown as that.
     int batteryLevel() const { return m_target ? m_target->batteryLevel() : -1; }
     bool charging() const { return m_target && m_target->charging(); }
+    QString firmwareVersion() const { return m_target ? m_target->firmwareVersion() : QString(); }
+    bool supportsFirmwareUpdate() const { return m_target && m_target->supportsFirmwareUpdate(); }
     QString name() const { return m_target ? m_target->name() : QString(); }
     bool isFlowScale() const { return m_target && m_target->isFlowScale(); }
     bool isSimulated() const { return m_target && m_target->isSimulated(); }
@@ -101,6 +105,7 @@ public slots:
     void wake();
     void disableLcd();
     void sendKeepAlive();
+    void startFirmwareUpdate();
     void disconnectFromScale();
     void resetFlowCalculation();
     void addFlowSample(double flowRate, double deltaTime);
@@ -124,6 +129,7 @@ signals:
     void flowRateChanged(double rate);
     void batteryLevelChanged(int level);
     void chargingChanged(bool charging);
+    void firmwareVersionChanged();
     void buttonPressed(int button);
     void errorOccurred(const QString& error);
     void simulationModeChanged();

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -91,7 +91,10 @@ void DecentScale::onTransportDisconnected() {
     // Re-log the firmware version on the next connect — the LED-response
     // packet only arrives periodically, but capturing it fresh per connect
     // is what makes the line useful for triage.
-    m_firmwareVersion.clear();
+    if (!m_firmwareVersion.isEmpty()) {
+        m_firmwareVersion.clear();
+        emit firmwareVersionChanged();
+    }
     m_lastBatteryByte = -1;
     m_ticksSinceBatteryPoll = 0;
     m_lcdOn = true;
@@ -317,21 +320,19 @@ void DecentScale::parseWeightData(const QByteArray& data) {
         // Log once per connect; a subsequent packet reporting a different
         // value warn-logs the transition (shouldn't happen on a live
         // scale — a change would itself be diagnostic).
-        const int major = ((d[5] >> 4) & 0x0F) * 10 + (d[5] & 0x0F);
-        const int minor = (d[6] >> 4) & 0x0F;
-        const int patch = d[6] & 0x0F;
-        const QString version = QStringLiteral("%1.%2.%3 (raw 0x%4 0x%5)")
-            .arg(major).arg(minor).arg(patch)
-            .arg(d[5], 2, 16, QLatin1Char('0'))
-            .arg(d[6], 2, 16, QLatin1Char('0'));
+        const QString version = DecentScaleProtocol::decodeHdsFirmwareVersion(d[5], d[6]);
         if (m_firmwareVersion != version) {
             if (m_firmwareVersion.isEmpty()) {
-                DECENT_LOG(QString("Firmware version: %1").arg(version));
+                DECENT_LOG(QString("Firmware version: %1 (raw 0x%2 0x%3)")
+                               .arg(version)
+                               .arg(d[5], 2, 16, QLatin1Char('0'))
+                               .arg(d[6], 2, 16, QLatin1Char('0')));
             } else {
                 DECENT_WARN(QString("Firmware version changed mid-connect: %1 -> %2")
                             .arg(m_firmwareVersion, version));
             }
             m_firmwareVersion = version;
+            emit firmwareVersionChanged();
         }
     } else if (command == 0xAA) {
         // Button pressed
@@ -496,6 +497,14 @@ void DecentScale::stopTimer() {
 
 void DecentScale::resetTimer() {
     sendCommand(QByteArray::fromHex("0B0200"));
+}
+
+void DecentScale::startFirmwareUpdate() {
+    if (!supportsFirmwareUpdate()) {
+        DECENT_LOG("Firmware update command dropped - HDS firmware version is unknown");
+        return;
+    }
+    sendCommand(QByteArray::fromHex("1B"));
 }
 
 void DecentScale::sleep() {

--- a/src/ble/scales/decentscale.h
+++ b/src/ble/scales/decentscale.h
@@ -14,6 +14,8 @@ public:
     void connectToDevice(const QBluetoothDeviceInfo& device) override;
     QString name() const override { return m_name; }
     QString type() const override { return ScaleTypeIds::scaleTypeId(ScaleType::DecentScale); }
+    QString firmwareVersion() const override { return m_firmwareVersion; }
+    bool supportsFirmwareUpdate() const override { return !m_firmwareVersion.isEmpty(); }
 
 public slots:
     void tare() override;
@@ -25,6 +27,7 @@ public slots:
     void sleep() override;
     void wake() override;
     void disableLcd() override;
+    void startFirmwareUpdate() override;
     void setLed(int r, int g, int b);
 private slots:
     void onTransportConnected();

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1,6 +1,7 @@
 #include "core/settings_app.h"
 #include "core/appsettings.h"
 #include "maincontroller.h"
+#include "ble/scaledeviceproxy.h"
 #include <QUuid>
 #include "shottimingcontroller.h"
 #include "autoflowcalclassifier.h"
@@ -111,6 +112,18 @@ MainController *MainController::create(QQmlEngine *qmlEngine, QJSEngine *jsEngin
     // owned by main().
     QJSEngine::setObjectOwnership(s_qmlInstance, QJSEngine::CppOwnership);
     return s_qmlInstance;
+}
+
+void MainController::setScaleDeviceProxy(ScaleDeviceProxy* proxy)
+{
+    if (!m_hdsFirmwareUpdate)
+        return;
+    m_hdsFirmwareUpdate->setScaleDevice(proxy ? proxy->target() : nullptr);
+    if (proxy) {
+        connect(proxy, &ScaleDeviceProxy::targetChanged, m_hdsFirmwareUpdate, [this, proxy]() {
+            m_hdsFirmwareUpdate->setScaleDevice(proxy->target());
+        });
+    }
 }
 
 MainController::MainController(QNetworkAccessManager* networkManager,
@@ -868,6 +881,7 @@ MainController::MainController(QNetworkAccessManager* networkManager,
 
     // Initialize update checker
     m_updateChecker = new UpdateChecker(m_networkManager, m_settings, this);
+    m_hdsFirmwareUpdate = new HdsFirmwareUpdateController(m_networkManager, this);
 
     // Initialize DE1 firmware update pipeline. FirmwareAssetCache shares
     // the MainController's QNetworkAccessManager (so proxy/TLS settings

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -42,6 +42,7 @@
 // The cost is real but bounded: touching mqttclient.h rebuilds 26 objects.
 #include "../network/mqttclient.h"
 #include "../core/updatechecker.h"
+#include "../core/hdsfirmwareupdatecontroller.h"
 #include "../core/firmwareassetcache.h"
 #include "firmwareupdater.h"
 #include "../core/datamigrationclient.h"
@@ -62,6 +63,7 @@ class ShotDebugLogger;
 class LocationProvider;
 class ShotTimingController;
 class TranslationManager;
+class ScaleDeviceProxy;
 struct ShotSample;
 
 class MainController : public QObject {
@@ -192,6 +194,7 @@ class MainController : public QObject {
     Q_PROPERTY(ShotServer* shotServer READ shotServer CONSTANT FINAL)
     Q_PROPERTY(MqttClient* mqttClient READ mqttClient CONSTANT FINAL)
     Q_PROPERTY(UpdateChecker* updateChecker READ updateChecker CONSTANT FINAL)
+    Q_PROPERTY(HdsFirmwareUpdateController* hdsFirmwareUpdate READ hdsFirmwareUpdate CONSTANT FINAL)
     Q_PROPERTY(FirmwareUpdater* firmwareUpdater READ firmwareUpdater CONSTANT FINAL)
     Q_PROPERTY(ShotReporter* shotReporter READ shotReporter CONSTANT FINAL)
     Q_PROPERTY(DataMigrationClient* dataMigration READ dataMigration CONSTANT FINAL)
@@ -301,6 +304,8 @@ public:
     ShotServer* shotServer() const { return m_shotServer; }
     MqttClient* mqttClient() const { return m_mqttClient; }
     UpdateChecker* updateChecker() const { return m_updateChecker; }
+    HdsFirmwareUpdateController* hdsFirmwareUpdate() const { return m_hdsFirmwareUpdate; }
+    void setScaleDeviceProxy(ScaleDeviceProxy* proxy);
     FirmwareUpdater* firmwareUpdater() const { return m_firmwareUpdater; }
     ShotReporter* shotReporter() const { return m_shotReporter; }
     DataMigrationClient* dataMigration() const { return m_dataMigration; }
@@ -856,6 +861,7 @@ private:
     ShotServer* m_shotServer = nullptr;
     MqttClient* m_mqttClient = nullptr;
     UpdateChecker* m_updateChecker = nullptr;
+    HdsFirmwareUpdateController* m_hdsFirmwareUpdate = nullptr;
     DE1::Firmware::FirmwareAssetCache* m_firmwareAssetCache = nullptr;
     FirmwareUpdater* m_firmwareUpdater = nullptr;
     QTimer* m_firmwareCheckTimer = nullptr;   // weekly recurring check

--- a/src/core/githubreleaseclient.cpp
+++ b/src/core/githubreleaseclient.cpp
@@ -1,0 +1,54 @@
+#include "githubreleaseclient.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrl>
+
+namespace {
+
+QNetworkRequest requestForPath(const QString& path)
+{
+    return GitHubReleaseClient::requestForUrl(
+        QUrl(QStringLiteral("https://api.github.com/repos/%1").arg(path)));
+}
+
+} // namespace
+
+QNetworkRequest GitHubReleaseClient::requestForUrl(const QUrl& url)
+{
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("Decenza"));
+    request.setRawHeader("Accept", "application/vnd.github.v3+json");
+    request.setAttribute(QNetworkRequest::ConnectionCacheExpiryTimeoutSecondsAttribute, 0);
+    return request;
+}
+
+QNetworkRequest GitHubReleaseClient::releasesRequest(const QString& repository)
+{
+    return requestForPath(repository + QStringLiteral("/releases?per_page=10"));
+}
+
+QNetworkRequest GitHubReleaseClient::releaseRequest(const QString& repository, const QString& tag)
+{
+    return requestForPath(repository + QStringLiteral("/releases/tags/") + tag);
+}
+
+std::optional<GitHubRelease> GitHubReleaseClient::parseRelease(const QByteArray& data, QString* error)
+{
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(data, &parseError);
+    if (!document.isObject()) {
+        if (error)
+            *error = parseError.error == QJsonParseError::NoError
+                ? QStringLiteral("GitHub release response is not an object") : parseError.errorString();
+        return std::nullopt;
+    }
+    const QJsonObject object = document.object();
+    const QString tag = object.value(QStringLiteral("tag_name")).toString();
+    if (tag.isEmpty()) {
+        if (error)
+            *error = QStringLiteral("GitHub release response has no tag name");
+        return std::nullopt;
+    }
+    return GitHubRelease{tag, object.value(QStringLiteral("body")).toString()};
+}

--- a/src/core/githubreleaseclient.h
+++ b/src/core/githubreleaseclient.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QNetworkRequest>
+#include <QString>
+#include <QUrl>
+
+#include <optional>
+
+struct GitHubRelease {
+    QString tag;
+    QString body;
+};
+
+namespace GitHubReleaseClient {
+
+QNetworkRequest requestForUrl(const QUrl& url);
+QNetworkRequest releasesRequest(const QString& repository);
+QNetworkRequest releaseRequest(const QString& repository, const QString& tag);
+std::optional<GitHubRelease> parseRelease(const QByteArray& data, QString* error = nullptr);
+
+} // namespace GitHubReleaseClient

--- a/src/core/hdsfirmwarecatalog.cpp
+++ b/src/core/hdsfirmwarecatalog.cpp
@@ -1,0 +1,125 @@
+#include "hdsfirmwarecatalog.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+
+namespace {
+
+std::optional<QList<int>> versionParts(const QString& version)
+{
+    static const QRegularExpression expression(
+        QStringLiteral("^v?(\\d+)\\.(\\d+)\\.(\\d+)$"));
+    const QRegularExpressionMatch match = expression.match(version.trimmed());
+    if (!match.hasMatch())
+        return std::nullopt;
+
+    bool ok = false;
+    const quint16 major = match.captured(1).toUShort(&ok);
+    if (!ok)
+        return std::nullopt;
+    const quint16 minor = match.captured(2).toUShort(&ok);
+    if (!ok)
+        return std::nullopt;
+    const quint16 patch = match.captured(3).toUShort(&ok);
+    if (!ok)
+        return std::nullopt;
+    return QList<int>{major, minor, patch};
+}
+
+HdsFirmwareRelease releaseFromObject(const QJsonObject& object)
+{
+    HdsFirmwareRelease release;
+    release.version = object.value(QStringLiteral("version")).toString();
+    release.minFromVersion = object.value(QStringLiteral("min_from")).toString();
+    release.model = object.value(QStringLiteral("model")).toString();
+    release.releaseNotesUrl = object.value(QStringLiteral("release_notes_url")).toString();
+    return release;
+}
+
+} // namespace
+
+std::optional<HdsFirmwareCatalog> HdsFirmwareCatalog::fromJson(const QByteArray& data, QString* error)
+{
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(data, &parseError);
+    if (!document.isObject()) {
+        if (error) {
+            *error = parseError.error == QJsonParseError::NoError
+                ? QStringLiteral("HDS manifest root is not an object")
+                : parseError.errorString();
+        }
+        return std::nullopt;
+    }
+
+    const QJsonObject root = document.object();
+    HdsFirmwareCatalog catalog;
+
+    const QJsonValue releasesValue = root.value(QStringLiteral("releases"));
+    if (!releasesValue.isUndefined() && !releasesValue.isNull()) {
+        if (!releasesValue.isArray()) {
+            if (error)
+                *error = QStringLiteral("HDS manifest releases is not an array");
+            return std::nullopt;
+        }
+        for (const QJsonValue& value : releasesValue.toArray()) {
+            if (!value.isObject())
+                continue;
+            const HdsFirmwareRelease release = releaseFromObject(value.toObject());
+            if (versionParts(release.version) && !release.model.isEmpty())
+                catalog.m_releases.append(release);
+        }
+    } else {
+        const HdsFirmwareRelease release = releaseFromObject(root);
+        if (versionParts(release.version) && !release.model.isEmpty())
+            catalog.m_releases.append(release);
+    }
+
+    if (catalog.m_releases.isEmpty()) {
+        if (error)
+            *error = QStringLiteral("HDS manifest contains no valid releases");
+        return std::nullopt;
+    }
+
+    return catalog;
+}
+
+std::optional<HdsFirmwareRelease> HdsFirmwareCatalog::newestEligibleRelease(
+    const QString& installedVersion, const QString& model) const
+{
+    if (!versionParts(installedVersion))
+        return std::nullopt;
+
+    std::optional<HdsFirmwareRelease> newest;
+    for (const HdsFirmwareRelease& release : m_releases) {
+        if (release.model.compare(model, Qt::CaseInsensitive) != 0
+            || compareVersions(release.version, installedVersion) <= 0) {
+            continue;
+        }
+        if (!release.minFromVersion.isEmpty()
+            && (!versionParts(release.minFromVersion)
+                || compareVersions(installedVersion, release.minFromVersion) < 0)) {
+            continue;
+        }
+        if (!newest || compareVersions(release.version, newest->version) > 0)
+            newest = release;
+    }
+    return newest;
+}
+
+int HdsFirmwareCatalog::compareVersions(const QString& left, const QString& right)
+{
+    const auto leftParts = versionParts(left);
+    const auto rightParts = versionParts(right);
+    if (!leftParts || !rightParts)
+        return 0;
+
+    for (int i = 0; i < leftParts->size(); ++i) {
+        if (leftParts->at(i) < rightParts->at(i))
+            return -1;
+        if (leftParts->at(i) > rightParts->at(i))
+            return 1;
+    }
+    return 0;
+}

--- a/src/core/hdsfirmwarecatalog.h
+++ b/src/core/hdsfirmwarecatalog.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+
+#include <optional>
+
+struct HdsFirmwareRelease {
+    QString version;
+    QString minFromVersion;
+    QString model;
+    QString releaseNotesUrl;
+};
+
+// An advisory view of the public catalog the HDS itself later downloads and
+// verifies. This class deliberately models only the compatibility information
+// Decenza can identify; the scale remains the final authority for installation.
+class HdsFirmwareCatalog {
+public:
+    static std::optional<HdsFirmwareCatalog> fromJson(const QByteArray& data, QString* error = nullptr);
+
+    std::optional<HdsFirmwareRelease> newestEligibleRelease(const QString& installedVersion,
+                                                             const QString& model = QStringLiteral("hds")) const;
+    const QList<HdsFirmwareRelease>& releases() const { return m_releases; }
+
+    static int compareVersions(const QString& left, const QString& right);
+
+private:
+    QList<HdsFirmwareRelease> m_releases;
+};

--- a/src/core/hdsfirmwareupdatecontroller.cpp
+++ b/src/core/hdsfirmwareupdatecontroller.cpp
@@ -1,0 +1,176 @@
+#include "hdsfirmwareupdatecontroller.h"
+
+#include "githubreleaseclient.h"
+#include "ble/scaledevice.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QDebug>
+
+namespace {
+
+constexpr auto kManifestUrl = "https://github.com/decentespresso/openscale/releases/latest/download/manifest.json";
+constexpr auto kOpenScaleRepository = "decentespresso/openscale";
+
+QString releaseTag(const QString& version)
+{
+    return version.startsWith(QLatin1Char('v')) ? version : QStringLiteral("v") + version;
+}
+
+} // namespace
+
+HdsFirmwareUpdateController::HdsFirmwareUpdateController(QNetworkAccessManager* networkManager, QObject* parent)
+    : QObject(parent)
+    , m_network(networkManager)
+{
+    Q_ASSERT(m_network);
+    checkForUpdates();
+}
+
+QString HdsFirmwareUpdateController::installedVersion() const
+{
+    return m_scale ? m_scale->firmwareVersion() : QString();
+}
+
+QString HdsFirmwareUpdateController::availableVersion() const
+{
+    return m_availableRelease ? m_availableRelease->version : QString();
+}
+
+void HdsFirmwareUpdateController::setScaleDevice(ScaleDevice* scale)
+{
+    if (m_scale == scale)
+        return;
+    if (m_scale)
+        disconnect(m_scale, nullptr, this, nullptr);
+    cancelReleaseNotesRequest();
+    m_scale = scale;
+    if (m_scale) {
+        connect(m_scale, &ScaleDevice::connectedChanged, this, &HdsFirmwareUpdateController::reevaluateAvailability);
+        connect(m_scale, &ScaleDevice::firmwareVersionChanged, this, &HdsFirmwareUpdateController::reevaluateAvailability);
+    }
+    reevaluateAvailability();
+    emit activeScaleChanged();
+}
+
+void HdsFirmwareUpdateController::checkForUpdates()
+{
+    if (m_manifestReply)
+        m_manifestReply->abort();
+    m_checking = true;
+    emit checkingChanged();
+
+    QNetworkReply* reply = m_network->get(GitHubReleaseClient::requestForUrl(
+        QUrl(QString::fromLatin1(kManifestUrl))));
+    m_manifestReply = reply;
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply != m_manifestReply) {
+            reply->deleteLater();
+            return;
+        }
+        m_manifestReply = nullptr;
+        m_checking = false;
+        emit checkingChanged();
+        if (!reply)
+            return;
+        if (reply->error() != QNetworkReply::NoError) {
+            qWarning().noquote() << "[Scale][HDS Update] Manifest check failed:" << reply->errorString();
+            reply->deleteLater();
+            return;
+        }
+        QString error;
+        const auto catalog = HdsFirmwareCatalog::fromJson(reply->readAll(), &error);
+        reply->deleteLater();
+        if (!catalog) {
+            qWarning().noquote() << "[Scale][HDS Update] Manifest ignored:" << error;
+            return;
+        }
+        m_catalog = catalog;
+        reevaluateAvailability();
+    });
+}
+
+void HdsFirmwareUpdateController::loadReleaseNotes()
+{
+    if (!m_availableRelease || m_releaseNotesLoading || !m_releaseNotes.isEmpty())
+        return;
+    m_releaseNotesLoading = true;
+    emit releaseNotesLoadingChanged();
+    QNetworkReply* reply = m_network->get(GitHubReleaseClient::releaseRequest(
+        QString::fromLatin1(kOpenScaleRepository), releaseTag(m_availableRelease->version)));
+    m_releaseNotesReply = reply;
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply != m_releaseNotesReply) {
+            reply->deleteLater();
+            return;
+        }
+        m_releaseNotesReply = nullptr;
+        m_releaseNotesLoading = false;
+        emit releaseNotesLoadingChanged();
+        if (!reply)
+            return;
+        if (reply->error() != QNetworkReply::NoError) {
+            qWarning().noquote() << "[Scale][HDS Update] Release notes check failed:" << reply->errorString();
+            reply->deleteLater();
+            return;
+        }
+        QString error;
+        const auto release = GitHubReleaseClient::parseRelease(reply->readAll(), &error);
+        reply->deleteLater();
+        if (!release) {
+            qWarning().noquote() << "[Scale][HDS Update] Release notes ignored:" << error;
+            return;
+        }
+        m_releaseNotes = release->body;
+        emit releaseNotesChanged();
+    });
+}
+
+void HdsFirmwareUpdateController::startUpdate()
+{
+    reevaluateAvailability();
+    if (!m_updateAvailable || !m_scale || m_handoffStarted)
+        return;
+    m_scale->startFirmwareUpdate();
+    m_handoffStarted = true;
+    emit handoffStartedChanged();
+}
+
+void HdsFirmwareUpdateController::cancelReleaseNotesRequest()
+{
+    if (m_releaseNotesReply) {
+        QNetworkReply* reply = m_releaseNotesReply;
+        m_releaseNotesReply = nullptr;
+        reply->abort();
+    }
+    if (!m_releaseNotesLoading)
+        return;
+    m_releaseNotesLoading = false;
+    emit releaseNotesLoadingChanged();
+}
+
+void HdsFirmwareUpdateController::reevaluateAvailability()
+{
+    const auto oldVersion = availableVersion();
+    const bool wasAvailable = m_updateAvailable;
+    m_availableRelease.reset();
+    if (m_catalog && m_scale && m_scale->isConnected() && m_scale->supportsFirmwareUpdate())
+        m_availableRelease = m_catalog->newestEligibleRelease(m_scale->firmwareVersion());
+    setUpdateAvailable(m_availableRelease.has_value());
+    if (wasAvailable != m_updateAvailable || oldVersion != availableVersion()) {
+        cancelReleaseNotesRequest();
+        m_releaseNotes.clear();
+        m_handoffStarted = false;
+        emit releaseNotesChanged();
+        emit handoffStartedChanged();
+        emit availabilityChanged();
+    }
+}
+
+void HdsFirmwareUpdateController::setUpdateAvailable(bool available)
+{
+    if (m_updateAvailable == available)
+        return;
+    m_updateAvailable = available;
+    emit updateAvailableChanged();
+}

--- a/src/core/hdsfirmwareupdatecontroller.h
+++ b/src/core/hdsfirmwareupdatecontroller.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "hdsfirmwarecatalog.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QtQml/qqmlregistration.h>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+class ScaleDevice;
+
+class HdsFirmwareUpdateController : public QObject {
+    Q_OBJECT
+
+    QML_ELEMENT
+    QML_UNCREATABLE("HdsFirmwareUpdateController is created in C++ and reached via MainController")
+
+    Q_PROPERTY(bool checking READ checking NOTIFY checkingChanged)
+    Q_PROPERTY(bool updateAvailable READ updateAvailable NOTIFY updateAvailableChanged)
+    Q_PROPERTY(QString installedVersion READ installedVersion NOTIFY availabilityChanged)
+    Q_PROPERTY(QString availableVersion READ availableVersion NOTIFY availabilityChanged)
+    Q_PROPERTY(QString releaseNotes READ releaseNotes NOTIFY releaseNotesChanged)
+    Q_PROPERTY(bool releaseNotesLoading READ releaseNotesLoading NOTIFY releaseNotesLoadingChanged)
+    Q_PROPERTY(bool handoffStarted READ handoffStarted NOTIFY handoffStartedChanged)
+
+public:
+    explicit HdsFirmwareUpdateController(QNetworkAccessManager* networkManager, QObject* parent = nullptr);
+
+    bool checking() const { return m_checking; }
+    bool updateAvailable() const { return m_updateAvailable; }
+    QString installedVersion() const;
+    QString availableVersion() const;
+    QString releaseNotes() const { return m_releaseNotes; }
+    bool releaseNotesLoading() const { return m_releaseNotesLoading; }
+    bool handoffStarted() const { return m_handoffStarted; }
+
+    void setScaleDevice(ScaleDevice* scale);
+
+public slots:
+    void checkForUpdates();
+    void loadReleaseNotes();
+    void startUpdate();
+
+signals:
+    void checkingChanged();
+    void updateAvailableChanged();
+    void availabilityChanged();
+    void releaseNotesChanged();
+    void releaseNotesLoadingChanged();
+    void handoffStartedChanged();
+    void activeScaleChanged();
+
+private:
+    void cancelReleaseNotesRequest();
+    void reevaluateAvailability();
+    void setUpdateAvailable(bool available);
+
+    QNetworkAccessManager* m_network = nullptr;
+    QPointer<ScaleDevice> m_scale;
+    QPointer<QNetworkReply> m_manifestReply;
+    QPointer<QNetworkReply> m_releaseNotesReply;
+    std::optional<HdsFirmwareCatalog> m_catalog;
+    std::optional<HdsFirmwareRelease> m_availableRelease;
+    bool m_checking = false;
+    bool m_updateAvailable = false;
+    bool m_releaseNotesLoading = false;
+    bool m_handoffStarted = false;
+    QString m_releaseNotes;
+};

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -1,4 +1,5 @@
 #include "updatechecker.h"
+#include "githubreleaseclient.h"
 #include "crashhandler.h"
 #include "settings.h"
 #include "settings_app.h"
@@ -30,7 +31,6 @@
 #include <QAtomicInt>
 #include <QThread>
 
-const QString UpdateChecker::GITHUB_API_URL = "https://api.github.com/repos/%1/releases?per_page=10";
 const QString UpdateChecker::GITHUB_REPO = "Kulitorum/Decenza";
 
 // File-scope so background QFile::remove threads can read it without capturing
@@ -231,22 +231,7 @@ UpdateChecker::~UpdateChecker()
 
 QNetworkRequest UpdateChecker::releaseInfoRequest() const
 {
-    QNetworkRequest request{QUrl(GITHUB_API_URL.arg(GITHUB_REPO))};
-    request.setHeader(QNetworkRequest::UserAgentHeader, "Decenza");
-    request.setRawHeader("Accept", "application/vnd.github.v3+json");
-
-    // Drop the connection as soon as the reply is done instead of parking it in
-    // Qt's connection cache for the default 120 s. We check once an hour and
-    // never reuse it, and GitHub closes the idle connection after ~30 s — at
-    // which point Qt's HTTP/2 closure path (QHttp2ProtocolHandler::
-    // handleConnectionClosure -> QHttp2Connection::handleReadyRead) reads from
-    // the already-closed socket and logs "QIODevice::read (QSslSocket): device
-    // not open". Harmless, but it landed in every user's log once an hour.
-    // Closing it ourselves costs nothing: the next check re-handshakes either
-    // way, since the connection was never going to survive the hour.
-    request.setAttribute(QNetworkRequest::ConnectionCacheExpiryTimeoutSecondsAttribute, 0);
-
-    return request;
+    return GitHubReleaseClient::releasesRequest(GITHUB_REPO);
 }
 
 QString UpdateChecker::currentVersion() const

--- a/src/core/updatechecker.h
+++ b/src/core/updatechecker.h
@@ -215,7 +215,6 @@ private:
     // Generation counter lives at file scope in updatechecker.cpp so background
     // QFile::remove threads don't capture `this` (see s_downloadGeneration).
 
-    static const QString GITHUB_API_URL;
     static const QString GITHUB_REPO;
 
 #ifdef DECENZA_TESTING

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2134,6 +2134,7 @@ int main(int argc, char *argv[])
     // re-point the `ScaleDevice` context property now call setTarget() on this.
     ScaleDeviceProxy scaleProxy;
     RefractometerProxy refractometerProxy;
+    mainController.setScaleDeviceProxy(&scaleProxy);
 
     // Hoisted for the same rule, and note it was ALREADY exposed to QML from below the engine —
     // as a context property, which QML drops on destroyed(), so the ordering hazard was papered
@@ -4428,6 +4429,7 @@ int main(int argc, char *argv[])
         else if (state == Qt::ApplicationActive && wasSuspended) {
             qDebug() << "App resumed from suspended state";
             wasSuspended = false;
+            mainController.hdsFirmwareUpdate()->checkForUpdates();
 
 #ifdef Q_OS_ANDROID
             // Re-enable accessibility bridge now that the EGL surface is valid again

--- a/src/usb/usbdecentscale.cpp
+++ b/src/usb/usbdecentscale.cpp
@@ -90,6 +90,15 @@ void UsbDecentScale::sleep()
     emit sleepCompleted();
 }
 
+void UsbDecentScale::startFirmwareUpdate()
+{
+    if (!supportsFirmwareUpdate()) {
+        USB_SCALE_LOG("Firmware update command dropped - HDS firmware version is unknown");
+        return;
+    }
+    sendCommand(QByteArray::fromHex("1B"));
+}
+
 // ===========================================================================
 // USB-specific API
 // ===========================================================================
@@ -169,6 +178,11 @@ void UsbDecentScale::close()
 #endif
 
     m_buffer.clear();
+
+    if (!m_firmwareVersion.isEmpty()) {
+        m_firmwareVersion.clear();
+        emit firmwareVersionChanged();
+    }
 
     if (isConnected()) {
         setConnected(false);
@@ -314,6 +328,15 @@ void UsbDecentScale::processPacket(const QByteArray& packet)
             setCharging(true);
             setBatteryLevel(100);  // Keep "100" reporting so existing UI bindings don't regress
         }
+        const QString version = DecentScaleProtocol::decodeHdsFirmwareVersion(d[5], d[6]);
+        if (m_firmwareVersion != version) {
+            USB_SCALE_LOG(QStringLiteral("Firmware version: %1 (raw 0x%2 0x%3)")
+                              .arg(version)
+                              .arg(d[5], 2, 16, QLatin1Char('0'))
+                              .arg(d[6], 2, 16, QLatin1Char('0')));
+            m_firmwareVersion = version;
+            emit firmwareVersionChanged();
+        }
     } else if (command == 0xAA) {
         // Button press
         int button = d[2];
@@ -351,5 +374,3 @@ void UsbDecentScale::writeRaw(const QByteArray& data)
     }
 #endif
 }
-
-

--- a/src/usb/usbdecentscale.h
+++ b/src/usb/usbdecentscale.h
@@ -36,6 +36,8 @@ public:
     void connectToDevice(const QBluetoothDeviceInfo& device) override;
     QString name() const override { return QStringLiteral("Half Decent Scale (USB)"); }
     QString type() const override { return ScaleTypeIds::scaleTypeId(ScaleType::DecentScaleUsb); }
+    QString firmwareVersion() const override { return m_firmwareVersion; }
+    bool supportsFirmwareUpdate() const override { return !m_firmwareVersion.isEmpty(); }
 
 public slots:
     void tare() override;
@@ -45,6 +47,7 @@ public slots:
     void resetTimer() override;
     void wake() override;
     void sleep() override;
+    void startFirmwareUpdate() override;
 
     // -- USB-specific API --
 
@@ -68,10 +71,18 @@ private slots:
     void onHeartbeatTimer();
 
 private:
+#ifdef DECENZA_TESTING
+    friend class tst_ScaleProtocol;
+    friend class tst_UsbDecentScale;
+#endif
     void processBuffer();
     void processPacket(const QByteArray& packet);
     void sendCommand(const QByteArray& commandData);
-    void writeRaw(const QByteArray& data);
+
+protected:
+    virtual void writeRaw(const QByteArray& data);
+
+private:
 
     QByteArray m_buffer;
     QTimer m_heartbeatTimer;
@@ -81,4 +92,5 @@ private:
 #else
     QSerialPort* m_port = nullptr;
 #endif
+    QString m_firmwareVersion;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 find_package(Qt6 REQUIRED COMPONENTS Test Core Bluetooth Sql Network WebSockets)
+if(NOT IOS)
+    find_package(Qt6 REQUIRED COMPONENTS SerialPort)
+endif()
 
 # Every test links decenza_testlib directly (see add_decenza_test), and the
 # targets that also link decenza_shotlib get it a second time through that
@@ -741,9 +744,24 @@ add_decenza_test(tst_dbtxn
 add_decenza_test(tst_updatechecker
     tst_updatechecker.cpp
     ${CMAKE_SOURCE_DIR}/src/core/updatechecker.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/githubreleaseclient.cpp
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
 target_include_directories(tst_updatechecker PRIVATE ${CMAKE_BINARY_DIR})
+
+# --- tst_hdsfirmwarecatalog: OpenScale manifest parsing and HDS eligibility ---
+add_decenza_test(tst_hdsfirmwarecatalog
+    tst_hdsfirmwarecatalog.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwarecatalog.cpp
+)
+
+# --- tst_hdsfirmwareupdatecontroller: manifest lifecycle, active-scale gate, and stale replies ---
+add_decenza_test(tst_hdsfirmwareupdatecontroller
+    tst_hdsfirmwareupdatecontroller.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/githubreleaseclient.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwarecatalog.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwareupdatecontroller.cpp
+)
 
 # --- tst_tclimport: TCL profile import round-trip against de1app profiles ---
 add_decenza_test(tst_tclimport
@@ -1216,6 +1234,15 @@ add_decenza_test(tst_scaleprotocol
     ${CMAKE_SOURCE_DIR}/src/ble/scales/difluidscale.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/acaiascale.cpp
 )
+
+if(NOT IOS)
+    # --- tst_usbdecentscale: HDS USB version and OTA trigger packet ---
+    add_decenza_test(tst_usbdecentscale
+        tst_usbdecentscale.cpp
+        ${CMAKE_SOURCE_DIR}/src/usb/usbdecentscale.cpp
+    )
+    target_link_libraries(tst_usbdecentscale PRIVATE Qt6::SerialPort)
+endif()
 
 # --- tst_decentscalewifi: WiFi scale driver (WebSocket protocol) ---
 add_decenza_test(tst_decentscalewifi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -362,6 +362,19 @@ add_library(decenza_firmwareassetcachelib STATIC
 set_target_properties(decenza_firmwareassetcachelib PROPERTIES AUTOMOC ON AUTOMOC_PATH_PREFIX OFF)
 target_link_libraries(decenza_firmwareassetcachelib PUBLIC decenza_testlib)
 
+# GitHub release requests and HDS manifest parsing are each exercised by two
+# focused targets. Keep them narrow: adding either to decenza_testlib would
+# relink all test executables for two sources that only these targets need.
+add_library(decenza_githubreleaseclientlib STATIC
+    ${CMAKE_SOURCE_DIR}/src/core/githubreleaseclient.cpp
+)
+target_link_libraries(decenza_githubreleaseclientlib PUBLIC decenza_testlib)
+
+add_library(decenza_hdsfirmwarecataloglib STATIC
+    ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwarecatalog.cpp
+)
+target_link_libraries(decenza_hdsfirmwarecataloglib PUBLIC decenza_testlib)
+
 add_decenza_test(tst_binarycodec
     tst_binarycodec.cpp
 )
@@ -744,23 +757,25 @@ add_decenza_test(tst_dbtxn
 add_decenza_test(tst_updatechecker
     tst_updatechecker.cpp
     ${CMAKE_SOURCE_DIR}/src/core/updatechecker.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/githubreleaseclient.cpp
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
 target_include_directories(tst_updatechecker PRIVATE ${CMAKE_BINARY_DIR})
+target_link_libraries(tst_updatechecker PRIVATE decenza_githubreleaseclientlib)
 
 # --- tst_hdsfirmwarecatalog: OpenScale manifest parsing and HDS eligibility ---
 add_decenza_test(tst_hdsfirmwarecatalog
     tst_hdsfirmwarecatalog.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwarecatalog.cpp
 )
+target_link_libraries(tst_hdsfirmwarecatalog PRIVATE decenza_hdsfirmwarecataloglib)
 
 # --- tst_hdsfirmwareupdatecontroller: manifest lifecycle, active-scale gate, and stale replies ---
 add_decenza_test(tst_hdsfirmwareupdatecontroller
     tst_hdsfirmwareupdatecontroller.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/githubreleaseclient.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwarecatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/core/hdsfirmwareupdatecontroller.cpp
+)
+target_link_libraries(tst_hdsfirmwareupdatecontroller PRIVATE
+    decenza_githubreleaseclientlib
+    decenza_hdsfirmwarecataloglib
 )
 
 # --- tst_tclimport: TCL profile import round-trip against de1app profiles ---
@@ -1237,11 +1252,11 @@ add_decenza_test(tst_scaleprotocol
 
 if(NOT IOS)
     # --- tst_usbdecentscale: HDS USB version and OTA trigger packet ---
-    add_decenza_test(tst_usbdecentscale
-        tst_usbdecentscale.cpp
-        ${CMAKE_SOURCE_DIR}/src/usb/usbdecentscale.cpp
-    )
-    target_link_libraries(tst_usbdecentscale PRIVATE Qt6::SerialPort)
+add_decenza_test(tst_usbdecentscale
+    tst_usbdecentscale.cpp
+    ${CMAKE_SOURCE_DIR}/src/usb/usbdecentscale.cpp
+)
+target_link_libraries(tst_usbdecentscale PRIVATE Qt6::SerialPort)
 endif()
 
 # --- tst_decentscalewifi: WiFi scale driver (WebSocket protocol) ---

--- a/tests/tst_hdsfirmwarecatalog.cpp
+++ b/tests/tst_hdsfirmwarecatalog.cpp
@@ -1,0 +1,84 @@
+#include <QtTest>
+
+#include "core/hdsfirmwarecatalog.h"
+
+class tst_HdsFirmwareCatalog : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    void selectsNewestCompatibleRelease();
+    void ignoresCurrentAndOlderRelease();
+    void rejectsDifferentModel();
+    void rejectsReleaseBlockedByMinFrom();
+    void rejectsNonStableVersion();
+    void rejectsMalformedOrEmptyCatalog();
+};
+
+void tst_HdsFirmwareCatalog::selectsNewestCompatibleRelease()
+{
+    const auto catalog = HdsFirmwareCatalog::fromJson(R"({
+        "model":"hds", "version":"3.1.13", "min_from":"3.0.0",
+        "release_notes_url":"https://example.test/releases/v3.1.13",
+        "releases":[
+            {"model":"hds","version":"3.1.13","min_from":"3.0.0",
+             "release_notes_url":"https://example.test/releases/v3.1.13"},
+            {"model":"hds","version":"3.1.12","min_from":"3.0.0"}
+        ]
+    })");
+    QVERIFY(catalog);
+
+    const auto release = catalog->newestEligibleRelease(QStringLiteral("3.1.10"));
+    QVERIFY(release);
+    QCOMPARE(release->version, QStringLiteral("3.1.13"));
+    QCOMPARE(release->releaseNotesUrl, QStringLiteral("https://example.test/releases/v3.1.13"));
+}
+
+void tst_HdsFirmwareCatalog::ignoresCurrentAndOlderRelease()
+{
+    const auto catalog = HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"3.1.13","releases":[
+            {"model":"hds","version":"3.1.13"},
+            {"model":"hds","version":"3.1.12"}
+        ]})");
+    QVERIFY(catalog);
+    QVERIFY(!catalog->newestEligibleRelease(QStringLiteral("3.1.13")));
+}
+
+void tst_HdsFirmwareCatalog::rejectsDifferentModel()
+{
+    const auto catalog = HdsFirmwareCatalog::fromJson(
+        R"({"model":"other-scale","version":"3.1.13"})");
+    QVERIFY(catalog);
+    QVERIFY(!catalog->newestEligibleRelease(QStringLiteral("3.1.10")));
+}
+
+void tst_HdsFirmwareCatalog::rejectsReleaseBlockedByMinFrom()
+{
+    const auto catalog = HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"3.1.13","min_from":"3.1.0"})");
+    QVERIFY(catalog);
+    QVERIFY(!catalog->newestEligibleRelease(QStringLiteral("3.0.9")));
+}
+
+void tst_HdsFirmwareCatalog::rejectsNonStableVersion()
+{
+    QVERIFY(!HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"3.1.14-dev"})"));
+    QVERIFY(!HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"3.1.14+metadata"})"));
+    QVERIFY(!HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"65536.1.1"})"));
+}
+
+void tst_HdsFirmwareCatalog::rejectsMalformedOrEmptyCatalog()
+{
+    QVERIFY(!HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"3.1.14","releases":{}})"));
+    QVERIFY(!HdsFirmwareCatalog::fromJson(
+        R"({"model":"hds","version":"3.1.14","releases":[]})"));
+}
+
+QTEST_GUILESS_MAIN(tst_HdsFirmwareCatalog)
+#include "tst_hdsfirmwarecatalog.moc"

--- a/tests/tst_hdsfirmwareupdatecontroller.cpp
+++ b/tests/tst_hdsfirmwareupdatecontroller.cpp
@@ -1,0 +1,238 @@
+#include <QtTest>
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QRegularExpression>
+#include <QTimer>
+
+#include <cstring>
+#include <utility>
+
+#include "ble/scaledevice.h"
+#include "core/hdsfirmwareupdatecontroller.h"
+
+namespace {
+
+QByteArray manifest(const char* version)
+{
+    return QByteArray("{\"model\":\"hds\",\"version\":\"") + version
+        + QByteArray("\",\"releases\":[{\"model\":\"hds\",\"version\":\"") + version
+        + QByteArray("\"}]}");
+}
+
+class ScriptedReply final : public QNetworkReply {
+public:
+    ScriptedReply(const QNetworkRequest& request, QByteArray body, QNetworkReply::NetworkError error,
+                  int delayMs, QObject* parent)
+        : QNetworkReply(parent)
+        , m_body(std::move(body))
+        , m_error(error)
+    {
+        setRequest(request);
+        setUrl(request.url());
+        open(QIODevice::ReadOnly | QIODevice::Unbuffered);
+        QTimer::singleShot(delayMs, this, [this] { finish(); });
+    }
+
+    void abort() override
+    {
+        if (m_finished || m_aborted)
+            return;
+        m_aborted = true;
+        setError(QNetworkReply::OperationCanceledError, QStringLiteral("Request canceled"));
+        // QNetworkReply::abort() reports finished asynchronously in the paths the
+        // controller cares about. Keeping that ordering makes stale-reply handling testable.
+        QTimer::singleShot(0, this, [this] { finish(); });
+    }
+
+    qint64 bytesAvailable() const override
+    {
+        return m_body.size() - m_offset + QNetworkReply::bytesAvailable();
+    }
+
+protected:
+    qint64 readData(char* data, qint64 maxSize) override
+    {
+        const qint64 count = qMin(maxSize, qint64(m_body.size() - m_offset));
+        if (count <= 0)
+            return -1;
+        memcpy(data, m_body.constData() + m_offset, size_t(count));
+        m_offset += count;
+        return count;
+    }
+
+private:
+    void finish()
+    {
+        if (m_finished)
+            return;
+        m_finished = true;
+        if (m_aborted) {
+            emit finished();
+            return;
+        }
+        if (m_error != QNetworkReply::NoError)
+            setError(m_error, QStringLiteral("Scripted network failure"));
+        else if (!m_body.isEmpty())
+            emit readyRead();
+        setFinished(true);
+        emit finished();
+    }
+
+    QByteArray m_body;
+    QNetworkReply::NetworkError m_error = QNetworkReply::NoError;
+    qint64 m_offset = 0;
+    bool m_aborted = false;
+    bool m_finished = false;
+};
+
+class ScriptedNam final : public QNetworkAccessManager {
+public:
+    struct Response {
+        QByteArray body;
+        QNetworkReply::NetworkError error = QNetworkReply::NoError;
+        int delayMs = 0;
+    };
+
+    QList<QNetworkRequest> requests;
+    QList<Response> responses;
+
+protected:
+    QNetworkReply* createRequest(Operation operation, const QNetworkRequest& request,
+                                 QIODevice* outgoingData) override
+    {
+        Q_UNUSED(operation);
+        Q_UNUSED(outgoingData);
+        requests.append(request);
+        Q_ASSERT(!responses.isEmpty());
+        const Response response = responses.takeFirst();
+        return new ScriptedReply(request, response.body, response.error, response.delayMs, this);
+    }
+};
+
+class FakeHdsScale final : public ScaleDevice {
+public:
+    explicit FakeHdsScale(QString version)
+        : m_version(std::move(version))
+    {
+    }
+
+    void connectToDevice(const QBluetoothDeviceInfo&) override {}
+    void tare() override {}
+    QString name() const override { return QStringLiteral("Half Decent Scale"); }
+    QString firmwareVersion() const override { return m_version; }
+    bool supportsFirmwareUpdate() const override { return true; }
+    void startFirmwareUpdate() override { ++updateRequests; }
+    void setTestConnected(bool connected) { setConnected(connected); }
+
+    int updateRequests = 0;
+
+private:
+    QString m_version;
+};
+
+} // namespace
+
+class tst_HdsFirmwareUpdateController : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    void launchCheckCachesManifestAndFollowsActiveScale();
+    void manifestRequestUsesSharedGithubPolicy();
+    void resumeRefreshesTheCatalog();
+    void cancellationIgnoresTheSupersededReply();
+    void failedRefreshRetainsTheLastKnownCatalog();
+};
+
+void tst_HdsFirmwareUpdateController::launchCheckCachesManifestAndFollowsActiveScale()
+{
+    ScriptedNam nam;
+    nam.responses = {{manifest("3.1.14")}};
+    HdsFirmwareUpdateController controller(&nam);
+    FakeHdsScale scale(QStringLiteral("3.1.13"));
+    scale.setTestConnected(true);
+    controller.setScaleDevice(&scale);
+
+    QTRY_COMPARE(nam.requests.size(), 1);
+    QTRY_VERIFY(controller.updateAvailable());
+    QCOMPARE(controller.availableVersion(), QStringLiteral("3.1.14"));
+
+    FakeHdsScale otherScale(QStringLiteral("3.1.13"));
+    otherScale.setTestConnected(true);
+    controller.setScaleDevice(&otherScale);
+    QCOMPARE(nam.requests.size(), 1); // The parsed manifest is a session cache.
+    QVERIFY(controller.updateAvailable());
+
+    QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Half Decent Scale DISCONNECTED"));
+    otherScale.setTestConnected(false);
+    QVERIFY(!controller.updateAvailable());
+    controller.startUpdate();
+    QCOMPARE(otherScale.updateRequests, 0);
+}
+
+void tst_HdsFirmwareUpdateController::manifestRequestUsesSharedGithubPolicy()
+{
+    ScriptedNam nam;
+    nam.responses = {{manifest("3.1.14")}};
+    HdsFirmwareUpdateController controller(&nam);
+
+    QTRY_COMPARE(nam.requests.size(), 1);
+    const QNetworkRequest request = nam.requests.first();
+    QCOMPARE(request.header(QNetworkRequest::UserAgentHeader).toString(), QStringLiteral("Decenza"));
+    QCOMPARE(request.rawHeader("Accept"), QByteArray("application/vnd.github.v3+json"));
+    QCOMPARE(request.attribute(QNetworkRequest::ConnectionCacheExpiryTimeoutSecondsAttribute).toInt(), 0);
+}
+
+void tst_HdsFirmwareUpdateController::resumeRefreshesTheCatalog()
+{
+    ScriptedNam nam;
+    nam.responses = {{manifest("3.1.14")}, {manifest("3.1.15")}};
+    HdsFirmwareUpdateController controller(&nam);
+    FakeHdsScale scale(QStringLiteral("3.1.13"));
+    scale.setTestConnected(true);
+    controller.setScaleDevice(&scale);
+
+    QTRY_COMPARE(controller.availableVersion(), QStringLiteral("3.1.14"));
+    controller.checkForUpdates();
+    QTRY_COMPARE(nam.requests.size(), 2);
+    QTRY_COMPARE(controller.availableVersion(), QStringLiteral("3.1.15"));
+}
+
+void tst_HdsFirmwareUpdateController::cancellationIgnoresTheSupersededReply()
+{
+    ScriptedNam nam;
+    nam.responses = {{manifest("3.1.14"), QNetworkReply::NoError, 100}, {manifest("3.1.15")}};
+    HdsFirmwareUpdateController controller(&nam);
+    FakeHdsScale scale(QStringLiteral("3.1.13"));
+    scale.setTestConnected(true);
+    controller.setScaleDevice(&scale);
+
+    controller.checkForUpdates();
+    QTRY_COMPARE(nam.requests.size(), 2);
+    QTRY_COMPARE(controller.availableVersion(), QStringLiteral("3.1.15"));
+    QTest::qWait(120);
+    QCOMPARE(controller.availableVersion(), QStringLiteral("3.1.15"));
+}
+
+void tst_HdsFirmwareUpdateController::failedRefreshRetainsTheLastKnownCatalog()
+{
+    ScriptedNam nam;
+    nam.responses = {{manifest("3.1.14")}, {{}, QNetworkReply::HostNotFoundError}};
+    HdsFirmwareUpdateController controller(&nam);
+    FakeHdsScale scale(QStringLiteral("3.1.13"));
+    scale.setTestConnected(true);
+    controller.setScaleDevice(&scale);
+
+    QTRY_VERIFY(controller.updateAvailable());
+    QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Manifest check failed.*"));
+    controller.checkForUpdates();
+    QTRY_COMPARE(nam.requests.size(), 2);
+    QTRY_VERIFY(!controller.checking());
+    QTRY_VERIFY(controller.updateAvailable());
+    QCOMPARE(controller.availableVersion(), QStringLiteral("3.1.14"));
+}
+
+QTEST_GUILESS_MAIN(tst_HdsFirmwareUpdateController)
+#include "tst_hdsfirmwareupdatecontroller.moc"

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -86,6 +86,7 @@ public:
     QBluetoothUuid m_lastWriteService;
 };
 
+
 class tst_ScaleProtocol : public QObject {
     Q_OBJECT
 
@@ -375,6 +376,28 @@ private slots:
             QRegularExpression(".*Firmware version changed mid-connect.*3\\.0\\.9.*3\\.1\\.0.*"));
         scale.onCharacteristicChanged(Scale::Decent::READ, pkt2);
     }
+
+    void hdsBluetoothFirmwareVersionAndUpdateCommand() {
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+        scale.m_characteristicsReady = true;
+
+        QSignalSpy versionSpy(&scale, &ScaleDevice::firmwareVersionChanged);
+        const auto response = buildDecentLedResponse(50, 3, 1, 13);
+        QTest::ignoreMessage(QtDebugMsg, QRegularExpression(".*Battery byte d\\[4\\]=.*"));
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: 3\\.1\\.13 \\(raw 0x03 0x1d\\).*"));
+        scale.onCharacteristicChanged(Scale::Decent::READ, response);
+
+        QCOMPARE(scale.firmwareVersion(), QStringLiteral("3.1.13"));
+        QVERIFY(scale.supportsFirmwareUpdate());
+        QCOMPARE(versionSpy.count(), 1);
+
+        transport->m_writes.clear();
+        scale.startFirmwareUpdate();
+        QCOMPARE(transport->m_writes, QList<QByteArray>{QByteArray::fromHex("031B0000000018")});
+    }
+
 
     // ==========================================
     // DecentScale: error handling

--- a/tests/tst_usbdecentscale.cpp
+++ b/tests/tst_usbdecentscale.cpp
@@ -1,0 +1,47 @@
+#include <QtTest>
+#include <QSignalSpy>
+#include <QRegularExpression>
+
+#include "usb/usbdecentscale.h"
+
+class RecordingUsbDecentScale : public UsbDecentScale {
+public:
+    using UsbDecentScale::UsbDecentScale;
+
+    void setTestConnected(bool connected) { setConnected(connected); }
+    QList<QByteArray> writes;
+
+protected:
+    void writeRaw(const QByteArray& data) override { writes.append(data); }
+};
+
+class tst_UsbDecentScale : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    void hdsFirmwareVersionAndUpdateCommand() {
+        RecordingUsbDecentScale scale;
+        QSignalSpy versionSpy(&scale, &ScaleDevice::firmwareVersionChanged);
+        const QByteArray response = QByteArray::fromHex("030A000032031D");
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: 3\\.1\\.13 \\(raw 0x03 0x1d\\).*"));
+        scale.processPacket(response);
+
+        QCOMPARE(scale.firmwareVersion(), QStringLiteral("3.1.13"));
+        QVERIFY(scale.supportsFirmwareUpdate());
+        QCOMPARE(versionSpy.count(), 1);
+
+        scale.setTestConnected(true);
+        scale.writes.clear();
+        scale.startFirmwareUpdate();
+        QCOMPARE(scale.writes, QList<QByteArray>{QByteArray::fromHex("031B0000000018")});
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Half Decent Scale \\(USB\\) DISCONNECTED"));
+        scale.setTestConnected(false);
+    }
+};
+
+QTEST_GUILESS_MAIN(tst_UsbDecentScale)
+#include "tst_usbdecentscale.moc"


### PR DESCRIPTION
## Summary
- show a conditional HDS firmware update action for the currently selected, connected HDS scale
- read compatible published HDS releases and reuse the shared GitHub release-notes client
- hand the update off to the HDS over Bluetooth or USB while the scale remains responsible for release selection and confirmation

## Verification
- Qt Creator application build passed
- Qt Creator focused HDS/update tests: 3/3 passed
- Qt Creator full test suite: 116/116 passed