### PR TITLE
feat(descale): log every descale step boundary and cycle

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -56,6 +56,7 @@
 #define FW_WARN(msg)            DE1_WARN_TAGGED("Firmware", msg)
 #define PHASE_LOG(msg)          DE1_LOG_STDERR_TAGGED("Phase", msg)
 #define WATER_LOG(msg)          DE1_LOG_STDERR_TAGGED("WaterLevel", msg)
+#define DESCALE_LOG(msg)        DE1_LOG_STDERR_TAGGED("Descale", msg)
 #define SHOTSETTINGS_LOG(msg)   DE1_LOG_STDERR_TAGGED("ShotSettings", msg)
 #include <QStringList>
 #include <chrono>
@@ -624,6 +625,58 @@ void DE1Device::parseStateInfo(const QByteArray& data) {
                       .arg(DE1::stateToString(newState))
                       .arg(m_waterLevelMm, 0, 'f', 1)
                       .arg(m_waterLevelMl));
+    }
+
+    // Descale step boundaries. The DE1 exposes no progress percentage and no
+    // expected duration for a descale, so the only way to weight the five steps
+    // (DescaleInit 8 .. DescaleSteam 12) is to measure them. Each boundary carries
+    // the time in that step and the time since the descale began, which is what a
+    // weight table is derived from; water level is carried too because the group
+    // steps consume tank water and the steam step does not, so it separates them
+    // when a boundary is missed.
+    if (newState == DE1::State::Descale) {
+        if (stateChanged) {
+            m_descaleTimer.start();
+            m_descaleStepStartMs = 0;
+            m_descaleCycle = 1;
+            DESCALE_LOG(QStringLiteral("start: cycle 1 %1 (water %2 ml)")
+                            .arg(DE1::subStateToString(newSubState))
+                            .arg(m_waterLevelMl));
+        } else if (subStateChanged && m_descaleTimer.isValid()) {
+            const qint64 nowMs = m_descaleTimer.elapsed();
+            // A step number that does not increase means the firmware went back to an
+            // earlier step, i.e. started another cycle. DescaleInit is not re-entered,
+            // so the wrap is typically DescaleSteam back to DescaleFillGroup.
+            const uint8_t from = static_cast<uint8_t>(m_subState);
+            const uint8_t to = static_cast<uint8_t>(newSubState);
+            const bool bothDescaleSteps = from >= static_cast<uint8_t>(DE1::SubState::DescaleInit)
+                                          && from <= static_cast<uint8_t>(DE1::SubState::DescaleSteam)
+                                          && to >= static_cast<uint8_t>(DE1::SubState::DescaleInit)
+                                          && to <= static_cast<uint8_t>(DE1::SubState::DescaleSteam);
+            // Only a step-to-step move counts. The machine drops to Ready between the
+            // last cycle and leaving Descale, and that is an ending, not a restart.
+            const bool wrapped = bothDescaleSteps && to <= from;
+            if (wrapped) {
+                ++m_descaleCycle;
+            }
+            DESCALE_LOG(QStringLiteral("cycle %1 %2 → %3 after %4 s (t=%5 s, water %6 ml)%7")
+                            .arg(m_descaleCycle)
+                            .arg(DE1::subStateToString(m_subState))
+                            .arg(DE1::subStateToString(newSubState))
+                            .arg((nowMs - m_descaleStepStartMs) / 1000.0, 0, 'f', 1)
+                            .arg(nowMs / 1000.0, 0, 'f', 1)
+                            .arg(m_waterLevelMl)
+                            .arg(wrapped ? QStringLiteral(" [new cycle]") : QString()));
+            m_descaleStepStartMs = nowMs;
+        }
+    } else if (stateChanged && m_state == DE1::State::Descale && m_descaleTimer.isValid()) {
+        DESCALE_LOG(QStringLiteral("end: %1 cycles, last step %2 after %3 s, total %4 s (water %5 ml)")
+                        .arg(m_descaleCycle)
+                        .arg(DE1::subStateToString(m_subState))
+                        .arg((m_descaleTimer.elapsed() - m_descaleStepStartMs) / 1000.0, 0, 'f', 1)
+                        .arg(m_descaleTimer.elapsed() / 1000.0, 0, 'f', 1)
+                        .arg(m_waterLevelMl));
+        m_descaleTimer.invalidate();
     }
 
     m_state = newState;

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -10,6 +10,7 @@
 #include <QEvent>
 #include <QHash>
 #include <QList>
