### PR TITLE
fix(descale): take focus so the key handler runs, and tidy a log line

### DIFF
--- a/qml/pages/DescalingPage.qml
+++ b/qml/pages/DescalingPage.qml
@@ -76,7 +76,13 @@ T.Page {
         MainController.endDescaleHeaterHold()
     }
 
+    // focus: true alone is not enough — it marks the page as WANTING focus within its scope,
+    // and without the grab the key never reaches this handler (nor the StackView's, which is
+    // why Escape did nothing at all on macOS rather than popping the page). EspressoPage
+    // pairs the two the same way.
     focus: true
+    StackView.onActivated: descalingPage.forceActiveFocus()
+
     Keys.onReleased: function(event) {
         if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
             event.accepted = true

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -3849,9 +3849,11 @@ void MainController::endDescaleHeaterHold() {
     // restored, "Heater off", Keep warm when idle and Let the recipe decide each decide
     // exactly what they decided before the descale, because the hold never touched them.
     m_settings->brew()->setSteamDisabled(m_descaleHeaterHoldPrevSteamDisabled);
-    // One string rather than streamed fragments: qDebug() puts a space between arguments, so
-    // `<< ")"` rendered as "restored to false )".
-    qDebug() << QStringLiteral("Descale heater hold released (steamDisabled restored to %1)")
+    // One string rather than streamed fragments, because qDebug() puts a space between
+    // arguments and `<< ")"` rendered as "restored to false )". noquote() because it then
+    // wraps a QString in quotes, which is the other half of the same papercut.
+    qDebug().noquote()
+             << QStringLiteral("Descale heater hold released (steamDisabled restored to %1)")
                     .arg(m_descaleHeaterHoldPrevSteamDisabled ? QStringLiteral("true")
                                                               : QStringLiteral("false"));
 }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -3849,8 +3849,11 @@ void MainController::endDescaleHeaterHold() {
     // restored, "Heater off", Keep warm when idle and Let the recipe decide each decide
     // exactly what they decided before the descale, because the hold never touched them.
     m_settings->brew()->setSteamDisabled(m_descaleHeaterHoldPrevSteamDisabled);
-    qDebug() << "Descale heater hold released (steamDisabled restored to"
-             << m_descaleHeaterHoldPrevSteamDisabled << ")";
+    // One string rather than streamed fragments: qDebug() puts a space between arguments, so
+    // `<< ")"` rendered as "restored to false )".
+    qDebug() << QStringLiteral("Descale heater hold released (steamDisabled restored to %1)")
+                    .arg(m_descaleHeaterHoldPrevSteamDisabled ? QStringLiteral("true")
+                                                              : QStringLiteral("false"));
 }
 
 // An explicit steam request outranks a descale hold: the user has asked for the boiler, so


### PR DESCRIPTION
Follow-up to #1877, from testing it on a real build.

## Escape did nothing at all

Not "popped without releasing the hold" — *nothing*. It neither ran the descale page's own `Keys.onReleased` nor fell through to the StackView's global handler in `main.qml`, which would have popped the page.

Cause: the page declared `focus: true` but never took active focus. `focus` only marks an item as *wanting* focus within its scope; without a grab, the key never reaches the handler. `EspressoPage` pairs the two:

```qml
focus: true
StackView.onActivated: espressoPage.forceActiveFocus()
```

This does the same.

**Why it matters past the desktop:** that handler exists to intercept Android's hardware back button — the primary platform's main navigation gesture, and the likeliest way anyone leaves this page. Without the grab, the press reaches `main.qml`'s global handler, which pops the page without calling `endDescaleHeaterHold()`. That is precisely the leak the handler was added to close in #1877, so the fix shipped inert on the platform it was written for.

## Evidence

From the running build's log, entering the page, pressing Escape, and re-entering:

```
[  23.149] Descale heater hold asserted (restoring steamDisabled = false on release)
[ 144.988] Descale heater hold released (steamDisabled restored to false )   <- on-screen back
[ 219.848] Descale heater hold asserted (restoring steamDisabled = false on release)
```

The third line is the re-entry. No release between it and the Escape press.

That same log also confirms the rest of #1877 works: the hold asserts on open and releases on the on-screen back button, restoring `steamDisabled` to what it was.

## Also

The release log line streamed its closing paren as a separate `qDebug` argument, so it rendered as `restored to false )`. Built as one string now.

## Testing

- Build clean; full suite 116 passed, 0 failed.
- **Still unverified:** whether Escape now works on macOS (it may not reach Qt at all there, which is a separate question from focus), and the Android hardware-back path, which needs the tablet. The "Done" button release also still needs a completed descale to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)