### PR TITLE
Stop wake() re-arming a running watchdog, and count AccessibilityManagers

### DIFF
--- a/scripts/check_log_markers.py
+++ b/scripts/check_log_markers.py
@@ -136,6 +136,14 @@ COVERED_GLOBS = [
     # re-open that hole.
     "src/weather/weathermanager.cpp",
     "src/core/updatechecker.cpp",
+    # Wholly about screen-reader announcements and the TTS engine behind them:
+    # every line is either the route an announcement took or the setup that
+    # decides which routes exist. Covered because "TalkBack says nothing on this
+    # screen" is answered ONLY by these lines, and the file shipped with two
+    # hand-rolled conventions that had already drifted apart — eight "[a11y] "
+    # bare-qInfo lines and six "AccessibilityManager: " ones — so neither a
+    # marker filter nor a single grep returned the whole story.
+    "src/core/accessibilitymanager.cpp",
 ]
 
 # Files that HOST a registered subsystem's lines alongside unrelated code.

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -630,7 +630,22 @@ void DecentScale::wake() {
         // Measured on a tablet: armed at 6.412 by the 500 ms wake, expired at
         // 7.412, and the enable did not reach the radio until 7.690. The
         // warning fired 278 ms before the question was asked.
-        if (!m_watchdogArmPending) startWatchdog();
+        //
+        // Nor while it is ALREADY RUNNING, which is the opposite ordering and
+        // was reachable the moment the enable started dispatching promptly.
+        // startWatchdog() resets m_watchdogRetries and m_watchdogUpdatesSeen, so
+        // a second arm silently restores the whole retry budget and forgets that
+        // weight data had been seen — the next lapse is then timed as a first
+        // sight (kWatchdogFirstTimeoutMs) rather than a stall. Build 3574's log
+        // shows both arms 198 ms apart: the enable issued at 5.040 s and cleared
+        // the pending flag, then the 500 ms wake() re-armed at 5.238 s. Before
+        // the connect burst got quieter the enable landed after both wakes, so
+        // this path never ran.
+        //
+        // This is the rule onNotificationsIssued() already follows for a later
+        // enable — restart the countdown, never reset the counters.
+        const bool watchdogRunning = m_watchdogTimer && m_watchdogTimer->isActive();
+        if (!m_watchdogArmPending && !watchdogRunning) startWatchdog();
     }
 }
 

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -171,6 +171,26 @@ void DecentScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& servi
 
     DECENT_LOG("Characteristics discovered");
     m_characteristicsReady = true;
+
+    // BEFORE setConnected(), which emits connectedChanged() SYNCHRONOUSLY
+    // (scaledevice.cpp) and so hands control to observers while this function is
+    // still mid-way through the connect sequence. One of them re-enters us:
+    // main.cpp's connectedChanged handler calls wake() when scaleLcdRestorePending
+    // is set (the DE1 slept, the link dropped, the scale came back). With the flag
+    // still false at that instant, wake()'s guards both pass and it arms the
+    // watchdog HERE — about 300 ms before the notify-enable is even submitted, and
+    // on a contended radio well over a second before it reaches the dispatcher.
+    // kWatchdogFirstTimeoutMs is 1000 ms, so it expires against a question that
+    // was never asked, logs "no initial weight data", and re-enables — the very
+    // duplicate CCCD write #1885 deleted the 400 ms repeat to avoid. Ten of those
+    // force-disconnect a healthy scale.
+    //
+    // This is the same defect the guard in wake() was written for (arming a
+    // "did weight arrive" clock against something that is not an enable); it just
+    // reaches it by a path the flag was not yet set to cover. Nothing between here
+    // and the wake sequence below reads the flag, so setting it early is free.
+    m_watchdogArmPending = true;
+
     setConnected(true);
 
     // Start periodic heartbeat to keep connection alive
@@ -245,7 +265,9 @@ void DecentScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& servi
     // smaller edit and would have left the same bug reachable: an enable that is
     // still queued when the watchdog was never armed at all (a wake sequence cut
     // short) has nothing to restart.
