### PR TITLE
feat(descale): real progress from the firmware schedule, and fix cold starts

### DIFF
--- a/qml/pages/DescalingPage.qml
+++ b/qml/pages/DescalingPage.qml
@@ -60,11 +60,20 @@ T.Page {
         }
     }
 
-    // Get progress percentage based on substate (8-12 = 5 steps)
-    function getDescaleProgress(subState) {
-        if (subState < 8) return 0
-        if (subState > 12) return 1
-        return (subState - 8 + 1) / 5  // Steps 8-12 = 20%, 40%, 60%, 80%, 100%
+    // Progress comes from DE1Device, which derives it from the firmware's fixed step
+    // schedule and resyncs at every substate boundary. It used to be computed here as
+    // the substate's RANK — (subState - 8 + 1) / 5 — which read 100% from the moment
+    // the final step began and stayed there for its whole 420 s: seven minutes of a
+    // twelve-minute descale spent claiming the machine was finished.
+
+    function formatRemaining(seconds) {
+        if (seconds <= 0) return ""
+        var mins = Math.floor(seconds / 60)
+        var secs = seconds % 60
+        return mins > 0
+            ? TranslationManager.translate("descaling.remaining.minutes", "%1 min %2 s left")
+                  .arg(mins).arg(secs)
+            : TranslationManager.translate("descaling.remaining.seconds", "%1 s left").arg(secs)
     }
 
     ScrollView {
@@ -128,7 +137,7 @@ T.Page {
                                 Accessible.ignored: true
 
                                 Rectangle {
-                                    width: parent.width * descalingPage.getDescaleProgress(DE1Device.subState)
+                                    width: parent.width * DE1Device.descaleProgress
                                     height: parent.height
                                     radius: Theme.scaled(6)
                                     color: Theme.primaryColor
@@ -139,7 +148,16 @@ T.Page {
 
                             Text {
                                 Layout.alignment: Qt.AlignHCenter
-                                text: Math.round(descalingPage.getDescaleProgress(DE1Device.subState) * 100) + "%"
+                                text: {
+                                    var pct = Math.round(DE1Device.descaleProgress * 100) + "%"
+                                    if (DE1Device.descaleStepIndex <= 0) return pct
+                                    var step = TranslationManager.translate("descaling.stepOf", "Step %1 of %2")
+                                                   .arg(DE1Device.descaleStepIndex)
+                                                   .arg(DE1Device.descaleStepCount)
+                                    var remaining = descalingPage.formatRemaining(DE1Device.descaleSecondsRemaining)
+                                    return remaining !== "" ? pct + " · " + step + " · " + remaining
+                                                            : pct + " · " + step
+                                }
                                 font: Theme.captionFont
                                 color: Theme.textSecondaryColor
                             }
@@ -356,7 +374,10 @@ T.Page {
                     }
                 }
 
-                // Cycle counter
+                // Cycle counter. This counts how many times the PAGE saw the machine enter
+                // Descale, i.e. how many times "Run Again" was used — not the firmware's
+                // own repeats within one run, which are DE1Device.descaleCycle. Two
+                // different numbers, both real; this line means the first.
                 Text {
                     Layout.alignment: Qt.AlignHCenter
                     text: TranslationManager.translate("descaling.cycleCount", "Cycle %1 complete").arg(descalingPage.descaleCycleCount)

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -15,6 +15,7 @@
 #include <QBluetoothAddress>
 #include <QDateTime>
 #include <cmath>
+#include <iterator>
 #include <QDebug>
 
 // Alias the shared DE1 helpers (src/ble/de1logging.h) — never copy a body.
@@ -604,6 +605,64 @@ void DE1Device::disconnect() {
     emit guiEnabledChanged();
 }
 
+namespace {
+
+// The DE1 runs each descale step for a FIXED time. Measured on firmware 1358 over
+// two full descales, which agreed to the tenth of a second (720.1 s and 720.2 s
+// total), with each step landing on a round number:
+//
+//     DescaleInit       30 s     DescaleGroup   120 s
+//     DescaleFillGroup  30 s     DescaleSteam   420 s
+//     DescaleReturn    120 s     ------------------------
+//                               total          720 s
+//
+// So descale progress is not an estimate — it is a schedule, and the substate
+// boundary resyncs it. Water hardness and tank temperature do not change these
+// numbers; the two runs were on different days from different starting levels.
+//
+// If a machine ever disagrees, the boundaries are logged ([DE1][Descale]) on every
+// run, so a submitted log says so directly rather than requiring a repro.
+struct DescaleStep {
+    DE1::SubState subState;
+    int seconds;
+};
+constexpr DescaleStep kDescaleSchedule[] = {
+    {DE1::SubState::DescaleInit,      30},
+    {DE1::SubState::DescaleFillGroup, 30},
+    {DE1::SubState::DescaleReturn,   120},
+    {DE1::SubState::DescaleGroup,    120},
+    {DE1::SubState::DescaleSteam,    420},
+};
+constexpr int kDescaleStepCount = static_cast<int>(std::size(kDescaleSchedule));
+
+// Seconds of the schedule completed before the step at `index` (0-based) begins.
+constexpr int descaleSecondsBefore(int index) {
+    int total = 0;
+    for (int i = 0; i < index && i < kDescaleStepCount; ++i) {
+        total += kDescaleSchedule[i].seconds;
+    }
+    return total;
+}
+constexpr int kDescaleTotalSeconds = descaleSecondsBefore(kDescaleStepCount);
+
+// 0-based position of a substate in the schedule, or -1 if it is not a descale step.
+int descaleStepPosition(DE1::SubState subState) {
+    for (int i = 0; i < kDescaleStepCount; ++i) {
+        if (kDescaleSchedule[i].subState == subState) return i;
+    }
+    return -1;
+}
+
+// First firmware build that honours a cold maintenance request (descale / clean /
+// air purge) on a machine with a GHC. Below it the firmware silently DROPS the
+// request while the machine is still heating, so the button appears to do nothing.
+// Matches Decaid's _kColdMaintenancePromotionMinFwBuild and de1app's onestep_cold
+// workaround (machine.tcl:702-706, "the first (cold) Descale request is sometimes
+// refused").
+constexpr int kColdMaintenanceMinFirmwareBuild = 1356;
+
+}  // namespace
+
 // -- Parse methods --
 
 void DE1Device::parseStateInfo(const QByteArray& data) {
@@ -639,6 +698,12 @@ void DE1Device::parseStateInfo(const QByteArray& data) {
             m_descaleTimer.start();
             m_descaleStepStartMs = 0;
             m_descaleCycle = 1;
+            if (!m_descaleTicker) {
+                m_descaleTicker = new QTimer(this);
+                m_descaleTicker->setInterval(1000);
+                connect(m_descaleTicker, &QTimer::timeout, this, &DE1Device::updateDescaleProgress);
+            }
+            m_descaleTicker->start();
             DESCALE_LOG(QStringLiteral("start: cycle 1 %1 (water %2 ml)")
                             .arg(DE1::subStateToString(newSubState))
                             .arg(m_waterLevelMl));
@@ -670,6 +735,7 @@ void DE1Device::parseStateInfo(const QByteArray& data) {
             m_descaleStepStartMs = nowMs;
         }
     } else if (stateChanged && m_state == DE1::State::Descale && m_descaleTimer.isValid()) {
+        if (m_descaleTicker) m_descaleTicker->stop();
         DESCALE_LOG(QStringLiteral("end: %1 cycles, last step %2 after %3 s, total %4 s (water %5 ml)")
                         .arg(m_descaleCycle)
                         .arg(DE1::subStateToString(m_subState))
@@ -682,11 +748,60 @@ void DE1Device::parseStateInfo(const QByteArray& data) {
     m_state = newState;
     m_subState = newSubState;
 
+    // After the new substate is committed, so the progress reflects the step the
+    // machine is in now rather than the one it just left.
+    if (stateChanged || subStateChanged) {
+        updateDescaleProgress();
+    }
+
+    // A maintenance request held back because the machine was cold goes out as soon
+    // as the machine reports it is no longer heating.
+    if (m_pendingMaintenanceState != DE1::State::NoRequest && (stateChanged || subStateChanged)) {
+        flushPendingMaintenanceState();
+    }
+
     if (stateChanged) {
         emit this->stateChanged();
     }
     if (subStateChanged) {
         emit this->subStateChanged();
+    }
+}
+
+int DE1Device::descaleStepCount() const {
+    return kDescaleStepCount;
+}
+
+void DE1Device::updateDescaleProgress() {
+    const double oldProgress = m_descaleProgress;
+    const int oldStep = m_descaleStepIndex;
+    const int oldRemaining = m_descaleSecondsRemaining;
+
+    const int position = (m_state == DE1::State::Descale) ? descaleStepPosition(m_subState) : -1;
+    if (position < 0 || !m_descaleTimer.isValid()) {
+        // Not in a descale step: Descale/Ready at the very start or the very end, or
+        // not descaling at all. Report no progress rather than a stale figure.
+        m_descaleProgress = 0.0;
+        m_descaleStepIndex = 0;
+        m_descaleSecondsRemaining = 0;
+    } else {
+        const double stepElapsed =
+            qBound(0.0,
+                   (m_descaleTimer.elapsed() - m_descaleStepStartMs) / 1000.0,
+                   static_cast<double>(kDescaleSchedule[position].seconds));
+        const double done = descaleSecondsBefore(position) + stepElapsed;
+        // Never reaches 1.0 from the schedule alone. The bar reads 100% only when
+        // the machine actually leaves Descale, which is the whole defect this
+        // replaces: the old bar showed 100% for the 420 s of the final step.
+        m_descaleProgress = qBound(0.0, done / kDescaleTotalSeconds, 0.999);
+        m_descaleStepIndex = position + 1;
+        m_descaleSecondsRemaining = qMax(0, qRound(kDescaleTotalSeconds - done));
+    }
+
+    if (!qFuzzyCompare(oldProgress + 1.0, m_descaleProgress + 1.0)
+        || oldStep != m_descaleStepIndex
+        || oldRemaining != m_descaleSecondsRemaining) {
+        emit descaleProgressChanged();
     }
 }
 
@@ -1239,15 +1354,103 @@ void DE1Device::startFlush() {
 }
 
 void DE1Device::startDescale() {
-    requestState(DE1::State::Descale);
+    requestMaintenanceState(DE1::State::Descale);
 }
 
 void DE1Device::startClean() {
-    requestState(DE1::State::Clean);
+    requestMaintenanceState(DE1::State::Clean);
+}
+
+// Descale, Clean and AirPurge share one failure: on a GHC machine running firmware
+// below 1356, the firmware DROPS the request while the machine is still heating. The
+// button does nothing, reports nothing, and the user is left tapping it. Route all
+// three through here so the workaround cannot be added to one and forgotten on the
+// others — which is how it stood: three identical one-line bodies, none of them
+// handling it.
+void DE1Device::requestMaintenanceState(DE1::State state) {
+    if (applyColdMaintenanceWorkaround(state)) {
+        return;  // Deferred; goes out when the machine reports it has left preheat.
+    }
+    requestState(state);
+}
+
+// True while the machine is still coming up to temperature — the window in which old
+// firmware discards a maintenance request. Substate carries this during Heating; the
+// Espresso-preheat substate is included because the machine reports it from Idle too.
+bool DE1Device::isMachineHeating() const {
+    return m_state == DE1::State::Busy
+           || m_subState == DE1::SubState::Heating
+           || m_subState == DE1::SubState::FinalHeating
+           || m_subState == DE1::SubState::Stabilising;
+}
+
+// Returns true when the request was DEFERRED. Mirrors de1app's onestep_cold
+// (machine.tcl:702-706) and Decaid's _prepareColdMaintenanceWorkaround: load a
+// profile whose group target is 1°C and whose tank target is 0, which makes the
+// machine stop preheating, then send the state once it has.
+//
+// de1app and Decaid both then wait a fixed second. We wait for the machine to SAY it
+// left preheat instead — same intent, no timer, and a slow machine is not raced.
+bool DE1Device::applyColdMaintenanceWorkaround(DE1::State state) {
+    // firmwareBuildNumber() is 0 until the MMR identity read returns (MMR::FIRMWARE_VERSION
+    // in parseMMRRead) — a few seconds after connect, or never on a machine whose MMR reads
+    // fail. Unknown counts as OLD, matching Decaid and de1app.
+    //
+    // Not a coin flip: a machine new enough to honour a cold maintenance request is new
+    // enough to REPORT its build, so a missing build number is itself evidence of an old
+    // or unhealthy machine. Applying the workaround is the safe direction.
+    //
+    // The costs agree. Assuming new when the machine is old drops the request silently —
+    // the button does nothing, with no error, which is the defect this function exists to
+    // remove. Assuming old when the machine is new uploads a throwaway 1C profile and waits
+    // for preheat to end; the descale still runs, and DescalingPage re-uploads the real
+    // profile on exit.
+    const int build = firmwareBuildNumber();
+    const bool firmwareDropsColdRequests = build < kColdMaintenanceMinFirmwareBuild;
+    const bool ghcPresent = !isHeadless();
+    if (!firmwareDropsColdRequests || !ghcPresent || !isMachineHeating()) {
+        return false;
+    }
+
+    DEVICE_INFO(QStringLiteral("Cold maintenance (%1) on GHC machine, firmware build %2 < %3: "
+                               "loading 1C profile and deferring the request until preheat ends")
+                    .arg(DE1::stateToString(state))
+                    .arg(build == 0 ? QStringLiteral("unknown") : QString::number(build))
+                    .arg(kColdMaintenanceMinFirmwareBuild));
+
+    Profile coldProfile;
+    coldProfile.setTitle(QStringLiteral("Decenza cold maintenance"));
+    coldProfile.setEspressoTemperature(1.0);
+    coldProfile.setTankDesiredWaterTemperature(0.0);
+    ProfileFrame frame;
+    frame.name = QStringLiteral("cold");
+    frame.temperature = 1.0;
+    frame.pump = QStringLiteral("flow");
+    frame.flow = 0.0;
+    frame.seconds = 1.0;
+    coldProfile.setSteps({frame});
+    uploadProfile(coldProfile);
+
+    m_pendingMaintenanceState = state;
+    return true;
+}
+
+// The deferred half of applyColdMaintenanceWorkaround. Called from parseStateInfo on
+// every state/substate change, so the request goes out on the first packet showing
+// the machine is no longer heating.
+void DE1Device::flushPendingMaintenanceState() {
+    if (m_pendingMaintenanceState == DE1::State::NoRequest || isMachineHeating()) {
+        return;
+    }
+    const DE1::State pending = m_pendingMaintenanceState;
+    m_pendingMaintenanceState = DE1::State::NoRequest;
+    DEVICE_INFO(QStringLiteral("Machine left preheat — sending deferred %1 request")
+                    .arg(DE1::stateToString(pending)));
+    requestState(pending);
 }
 
 void DE1Device::startAirPurge() {
-    requestState(DE1::State::AirPurge);
+    requestMaintenanceState(DE1::State::AirPurge);
 }
 
 void DE1Device::stopOperation() {

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -91,6 +91,14 @@ class DE1Device : public QObject {
     Q_PROPERTY(bool usbChargerOn READ usbChargerOn NOTIFY usbChargerOnChanged)
     Q_PROPERTY(bool isHeadless READ isHeadless NOTIFY isHeadlessChanged)
     Q_PROPERTY(int refillKitDetected READ refillKitDetected NOTIFY refillKitDetectedChanged)
+    // Descale progress. The DE1 reports no percentage and no expected duration, so
+    // these are derived from the firmware's fixed step schedule (see kDescaleSchedule
+    // in the .cpp) resynced at every substate boundary. 0/absent when not descaling.
+    Q_PROPERTY(double descaleProgress READ descaleProgress NOTIFY descaleProgressChanged)
+    Q_PROPERTY(int descaleStepIndex READ descaleStepIndex NOTIFY descaleProgressChanged)
+    Q_PROPERTY(int descaleStepCount READ descaleStepCount CONSTANT)
+    Q_PROPERTY(int descaleSecondsRemaining READ descaleSecondsRemaining NOTIFY descaleProgressChanged)
+    Q_PROPERTY(int descaleCycle READ descaleCycle NOTIFY descaleProgressChanged)
     Q_PROPERTY(QString connectionType READ connectionType NOTIFY connectedChanged)
     Q_PROPERTY(int machineModel READ machineModel NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int heaterVoltage READ heaterVoltage NOTIFY heaterVoltageChanged)
@@ -138,6 +146,12 @@ public:
     QString firmwareVersion() const { return m_firmwareVersion; }
     bool usbChargerOn() const { return m_usbChargerOn; }
     bool isHeadless() const { return m_isHeadless; }
+
+    double descaleProgress() const { return m_descaleProgress; }
+    int descaleStepIndex() const { return m_descaleStepIndex; }
+    int descaleStepCount() const;
+    int descaleSecondsRemaining() const { return m_descaleSecondsRemaining; }
+    int descaleCycle() const { return m_descaleCycle; }
     Q_INVOKABLE void setIsHeadless(bool headless);  // Debug toggle
     int refillKitDetected() const { return m_refillKitDetected; }  // -1=unknown, 0=not detected, 1=detected
     int machineModel() const { return m_machineModel; }  // 0=unknown, 1=DE1, 2=DE1+, 3=PRO, 4=XL, 5=CAFE, 6=XXL, 7=XXXL
@@ -338,6 +352,10 @@ signals:
     void usbChargerOnChanged();
     void isHeadlessChanged();
     void refillKitDetectedChanged();
+    // One signal for every descale progress property — they are all recomputed
+    // together from the same tick, so separate notifies would only fan out the
+    // same instant to four bindings.
+    void descaleProgressChanged();
     void heaterVoltageChanged();
 
     // Firmware-update response from the DE1 (A009 notification). Carries
@@ -440,6 +458,16 @@ private:
     // leaves the previous profile's preheat active.
     void writeTankPreheatForProfile(const Profile& profile);
 
+    // Descale progress, recomputed from the fixed step schedule plus the elapsed
+    // time in the current step. Emits descaleProgressChanged() when a value moved.
+    void updateDescaleProgress();
+    // Maintenance states (descale/clean/air purge) that the machine refused while
+    // cold, deferred until it reports that it has left preheat. See requestMaintenanceState().
+    void requestMaintenanceState(DE1::State state);
+    bool applyColdMaintenanceWorkaround(DE1::State state);
+    bool isMachineHeating() const;
+    void flushPendingMaintenanceState();
+
     // Owned when created internally via connectToDevice(); set externally via setTransport() for USB
     DE1Transport* m_transport = nullptr;
     bool m_ownsTransport = false;  // True when DE1Device created the transport (connectToDevice)
@@ -454,12 +482,25 @@ private:
     // Started when the machine enters Descale, read at each substate change.
     QElapsedTimer m_descaleTimer;
     qint64 m_descaleStepStartMs = 0;
+    // Recomputes the progress properties once a second so the bar and the
+    // remaining-time readout advance between substate boundaries, which can be
+    // seven minutes apart. Periodic UI refresh, not a guard.
+    QTimer* m_descaleTicker = nullptr;
+    double m_descaleProgress = 0.0;
+    int m_descaleStepIndex = 0;
+    int m_descaleSecondsRemaining = 0;
     // Firmware runs the five steps more than once per descale, so a step alone does
     // not say how far along the machine is — the same "Descaling steam system" is
     // both a third of the way in and nearly done. Counted from the substate walking
     // BACKWARD (DescaleSteam back to a group step), which is the only signal the
     // firmware gives that a cycle restarted.
     int m_descaleCycle = 0;
+
+    // Set when a maintenance request was held back because the machine was cold on
+    // firmware that drops those requests (see applyColdMaintenanceWorkaround). Cleared
+    // by the state packet that shows the machine has left preheat — an event, not a
+    // timer, so a slow machine waits as long as it needs to.
+    DE1::State m_pendingMaintenanceState = DE1::State::NoRequest;
     double m_pressure = 0.0;
     double m_flow = 0.0;
     double m_mixTemp = 0.0;


### PR DESCRIPTION
Follow-up to #1874, which added the instrumentation this is built on.

## 1. The progress bar showed 100% for the last seven minutes of every descale

It was the substate's rank in the 5-step sequence:

```qml
return (subState - 8 + 1) / 5  // Steps 8-12 = 20%, 40%, 60%, 80%, 100%
```

`DescaleSteam` is both the last step and by far the longest, so the bar read 100% from the moment that step began — more than half of a twelve-minute descale spent telling the user the machine had finished. Observed at t=463 s of a 720 s run with four minutes still to go.

The #1874 logging shows the DE1 runs each step for a **fixed** time. Two full descales agreed to the tenth of a second (720.1 s and 720.2 s), every step a round number:

| Step | Duration | Share | Progress at end |
|---|---|---|---|
| DescaleInit | 30 s | 4.2% | 4.2% |
| DescaleFillGroup | 30 s | 4.2% | 8.3% |
| DescaleReturn | 120 s | 16.7% | 25.0% |
| DescaleGroup | 120 s | 16.7% | 41.7% |
| DescaleSteam | 420 s | 58.3% | 100% |

So progress is a schedule, not an estimate. `DE1Device` now exposes `descaleProgress`, `descaleStepIndex`, `descaleSecondsRemaining` and `descaleCycle`, derived from that table and resynced at every substate boundary, with a 1 Hz tick so the bar moves between boundaries that can be seven minutes apart. Capped below 1.0, so 100% means the machine actually left Descale.

The page now reads `42% · Step 4 of 5 · 7 min 0 s left`.

If a machine ever disagrees with the schedule, #1874 logs every boundary on every run, so a submitted log says so directly rather than needing a repro.

## 2. Descale, clean and air purge did nothing on a cold GHC machine

Firmware below build 1356 silently drops those requests while the machine is still heating. The button does nothing, reports nothing, and the user keeps tapping it. Decaid handles this (`_prepareColdMaintenanceWorkaround`), de1app handles it (`machine.tcl:702-706` — "the first (cold) Descale request is sometimes refused"), Decenza did not.

`startDescale()`, `startClean()` and `startAirPurge()` were three identical one-line bodies, so the fix lives in one `requestMaintenanceState()` all three route through, rather than in whichever one someone remembers to patch.

The workaround loads a profile with a 1 °C group target and 0 °C tank target so the machine leaves preheat, then sends the state. de1app and Decaid then wait a fixed second; this waits for the machine to **report** it left preheat instead — an event, not a timer, per the project's no-timers-as-guards rule, so a slow machine is not raced.

**An unreported firmware build counts as old.** A machine new enough to honour a cold maintenance request is new enough to report its build, so a missing build number is itself evidence. The costs agree: assuming new when the machine is old reproduces the silent drop; assuming old when the machine is new uploads a throwaway profile and waits for preheat, after which the descale still runs and the page re-uploads the real profile on exit.

## Testing

- Local build green; full suite **116 passed, 0 failed**.
- `scripts/check_log_markers.py` passes.
- **The QML page is unverified** — no QML test harness, and the progress readout needs eyes on a real descale.
- The cold-start path cannot be exercised here: this machine is on build 1358, above the threshold. It needs an old-firmware GHC machine, or a deliberate cold start on one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)