### PR TITLE
chore: bump display version to 2.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 2.0.4 LANGUAGES CXX)
+project(Decenza VERSION 2.0.5 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
Bumps `project(Decenza VERSION ...)` for the v2.0.5 pre-release.

Version code (`versioncode.txt`) is untouched — CI bumps it on tag push and commits it back to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)