-    m_watchdogArmPending = true;
+    //
+    // Set at the top of this function rather than here — see the comment beside
+    // it for the re-entrant observer that reaches wake() before this point.
 
     // Heartbeat at 2000ms
     QTimer::singleShot(2000, this, [this]() {
@@ -257,8 +279,8 @@ void DecentScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& servi
 
 // The watchdog is armed BY the enable reaching the radio (onNotificationsIssued),
 // so an enable that fails BEFORE dispatch arms nothing: m_watchdogArmPending stays
-// set, wake()'s own arm is gated on that same flag being clear, and the watchdog
-// never fires — no re-enable, no retry ladder, no disconnect, with the app still
+// set, wake()'s own arm is gated on that same flag being clear (and startWatchdog()
+// declines a second arm besides), and the watchdog never fires — no re-enable, no retry ladder, no disconnect, with the app still
 // believing a scale is connected that will never report a weight. That is the
 // #1519 symptom.
 //
@@ -449,6 +471,27 @@ void DecentScale::enableWeightNotifications(const QString& reason) {
 }
 
 void DecentScale::startWatchdog() {
+    // Already running: leave it entirely alone. This resets m_watchdogRetries and
+    // m_watchdogUpdatesSeen, so a second arm silently restores the whole retry
+    // budget and forgets that weight data had been seen — the next lapse is then
+    // timed as a first sight (kWatchdogFirstTimeoutMs) rather than as a stall.
+    // Build 3574's log shows two arms 198 ms apart: the enable issued at 5.040 s
+    // and cleared the pending flag, then the 500 ms wake() armed again at
+    // 5.238 s. Before #1885 quietened the connect burst the enable landed after
+    // both wakes, so this was unreachable.
+    //
+    // The guard lives HERE rather than at the caller because startWatchdog() has
+    // three callers — wake(), onNotificationsIssued() and
+    // armWatchdogIfEnableNeverIssues() — and only one of them was guarded. That
+    // left the others correct by an invariant nothing asserts. startHeartbeat()
+    // below took the same decision for the same reason.
+    //
+    // Note this is NOT onNotificationsIssued()'s "later enable" rule, which
+    // restarts the countdown while preserving the counters. This restarts
+    // nothing: a wake()'s LCD write carries no information about when weight data
+    // should arrive, so the window already in flight is the correct one to keep.
+    if (m_watchdogTimer && m_watchdogTimer->isActive()) return;
+
     if (!m_watchdogTimer) {
         m_watchdogTimer = new QTimer(this);
         m_watchdogTimer->setSingleShot(true);
@@ -631,21 +674,9 @@ void DecentScale::wake() {
         // 7.412, and the enable did not reach the radio until 7.690. The
         // warning fired 278 ms before the question was asked.
         //
-        // Nor while it is ALREADY RUNNING, which is the opposite ordering and
-        // was reachable the moment the enable started dispatching promptly.
-        // startWatchdog() resets m_watchdogRetries and m_watchdogUpdatesSeen, so
-        // a second arm silently restores the whole retry budget and forgets that
-        // weight data had been seen — the next lapse is then timed as a first
-        // sight (kWatchdogFirstTimeoutMs) rather than a stall. Build 3574's log
-        // shows both arms 198 ms apart: the enable issued at 5.040 s and cleared
-        // the pending flag, then the 500 ms wake() re-armed at 5.238 s. Before
-        // the connect burst got quieter the enable landed after both wakes, so
-        // this path never ran.
-        //
-        // This is the rule onNotificationsIssued() already follows for a later
-        // enable — restart the countdown, never reset the counters.
-        const bool watchdogRunning = m_watchdogTimer && m_watchdogTimer->isActive();
-        if (!m_watchdogArmPending && !watchdogRunning) startWatchdog();
+        // A watchdog already running is declined by startWatchdog() itself, not
+        // by a second condition here — see the guard at the top of it.
+        if (!m_watchdogArmPending) startWatchdog();
     }
 }
 

--- a/src/core/accessibilitylogging.h
+++ b/src/core/accessibilitylogging.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "core/logtags.h"
+
+#include <QDebug>
+#include <QString>
+
+// Shared logging helpers for screen-reader announcements and TTS setup.
+//
+// Every line gets the [Accessibility] marker from the registry (core/logtags.h)
+// plus a tag naming its own source:
+//
+//     [Accessibility][Route] path=platform isActive=true len=42
+//     [Accessibility][Tts] engine ready, locale en_US
+//
+// ---- Why this earns a marker ------------------------------------------
+//
+// "TalkBack says nothing on this screen" and "it speaks everything twice" are
+// the two reports this subsystem generates, and neither is answerable from any
+// other marker. An announcement either reached the platform, went to the app's
+// own TTS, or was dropped — and only these lines say which. The route matters
+// more than any assumption about the reader: #1300's reporter ran TalkMan under
+// TalkBack's class name, so what the code DID is the only reliable evidence.
+//
+// Before this marker the file carried two hand-rolled conventions that had
+// drifted apart — eight "[a11y] …" lines on bare qInfo and six
+// "AccessibilityManager: …" lines on bare qDebug/qWarning/qInfo/qCritical.
+// Neither was a registered marker, so a reader pulling the accessibility story
+// out of a submitted log with a [Accessibility] filter got nothing at all, and
+// a `grep a11y` got only the announcement half without the TTS setup that
+// usually explains it. That is the same split logtags.h records for
+// "[DecentScaleWifi]" and "[MulticastLock]".
+//
+// ---- Choosing a helper --------------------------------------------------
+//
+//   A11Y_LOG_*   qDebug    setup steps, migration detail
+//   A11Y_INFO_*  qInfo     the route an announcement actually took
+//   A11Y_WARN_*  qWarning  an unreadable store, an invariant broken
+//
+// INFO for the routes is deliberate and is the audience rule from LOGGING.md,
+// not a judgement about importance: the connections views default to minLevel
+// INFO, so a route left at DEBUG is absent from the view a user is asked to
+// screenshot — which is precisely the half of a "says nothing" report that
+// carries the answer.
+//
+// The suffix is the other half of the choice and is NOT cosmetic: _TAGGED also
+// emits logMessage and so reaches the in-app view, _STDERR does not. Both are
+// spelled out; there is deliberately no bare A11Y_LOG — see networklogging.h
+// for why an unsuffixed name is a trap across headers.
+
+#define A11Y_LOG_TAGGED(tag, msg) \
+    DECENZA_SUBSYS_LOG(DECENZA_LOG_MARKER_ACCESSIBILITY, tag, msg, qDebug)
+#define A11Y_INFO_TAGGED(tag, msg) \
+    DECENZA_SUBSYS_LOG(DECENZA_LOG_MARKER_ACCESSIBILITY, tag, msg, qInfo)
+#define A11Y_WARN_TAGGED(tag, msg) \
+    DECENZA_SUBSYS_LOG(DECENZA_LOG_MARKER_ACCESSIBILITY, tag, msg, qWarning)
+
+// Stderr-only variants. AccessibilityManager is constructed before anything is
+// wired to its logMessage signal, so setup lines use these.
+#define A11Y_LOG_STDERR(tag, msg) \
+    DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_ACCESSIBILITY, tag, msg, qDebug)
+#define A11Y_INFO_STDERR(tag, msg) \
+    DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_ACCESSIBILITY, tag, msg, qInfo)
+#define A11Y_WARN_STDERR(tag, msg) \
+    DECENZA_SUBSYS_LOG_STDERR(DECENZA_LOG_MARKER_ACCESSIBILITY, tag, msg, qWarning)

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -16,6 +16,7 @@
 #endif
 
 AccessibilityManager *AccessibilityManager::s_qmlInstance = nullptr;
+int AccessibilityManager::s_instanceCount = 0;
 
 void AccessibilityManager::setQmlInstance(AccessibilityManager *instance)
 {
@@ -55,6 +56,32 @@ AccessibilityManager::AccessibilityManager(QObject *parent)
     // third store that broke accessibility backup/restore and survived factory
     // reset. Existing values are carried over by migrateLegacyStore().
 {
+    // Exactly one of these should ever exist, and on build 3574 more than one
+    // did: the 2026-08-30T15:41:41 session logs initTts()'s "Available TTS
+    // engines" at 0.798 s and again at 1.802 s, with no "initTts() called again"
+    // warning between them — so both calls found m_tts null, which one object
+    // cannot do outside shutdown() (not called; its line is absent). "App
+    // started" appears once, so it is not a second process either. The second
+    // construction site is not identified, and this counter is here to name it
+    // rather than to guess at it.
+    //
+    // It is not merely noise. The second instance builds its own QTextToSpeech
+    // — a live Android TTS binding with its own stateChanged handler — while
+    // setQmlInstance() publishes only main.cpp's object, so a screen-reader user
+    // can end up with the locale on one engine and the announcements on the
+    // other, or with both speaking.
+    //
+    // Kept permanently rather than as a probe: it asserts an invariant that
+    // holds today, costs an int, and says nothing at all when the app is well.
+    // That is the difference between this and the #582 diagnostics, which
+    // narrated a healthy startup 14 lines at a time.
+    if (++s_instanceCount > 1) {
+        qWarning() << "AccessibilityManager: instance" << s_instanceCount
+                   << "constructed — the app owns exactly one (main.cpp, published "
+                      "via setQmlInstance). This one builds a second TTS engine that "
+                      "QML will never reach. Backtrace the caller.";
+    }
+
     migrateLegacyStore();
     loadSettings();
     initTts();

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -15,8 +15,10 @@
 #include <QAccessible>
 #endif
 
+#include "core/accessibilitylogging.h"
+
 AccessibilityManager *AccessibilityManager::s_qmlInstance = nullptr;
-int AccessibilityManager::s_instanceCount = 0;
+std::atomic<int> AccessibilityManager::s_instanceCount{0};
 
 void AccessibilityManager::setQmlInstance(AccessibilityManager *instance)
 {
@@ -31,9 +33,9 @@ AccessibilityManager *AccessibilityManager::create(QQmlEngine *qmlEngine, QJSEng
         // Reached only if QML resolves the singleton before main.cpp published the instance.
         // Name the missing call: the symptom otherwise is every accessibility binding in the UI
         // reading as undefined, which looks like an accessibility bug and is not.
-        qCritical("AccessibilityManager: QML asked for the singleton before "
-                  "AccessibilityManager::setQmlInstance() was called. Publish the instance "
-                  "before QQmlEngine::load().");
+        A11Y_WARN_STDERR("Singleton",
+            QStringLiteral("QML asked for the singleton before setQmlInstance() was called. "
+                           "Publish the instance before QQmlEngine::load()."));
         return nullptr;
     }
     // No second-engine guard here, unlike TranslationManager::create() — deliberately, not by
@@ -71,15 +73,27 @@ AccessibilityManager::AccessibilityManager(QObject *parent)
     // can end up with the locale on one engine and the announcements on the
     // other, or with both speaking.
     //
+    // Atomic because the construction site this exists to name is precisely the
+    // one we cannot see, so it cannot be assumed to be on the GUI thread — a
+    // counter that races is a second unreliable witness on top of the bug.
+    //
+    // Never decremented, deliberately: the production object is main.cpp's stack
+    // object and lives for the process, so there is no construct-destroy-construct
+    // path to confuse this with a second live instance. The test-only
+    // TestSkipAudioInit constructor does not increment at all — tests legitimately
+    // build many, and counting them would bury the real signal in permanent noise.
+    //
     // Kept permanently rather than as a probe: it asserts an invariant that
     // holds today, costs an int, and says nothing at all when the app is well.
     // That is the difference between this and the #582 diagnostics, which
     // narrated a healthy startup 14 lines at a time.
-    if (++s_instanceCount > 1) {
-        qWarning() << "AccessibilityManager: instance" << s_instanceCount
-                   << "constructed — the app owns exactly one (main.cpp, published "
-                      "via setQmlInstance). This one builds a second TTS engine that "
-                      "QML will never reach. Backtrace the caller.";
+    const int instanceOrdinal = ++s_instanceCount;
+    if (instanceOrdinal > 1) {
+        A11Y_WARN_STDERR("Lifetime",
+            QStringLiteral("instance %1 constructed — the app owns exactly one (main.cpp, "
+                           "published via setQmlInstance). This one builds a second TTS "
+                           "engine that QML will never reach. Backtrace the caller.")
+                .arg(instanceOrdinal));
     }
 
     migrateLegacyStore();
@@ -117,7 +131,7 @@ void AccessibilityManager::shutdown()
     if (m_shuttingDown) return;
     m_shuttingDown = true;
 
-    qDebug() << "AccessibilityManager shutting down";
+    A11Y_LOG_STDERR("Lifetime", QStringLiteral("shutting down"));
 
     // Disconnect all signals from TTS to prevent callbacks during shutdown
     if (m_tts) {
@@ -222,16 +236,17 @@ void AccessibilityManager::migrateLegacyStore()
     if (r.alreadyDone)
         return;
     if (r.deferredOnError) {
-        qWarning() << "AccessibilityManager: legacy store unreadable —"
-                      " deferring migration, guard NOT set";
+        A11Y_WARN_STDERR("Migration",
+            QStringLiteral("legacy store unreadable — deferring migration, guard NOT set"));
         return;
     }
     // qInfo (not qDebug) + legacy key count so a support log can tell
     // "nothing to migrate" (legacyKeyCount==0) apart from "all already
     // present" (copied==0 && legacyKeyCount>0) — an irreversible
     // one-time migration deserves a durable, unambiguous breadcrumb.
-    qInfo() << "AccessibilityManager: migrated" << r.copied << "of"
-            << r.legacyKeyCount << "legacy accessibility key(s) into the primary store";
+    A11Y_INFO_STDERR("Migration",
+        QStringLiteral("migrated %1 of %2 legacy accessibility key(s) into the primary store")
+            .arg(r.copied).arg(r.legacyKeyCount));
 }
 
 void AccessibilityManager::loadSettings()
@@ -278,21 +293,22 @@ void AccessibilityManager::initTts()
     // and the type is not QML-creatable — so the warning below is here to name
     // the second caller in the next log rather than to assert a cause.
     if (m_tts) {
-        qWarning() << "initTts() called again — TTS is already initialised; "
-                      "ignoring. The first call built the engine and connected "
-                      "its stateChanged handler.";
+        A11Y_WARN_STDERR("Tts",
+            QStringLiteral("initTts() called again — TTS is already initialised; ignoring. "
+                           "The first call built the engine and connected its stateChanged "
+                           "handler."));
         return;
     }
 
     auto engines = QTextToSpeech::availableEngines();
-    qDebug() << "Available TTS engines:" << engines;
+    A11Y_LOG_STDERR("Tts", QStringLiteral("available engines: %1").arg(engines.join(u", ")));
 
     // On Android, use "android" engine which delegates to system TTS settings
     // This respects the user's preferred engine and voice from Android preferences
 #ifdef Q_OS_ANDROID
     if (engines.contains("android")) {
         m_tts = new QTextToSpeech("android", this);
-        qDebug() << "Using Android system TTS";
+        A11Y_LOG_STDERR("Tts", QStringLiteral("using Android system TTS"));
     } else {
         m_tts = new QTextToSpeech(this);
     }
@@ -301,11 +317,11 @@ void AccessibilityManager::initTts()
 #endif
 
     connect(m_tts, &QTextToSpeech::stateChanged, this, [this](QTextToSpeech::State state) {
-        qDebug() << "TTS state changed:" << state;
+        A11Y_LOG_STDERR("Tts", QStringLiteral("state changed: %1").arg(int(state)));
         if (state == QTextToSpeech::Error) {
-            qWarning() << "TTS error:" << m_tts->errorString();
+            A11Y_WARN_STDERR("Tts", QStringLiteral("error: %1").arg(m_tts->errorString()));
         } else if (state == QTextToSpeech::Ready) {
-            qDebug() << "TTS ready";
+            A11Y_LOG_STDERR("Tts", QStringLiteral("ready"));
             // Sync locale with app language
             if (m_translationManager) {
                 onLanguageChanged();
@@ -362,7 +378,8 @@ void AccessibilityManager::setEnabledImpl(bool enabled, bool announce)
     saveSettings();
     emit enabledChanged();
 
-    qDebug() << "Accessibility" << (m_enabled ? "enabled" : "disabled");
+    A11Y_LOG_STDERR("Settings",
+        QStringLiteral("accessibility %1").arg(m_enabled ? u"enabled" : u"disabled"));
 
     if (!announce) return;
 
@@ -490,8 +507,8 @@ void AccessibilityManager::routeAnnouncement(const QString& text, bool interrupt
         // VoiceOver). dispatchPlatformAnnouncement() handles the empty-window
         // null guard internally and logs path=dropped if it can't deliver.
         dispatchPlatformAnnouncement(text, interrupt);
-        qInfo().noquote() << "[a11y] route path=platform isActive=true len=" << text.size()
-                          << " preview=" << preview;
+        A11Y_INFO_STDERR("Route", QStringLiteral("path=platform isActive=true len=%1 preview=%2")
+                                      .arg(text.size()).arg(preview));
         return;
     }
 
@@ -501,13 +518,13 @@ void AccessibilityManager::routeAnnouncement(const QString& text, bool interrupt
         // need it called even when m_tts is intentionally absent (the
         // TestSkipAudioInit ctor leaves it null on purpose).
         dispatchTtsAnnouncement(text, interrupt);
-        qInfo().noquote() << "[a11y] route path=tts isActive=false len=" << text.size()
-                          << " preview=" << preview;
+        A11Y_INFO_STDERR("Route", QStringLiteral("path=tts isActive=false len=%1 preview=%2")
+                                      .arg(text.size()).arg(preview));
         return;
     }
 
-    qInfo().noquote() << "[a11y] route path=silent isActive=false ttsEnabled=" << m_ttsEnabled
-                      << " len=" << text.size();
+    A11Y_INFO_STDERR("Route", QStringLiteral("path=silent isActive=false ttsEnabled=%1 len=%2")
+                                  .arg(m_ttsEnabled).arg(text.size()));
 }
 
 void AccessibilityManager::announce(const QString& text, bool interrupt)
@@ -531,15 +548,15 @@ void AccessibilityManager::announceCoaching(const QString& text, bool interrupt)
     const QString preview = a11yLogPreview(text);
     if (isScreenReaderActive()) {
         dispatchPlatformAnnouncement(text, interrupt);
-        qInfo().noquote() << "[a11y] route path=platform coaching=true len=" << text.size()
-                          << " preview=" << preview;
+        A11Y_INFO_STDERR("Route", QStringLiteral("path=platform coaching=true len=%1 preview=%2")
+                                      .arg(text.size()).arg(preview));
         return;
     }
     // dispatchTtsAnnouncement() handles the m_tts null check internally (and
     // tests override the virtual with m_tts intentionally absent).
     dispatchTtsAnnouncement(text, interrupt);
-    qInfo().noquote() << "[a11y] route path=tts coaching=true len=" << text.size()
-                      << " preview=" << preview;
+    A11Y_INFO_STDERR("Route", QStringLiteral("path=tts coaching=true len=%1 preview=%2")
+                                  .arg(text.size()).arg(preview));
 }
 
 bool AccessibilityManager::isScreenReaderActive() const
@@ -573,7 +590,8 @@ void AccessibilityManager::dispatchPlatformAnnouncement(const QString& text, boo
     if (!target) {
         // qInfo (not qDebug) so dropped announcements show up in transcripts —
         // this is the case most likely to be reported as a "missed announcement".
-        qInfo().noquote() << "[a11y] announce path=dropped reason=no-window len=" << text.size();
+        A11Y_INFO_STDERR("Route", QStringLiteral("announce path=dropped reason=no-window len=%1")
+                                      .arg(text.size()));
         return;
     }
 
@@ -609,8 +627,8 @@ void AccessibilityManager::announceLabel(const QString& text)
     // must not double-speak. Same fix as announce().
     if (isScreenReaderActive()) {
         dispatchPlatformAnnouncement(text, /*assertive=*/false);
-        qInfo().noquote() << "[a11y] announceLabel path=platform isActive=true len=" << text.size()
-                          << " preview=" << a11yLogPreview(text);
+        A11Y_INFO_STDERR("Route", QStringLiteral("announceLabel path=platform isActive=true len=%1 preview=%2")
+                                      .arg(text.size()).arg(a11yLogPreview(text)));
         return;
     }
 
@@ -635,8 +653,8 @@ void AccessibilityManager::announceLabel(const QString& text)
         // "TTS path was chosen" assertion for unit tests.
         dispatchTtsAnnouncement(text, /*interrupt=*/false);
     }
-    qInfo().noquote() << "[a11y] announceLabel path=tts isActive=false len=" << text.size()
-                      << " preview=" << a11yLogPreview(text);
+    A11Y_INFO_STDERR("Route", QStringLiteral("announceLabel path=tts isActive=false len=%1 preview=%2")
+                                  .arg(text.size()).arg(a11yLogPreview(text)));
 }
 
 void AccessibilityManager::playTick()
@@ -730,7 +748,7 @@ void AccessibilityManager::onLanguageChanged()
     if (!m_tts || !m_translationManager) return;
 
     if (m_tts->state() != QTextToSpeech::Ready) {
-        qDebug() << "TTS not ready yet, skipping locale update";
+        A11Y_LOG_STDERR("Tts", QStringLiteral("not ready yet, skipping locale update"));
         return;
     }
 
@@ -744,12 +762,13 @@ void AccessibilityManager::onLanguageChanged()
     // C++ try/catch cannot intercept. setLocale() is safe — if the locale isn't
     // supported, Android TTS silently falls back to the system default.
     m_tts->setLocale(locale);
-    qDebug() << "TTS locale set to:" << locale.name() << "for language:" << langCode;
+    A11Y_LOG_STDERR("Tts", QStringLiteral("locale set to %1 for language %2")
+                               .arg(locale.name(), langCode));
 #else
     // On desktop, check available locales before setting
     QList<QLocale> availableLocales = m_tts->availableLocales();
     if (availableLocales.isEmpty()) {
-        qDebug() << "No TTS locales available — using system default";
+        A11Y_LOG_STDERR("Tts", QStringLiteral("no locales available — using system default"));
         return;
     }
 
@@ -757,14 +776,16 @@ void AccessibilityManager::onLanguageChanged()
     for (const QLocale& available : availableLocales) {
         if (available.language() == locale.language()) {
             m_tts->setLocale(available);
-            qDebug() << "TTS locale set to:" << available.name() << "for language:" << langCode;
+            A11Y_LOG_STDERR("Tts", QStringLiteral("locale set to %1 for language %2")
+                                       .arg(available.name(), langCode));
             found = true;
             break;
         }
     }
 
     if (!found) {
-        qDebug() << "TTS locale not available for:" << langCode << "- using system default";
+        A11Y_LOG_STDERR("Tts", QStringLiteral("locale not available for %1 — using system default")
+                                   .arg(langCode));
     }
 #endif
 }

--- a/src/core/accessibilitymanager.h
+++ b/src/core/accessibilitymanager.h
@@ -185,6 +185,12 @@ private:
     // the engine, which is why create() pins CppOwnership.
     static AccessibilityManager *s_qmlInstance;
 
+    // How many have been built. The app owns exactly one (main.cpp's stack
+    // object, published via setQmlInstance); create() never constructs and the
+    // type is not QML-creatable, so a second is a defect. See the constructor
+    // for what the second one costs and why this counter exists at all.
+    static int s_instanceCount;
+
     void loadSettings();
     void saveSettings();
     // Constructs the real legacy QSettings("Decenza","DE1") and

--- a/src/core/accessibilitymanager.h
+++ b/src/core/accessibilitymanager.h
@@ -1,6 +1,7 @@
 #ifndef ACCESSIBILITYMANAGER_H
 #define ACCESSIBILITYMANAGER_H
 
+#include <atomic>
 #include <QObject>
 #include <QPointer>
 #include <QTextToSpeech>
@@ -189,7 +190,7 @@ private:
     // object, published via setQmlInstance); create() never constructs and the
     // type is not QML-creatable, so a second is a defect. See the constructor
     // for what the second one costs and why this counter exists at all.
-    static int s_instanceCount;
+    static std::atomic<int> s_instanceCount;
 
     void loadSettings();
     void saveSettings();

--- a/src/core/logtags.h
+++ b/src/core/logtags.h
@@ -84,6 +84,7 @@
 #define DECENZA_LOG_MARKER_AUTOLOAD      "AutoLoad"
 #define DECENZA_LOG_MARKER_KEYBOARD      "Keyboard"
 #define DECENZA_LOG_MARKER_APP           "App"
+#define DECENZA_LOG_MARKER_ACCESSIBILITY "Accessibility"
 
 // The registry. Each row: (marker literal, what the subsystem covers).
 // The description is user/assistant-facing — it reaches the MCP tool
@@ -176,6 +177,16 @@
       "or never held, and every correction written to the machine's pressure or "  \
       "temperature sensor with the pair it was computed from. Answers \"why "      \
       "can I not apply a correction\" and \"did my correction actually land\"")                                         \
+    X(DECENZA_LOG_MARKER_ACCESSIBILITY,                                            \
+      "Where a screen-reader announcement went, and why: the platform path when "  \
+      "a reader is active, the app's own TTS when it is not, and the silent and "  \
+      "dropped paths with the reason. Also TTS engine setup and the legacy "       \
+      "settings-store migration. Answers \"TalkBack says nothing on this "         \
+      "screen\" and \"it speaks twice\" — questions no other marker can, because " \
+      "the announcement either reached the platform or it did not, and only "      \
+      "these lines say which. Third-party readers matter here: #1300's reporter "  \
+      "used TalkMan under TalkBack's class name, so the route a line reports is "  \
+      "worth more than any assumption about which reader is installed")            \
     X(DECENZA_LOG_MARKER_AUTOSLEEP,                                                \
       "Why the app did or did not put the machine to sleep on its own: the "       \
       "inactivity countdown starting and being reset, a scheduled stay-awake "     \

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -867,6 +867,38 @@ private slots:
         QVERIFY(!scale.m_watchdogArmPending);
     }
 
+    // A wake() while the watchdog is already running must not re-arm it.
+    // startWatchdog() resets m_watchdogRetries and m_watchdogUpdatesSeen, so a
+    // second arm hands back the whole retry budget and forgets that weight data
+    // had been seen — the next lapse is then timed as a first sight rather than
+    // a stall. Build 3574 logged both arms 198 ms apart once the enable started
+    // dispatching promptly enough to clear the pending flag before the 500 ms
+    // wake().
+    void aWakeDoesNotReArmARunningWatchdog() {
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+
+        // The enable issues (the mock emits notificationsIssued inline), which
+        // arms the watchdog and clears the pending flag — the state the 500 ms
+        // wake() then runs in.
+        scale.m_watchdogArmPending = true;
+        scale.enableWeightNotifications(QStringLiteral("test"));
+        QVERIFY(scale.m_watchdogTimer && scale.m_watchdogTimer->isActive());
+        QVERIFY(!scale.m_watchdogArmPending);
+
+        // Spend part of the budget and see data, then wake.
+        scale.m_watchdogRetries = 4;
+        scale.m_watchdogUpdatesSeen = true;
+        scale.wake();
+
+        QCOMPARE(scale.m_watchdogRetries, 4);
+        QVERIFY(scale.m_watchdogUpdatesSeen);
+        QVERIFY(scale.m_watchdogTimer->isActive());
+    }
+
     void noPathArmsTheWatchdogBeforeTheEnableIsIssued() {
         auto* transport = new MockScaleBleTransport;
         DecentScale scale(transport);

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -881,10 +881,10 @@ private slots:
         scale.m_serviceFound = true;
         scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
 
-        // The enable issues (the mock emits notificationsIssued inline), which
-        // arms the watchdog and clears the pending flag — the state the 500 ms
-        // wake() then runs in.
-        scale.m_watchdogArmPending = true;
+        // onCharacteristicsDiscoveryFinished() set m_watchdogArmPending; the
+        // enable then issues (the mock emits notificationsIssued inline), which
+        // arms the watchdog and clears the flag — the state the 500 ms wake()
+        // runs in.
         scale.enableWeightNotifications(QStringLiteral("test"));
         QVERIFY(scale.m_watchdogTimer && scale.m_watchdogTimer->isActive());
         QVERIFY(!scale.m_watchdogArmPending);
@@ -892,11 +892,44 @@ private slots:
         // Spend part of the budget and see data, then wake.
         scale.m_watchdogRetries = 4;
         scale.m_watchdogUpdatesSeen = true;
+        const int remainingBeforeWake = scale.m_watchdogTimer->remainingTime();
         scale.wake();
 
         QCOMPARE(scale.m_watchdogRetries, 4);
         QVERIFY(scale.m_watchdogUpdatesSeen);
         QVERIFY(scale.m_watchdogTimer->isActive());
+        // The countdown is left ALONE, not restarted. Without this a wrong fix
+        // that called m_watchdogTimer->start() — "parity with
+        // onNotificationsIssued()" — would still pass every assertion above.
+        QVERIFY(scale.m_watchdogTimer->remainingTime() <= remainingBeforeWake);
+    }
+
+    // main.cpp wakes the scale from its connectedChanged handler when an LCD
+    // restore is pending, and connectedChanged is emitted SYNCHRONOUSLY from
+    // inside onCharacteristicsDiscoveryFinished(). That re-enters wake() before
+    // the connect sequence has submitted its notify-enable, so the arm-pending
+    // flag has to be set before setConnected() rather than after it — otherwise
+    // the watchdog arms against an LCD command and expires before the enable is
+    // ever asked for.
+    //
+    // noPathArmsTheWatchdogBeforeTheEnableIsIssued() below cannot see this: it
+    // wires no connectedChanged observer, so it passes either way.
+    void aWakeReEnteredFromConnectedChangedDoesNotArmTheWatchdog() {
+        auto* transport = new MockScaleBleTransport;
+        transport->m_suppressNotificationsIssued = true;
+        DecentScale scale(transport);
+
+        connect(&scale, &ScaleDevice::connectedChanged, &scale, [&scale]() {
+            if (scale.isConnected()) scale.wake();
+        });
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+
+        // The re-entrant wake() must not have armed anything: no enable has been
+        // submitted yet, so there is nothing for a watchdog to time.
+        QVERIFY(!(scale.m_watchdogTimer && scale.m_watchdogTimer->isActive()));
+        QVERIFY(scale.m_watchdogArmPending);
     }
 
     void noPathArmsTheWatchdogBeforeTheEnableIsIssued() {


### PR DESCRIPTION
Both found by reading build 3574's log on the tablet after #1885 shipped — the two things I flagged there as unresolved.

## 1. `wake()` re-arms a running watchdog (fix)

`wake()` arms the watchdog whenever `m_watchdogArmPending` is clear, and `startWatchdog()` resets `m_watchdogRetries` and `m_watchdogUpdatesSeen`. A `wake()` landing while the watchdog already runs therefore hands back the **entire retry budget** and forgets that weight data had been seen, so the next lapse is timed as a first sight (`kWatchdogFirstTimeoutMs`) rather than as a stall.

**The logic is old; what is new is that it became reachable.** Previously the enable dispatched after both wakes — the build-3573 session shows it issuing at 8.19 s against wakes at 200 ms and 500 ms — so the pending flag was still set and `wake()` never armed. #1885 cut the connect-burst contention, and build 3574 issues the enable at 5.040 s, before the 500 ms wake at 5.238 s:

```
[   5.040] [Scale][BLE DecentScale] Watchdog started (initial 1000ms timeout)
[   5.233] [Scale][BLE DecentScale] Sending wake/LCD command again (500ms)
[   5.238] [Scale][BLE DecentScale] Watchdog started (initial 1000ms timeout)
```

`wake()` now declines to arm a watchdog that is already running — the rule `onNotificationsIssued()` already follows for a later enable: restart the countdown, never reset the counters.

## 2. AccessibilityManager instance count (diagnostic, not a fix)

The class is meant to hold exactly one instance: main.cpp's stack object, published via `setQmlInstance()`. `create()` never constructs and the type is not QML-creatable.

Build 3574 shows more than one. `initTts()`'s "Available TTS engines" appears at 0.798 s and again at 1.802 s **with no "initTts() called again" warning between them** — the guard added in #1885 — so both calls found `m_tts` null. A single object cannot do that outside `shutdown()`, which is called once at quit and logs a line that is absent here. "App started" appears once, so it is not a second process either.

**The second construction site is not identified.** The tree has exactly one, no string-based `invokeMethod` reaches `initTts`, and every other reference is a pointer or a forward declaration. The timing puts it inside QML loading — after context-property registration at 0.875 s, before `engine.load()` returns at 3.197 s.

So this counter names the caller rather than guessing at it, and **the guess is the thing it exists to prevent**: a blind guard around an unidentified mechanism is exactly how the #582 diagnostics got written. It is kept permanently rather than as a probe because it asserts an invariant that holds today, costs an `int`, and says nothing at all when the app is well.

Worth stating the stake — this is not only log noise. The second instance builds its own `QTextToSpeech`, a live Android TTS binding with its own `stateChanged` handler, while `setQmlInstance()` publishes only main.cpp's object. A screen-reader user can end up with the locale on one engine and announcements on the other, or with both speaking.

## Tests

Two new slots in `tests/tst_scaleprotocol.cpp` (existing file, no new TU). `aWakeDoesNotReArmARunningWatchdog` spends part of the retry budget, sees data, then wakes, and asserts neither counter moved. **Verified it fails when reverted** — the retries drop 4 → 0.

Local: build clean, **117/117 pass, no warnings**. `check_log_markers.py` and `check_test_source_duplication.py` both OK.

## Verification gap

Same as #1885 — the scale wake path and the AccessibilityManager constructor are both Android-exercised, and the macOS build these results come from does not run them. The counter's whole purpose is to be read in the next beta's log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)