+#include <QElapsedTimer>
 #include <QString>
 #include <QTimer>
 
@@ -445,6 +446,20 @@ private:
 
     DE1::State m_state = DE1::State::Sleep;
     DE1::SubState m_subState = DE1::SubState::Ready;
+
+    // Descale step timing. The firmware reports no progress figure and no expected
+    // duration, so the descale page's progress bar has to be built from measured
+    // step weights — and the substates it would weight (DescaleInit .. DescaleSteam)
+    // were never logged, so no submitted log contained a single step boundary.
+    // Started when the machine enters Descale, read at each substate change.
+    QElapsedTimer m_descaleTimer;
+    qint64 m_descaleStepStartMs = 0;
+    // Firmware runs the five steps more than once per descale, so a step alone does
+    // not say how far along the machine is — the same "Descaling steam system" is
+    // both a third of the way in and nearly done. Counted from the substate walking
+    // BACKWARD (DescaleSteam back to a group step), which is the only signal the
+    // firmware gives that a cycle restarted.
+    int m_descaleCycle = 0;
     double m_pressure = 0.0;
     double m_flow = 0.0;
     double m_mixTemp = 0.0;


### PR DESCRIPTION
## Why

The descale page's progress bar is computed from the substate's rank in the 5-step sequence:

```qml
return (subState - 8 + 1) / 5  // Steps 8-12 = 20%, 40%, 60%, 80%, 100%
```
([`DescalingPage.qml:67`](https://github.com/Kulitorum/Decenza/blob/main/qml/pages/DescalingPage.qml#L67))

`DescaleSteam` (substate 12) is both the last step and by far the longest, so the bar reads 100% from the moment that step begins and stays there for the rest of the run. Observed on a real descale: 100% at t=463 s of a 720 s run, with roughly four minutes still to go. The steps are also not equal in length, so the 20%-per-step assumption is wrong before the last one too, and the substate is not monotonic — the firmware repeats the sequence, which would make the bar jump backward.

Fixing that needs measured step weights, and the logs cannot supply them: substate transitions are never logged during a descale. The only `subState` logging in the app belongs to `SteamPage`, which is not alive on the descale page. The entire log ring buffer (8 sessions) held one descale run, from which only the total duration and a coarse inference from water-level refill events could be recovered.

## What

Adds a `[DE1][Descale]` line at each step boundary in `parseStateInfo()`, carrying the time spent in the step just finished, the time since the descale began, the cycle number, and the water level:

```
[DE1][Descale] start: cycle 1 DescaleInit (water 648 ml)
[DE1][Descale] cycle 1 DescaleGroup → DescaleSteam after 57.2 s (t=302.4 s, water 481 ml)
[DE1][Descale] cycle 2 DescaleSteam → DescaleFillGroup after 417.1 s (t=719.5 s, water 398 ml) [new cycle]
[DE1][Descale] end: 2 cycles, last step DescaleSteam after 39.1 s, total 720.1 s (water 426 ml)
```

The firmware runs the five steps more than once per descale, so the step alone does not locate the machine in the run — the same "Descaling steam system" is both a third of the way in and nearly done. Cycles are counted from the substate walking backward, which is the only restart signal the firmware gives. A drop to `Ready` before leaving `Descale` is excluded, so an ending is not miscounted as a new cycle.

Water level is carried on every line because the group steps consume tank water and the steam step does not, which separates them if a boundary is ever missed.

DEBUG tier, matching the adjacent `[DE1][Phase]` line — this is state-machine detail for deriving a weight table, not user-facing narrative.

## Scope

No behaviour change. This is the instrumentation only; the progress-bar fix and the richer descale UI (step N of 5, cycle N, honest estimate) follow once a couple of real runs have been captured.

## Testing

- Local build green (Qt Creator, macOS Debug).
- `scripts/check_log_markers.py` passes.
- Verification is a real descale on the machine — the log lines are the deliverable, and they will be read back over `debug_get_log` after the next runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)