### PR TITLE
Decode the Skale's weight exponent instead of assuming it is -1

### DIFF
--- a/src/ble/protocol/skalescaleprotocol.h
+++ b/src/ble/protocol/skalescaleprotocol.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QByteArray>
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+// Atomax Skale II weight notifications (characteristic EF81).
+//
+// Frame: [flags, mantissa LE 24-bit signed, exponent int8], weight = mantissa * 10^exponent.
+namespace SkaleScaleProtocol {
+
+inline constexpr qsizetype WeightFrameLength = 5;
+
+// The exponent range this driver will act on. The SDK format permits any int8,
+// but nothing between a microgram and a tonne needs more, and the value reached
+// here feeds stop-at-weight: 10^127 would arrive as a weight, not as an error.
+inline constexpr int MinExponent = -6;
+inline constexpr int MaxExponent = 6;
+
+// Grams, or nullopt when the frame is not one this decoder can read.
+//
+// The exponent is the point. Decenza, de1app (bluetooth.tcl, `binary scan ...
+// cus1cu` then `t1 / 10.0`) and decaid all read bytes 1-2 as a 16-bit mantissa
+// and divided by ten, which is correct ONLY for exponent -1 -- the one value
+// every observed scale happens to send. A frame carrying any other exponent
+// decoded to a weight wrong by a factor of ten or a hundred:
+//
+//   00 D2 04 00 FE   1234 x 10^-2 = 12.34 g,  read as 123.4 g
+//   00 7B 00 00 01    123 x 10^1  = 1230 g,   read as 12.3 g
+//
+// Sourced from decentespresso/decaid#722 and its issue #712, which carry the
+// Atomax SDK's own decode and those examples. No Skale has been observed
+// sending another exponent, so this is a latent misread rather than a live
+// fault -- worth correcting because the consumer is stop-at-weight.
+inline std::optional<double> decodeWeightGrams(const QByteArray& frame) {
+    if (frame.size() != WeightFrameLength)
+        return std::nullopt;
+
+    const uint8_t* d = reinterpret_cast<const uint8_t*>(frame.constData());
+
+    // Sign-extend from bit 23. Reading only bytes 1-2 as int16 got small
+    // negatives right by accident -- their low 16 bits match -- and everything
+    // past +-32.767 g at exponent -1 wrong.
+    int32_t mantissa = int32_t(d[1]) | (int32_t(d[2]) << 8) | (int32_t(d[3]) << 16);
+    if (mantissa & 0x800000)
+        mantissa -= 0x1000000;
+
+    const int exponent = static_cast<int8_t>(d[4]);
+    if (exponent < MinExponent || exponent > MaxExponent)
+        return std::nullopt;
+
+    // Divide rather than multiply by a negative power: std::pow(10, n) for a
+    // small non-negative n is an exact integer, so the result is one correctly
+    // rounded operation away from the true value.
+    const double scale = std::pow(10.0, std::abs(exponent));
+    return exponent < 0 ? mantissa / scale : mantissa * scale;
+}
+
+} // namespace SkaleScaleProtocol

--- a/src/ble/scales/skalescale.cpp
+++ b/src/ble/scales/skalescale.cpp
@@ -1,6 +1,8 @@
 #include "skalescale.h"
 #include "../protocol/de1characteristics.h"
+#include "../protocol/skalescaleprotocol.h"
 #include "scalelogging.h"
+#include <QDateTime>
 #include <QTimer>
 
 #define SKALE_LOG(msg)  SCALE_LOG("SkaleScale", msg)
@@ -64,6 +66,11 @@ void SkaleScale::onTransportConnected() {
 
 void SkaleScale::onTransportDisconnected() {
     SKALE_INFO(DECENZA_BLE_MSG_TRANSPORT_DISCONNECTED);
+    // Run end for the frame-shape collapse (core/logcollapse.h).
+    for (const auto& [shape, collapsed] :
+         m_frameShapeLog.flushAll(QDateTime::currentMSecsSinceEpoch())) {
+        SKALE_LOG(shape + LogCollapse::suffix(collapsed));
+    }
     setConnected(false);
 }
 
@@ -133,12 +140,15 @@ void SkaleScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& servic
 void SkaleScale::onCharacteristicChanged(const QBluetoothUuid& characteristicUuid,
                                          const QByteArray& value) {
     if (characteristicUuid == Scale::Skale::WEIGHT) {
-        // Skale weight format: byte 0 = type, bytes 1-2 = unsigned short weight (10ths of gram)
-        if (value.size() >= 3) {
-            const uint8_t* d = reinterpret_cast<const uint8_t*>(value.constData());
-            int16_t weightRaw = static_cast<int16_t>((d[2] << 8) | d[1]);
-            double weight = weightRaw / 10.0;
-            setWeight(weight);
+        // Dispatch on length, then decode mantissa and exponent — see
+        // SkaleScaleProtocol. The old parser accepted any frame of 3 bytes or
+        // more and read two of them, so a truncated notification produced a
+        // reading and a 5-byte frame's exponent was never consulted.
+        if (const auto grams = SkaleScaleProtocol::decodeWeightGrams(value)) {
+            setWeight(*grams);
+        } else {
+            logFrameShapeOnce(QString("Undecodable weight frame, %1 bytes").arg(value.size()),
+                              value);
         }
     } else if (characteristicUuid == Scale::Skale::BUTTON) {
         // Button press notification
@@ -146,6 +156,14 @@ void SkaleScale::onCharacteristicChanged(const QBluetoothUuid& characteristicUui
             emit buttonPressed(value[0]);
         }
     }
+}
+
+void SkaleScale::logFrameShapeOnce(const QString& shape, const QByteArray& data)
+{
+    const QString line = scaleFrameShapeLine(m_frameShapeLog, shape, data,
+                                             QDateTime::currentMSecsSinceEpoch());
+    if (!line.isEmpty())
+        SKALE_LOG(line);
 }
 
 void SkaleScale::sendCommand(uint8_t cmd) {

--- a/src/ble/scales/skalescale.h
+++ b/src/ble/scales/skalescale.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../scaledevice.h"
+#include "core/logcollapse.h"
 #include "../transport/scalebletransport.h"
 #include <QTimer>
 
@@ -40,9 +41,18 @@ private slots:
     void onCharacteristicChanged(const QBluetoothUuid& characteristicUuid, const QByteArray& value);
 
 private:
+#ifdef DECENZA_TESTING
+    friend class tst_ScaleProtocol;
+#endif
     void sendCommand(uint8_t cmd);
+    // See scaleFrameShapeLine() for the once-per-shape, capped policy.
+    void logFrameShapeOnce(const QString& shape, const QByteArray& data);
 
     ScaleBleTransport* m_transport = nullptr;
+    
+    // Weight frames the decoder could not read. EPISODIC — a connection ends — so
+    // onTransportDisconnected() ends the run with flushAll().
+    LogCollapse m_frameShapeLog{LogCollapse::kChangesOnly};
     QString m_name = "Skale";
     bool m_serviceFound = false;
     bool m_characteristicsReady = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1275,6 +1275,7 @@ add_decenza_test(tst_scaleprotocol
     ${CMAKE_SOURCE_DIR}/src/ble/scales/bookooscale.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/difluidscale.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/acaiascale.cpp
+    ${CMAKE_SOURCE_DIR}/src/ble/scales/skalescale.cpp
 )
 
 if(NOT IOS)

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -7,6 +7,8 @@
 #include "ble/scales/bookooscale.h"
 #include "ble/scales/difluidscale.h"
 #include "ble/scales/acaiascale.h"
+#include "ble/scales/skalescale.h"
+#include "ble/protocol/skalescaleprotocol.h"
 #include "ble/blegattqueue.h"
 #include "ble/transport/scalebletransport.h"
 #include "ble/protocol/de1characteristics.h"
@@ -713,6 +715,79 @@ private slots:
 
         QVERIFY(spy.count() >= 1);
         QCOMPARE(spy.last().at(0).toInt(), 60);
+    }
+
+    // ==========================================
+    // SkaleScale: mantissa/exponent weight frames
+    // ==========================================
+
+    void skaleWeightMantissaExponent_data() {
+        QTest::addColumn<QByteArray>("frame");
+        QTest::addColumn<double>("grams");
+
+        // The Atomax SDK decode and its worked examples come from
+        // decentespresso/decaid#712. Exponent -1 is the case every observed
+        // scale sends and the only one the old bytes-1-2-divided-by-ten parser
+        // got right; the rest were wrong by a factor of ten or a hundred.
+        QTest::newRow("exponent -2 (fractional)") << QByteArray::fromHex("00D20400FE") << 12.34;
+        QTest::newRow("exponent -1 (the common case)") << QByteArray::fromHex("00E80300FF") << 100.0;
+        QTest::newRow("exponent +1") << QByteArray::fromHex("007B000001") << 1230.0;
+        QTest::newRow("negative, 24-bit sign extension") << QByteArray::fromHex("00C9FDFFFF") << -56.7;
+    }
+
+    void skaleWeightMantissaExponent() {
+        QFETCH(QByteArray, frame);
+        QFETCH(double, grams);
+
+        SkaleScale scale(nullptr);
+        QSignalSpy spy(&scale, &ScaleDevice::weightChanged);
+        scale.onCharacteristicChanged(Scale::Skale::WEIGHT, frame);
+
+        QVERIFY(spy.count() >= 1);
+        QCOMPARE(spy.last().at(0).toDouble(), grams);
+    }
+
+    void skaleRejectsFramesItCannotDecode_data() {
+        QTest::addColumn<QByteArray>("frame");
+
+        // Anything but a 5-byte frame. The old parser took any frame of 3 bytes
+        // or more, so a truncated notification produced a weight.
+        QTest::newRow("truncated to 3 bytes") << QByteArray::fromHex("00D204");
+        QTest::newRow("legacy 4-byte") << QByteArray::fromHex("00D20400");
+        QTest::newRow("oversized 6-byte") << QByteArray::fromHex("00D20400FE00");
+        QTest::newRow("empty") << QByteArray();
+        // An exponent no gram reading needs. It reaches stop-at-weight, so an
+        // implausible one is refused rather than turned into 10^127.
+        QTest::newRow("absurd exponent") << QByteArray::fromHex("00D204007F");
+    }
+
+    void skaleRejectsFramesItCannotDecode() {
+        QFETCH(QByteArray, frame);
+
+        SkaleScale scale(nullptr);
+        QSignalSpy spy(&scale, &ScaleDevice::weightChanged);
+        MessageCapture capture;
+
+        scale.onCharacteristicChanged(Scale::Skale::WEIGHT, frame);
+
+        QCOMPARE(spy.count(), 0);
+        QCOMPARE(capture.count(QStringLiteral("Undecodable weight frame")), 1);
+    }
+
+    void skaleUndecodableFramesAreLoggedOncePerShape() {
+        // Same policy as the Decent driver: the hex on the first sighting of a
+        // shape and nothing on repeats, so a scale streaming frames we cannot
+        // read cannot flood the log.
+        SkaleScale scale(nullptr);
+        MessageCapture capture;
+
+        for (int i = 0; i < 20; i++) {
+            QByteArray odd = QByteArray::fromHex("00D204");
+            odd[2] = static_cast<char>(i);  // volatile payload, constant shape
+            scale.onCharacteristicChanged(Scale::Skale::WEIGHT, odd);
+        }
+
+        QCOMPARE(capture.count(QStringLiteral("Undecodable weight frame, 3 bytes")), 1);
     }
 
     // ==========================================


### PR DESCRIPTION
## The bug

The Atomax Skale II sends five-byte weight notifications on `EF81`: a flag byte, a signed 24-bit little-endian mantissa, and a signed base-10 exponent. [skalescale.cpp:136](https://github.com/Kulitorum/Decenza/blob/main/src/ble/scales/skalescale.cpp#L136) read bytes 1-2 as a 16-bit mantissa and divided by ten — correct only for exponent `-1`, which is the one value every observed scale sends.

| Frame | Correct | Old parser |
|---|---:|---:|
| `00 D2 04 00 FE` | 12.34 g | **123.4 g** |
| `00 E8 03 00 FF` | 100.0 g | 100.0 g ✓ |
| `00 7B 00 00 01` | 1230 g | **12.3 g** |
| `00 C9 FD FF FF` | −56.7 g | −56.7 g ✓ |

de1app has the same decode (`binary scan ... cus1cu` then `t1 / 10.0`), so this is inherited across all three apps rather than a Decenza mistake.

**No Skale has been observed sending another exponent** — this is a latent misread, not a reported fault. It's worth correcting because the value feeds stop-at-weight, where a silent factor of ten is worse than most bugs.

## The fix

`SkaleScaleProtocol::decodeWeightGrams()` — length check, 24-bit sign extension, exponent applied. Same shape as the Decent scale fix in #1891: dispatch on frame length first, and report what could not be decoded once per shape through the shared `scaleFrameShapeLine()`. The old parser accepted any frame of three bytes or more, so a truncated notification produced a reading; only a five-byte frame does now.

**Not** taken from decaid#722: its 4-byte `/2560` compatibility path. That's decaid's own historical representation, and adding a branch for a format Decenza has never emitted would invent a compatibility requirement.

## Log noise

One line per undecodable frame shape per connection, DEBUG, collapsed and capped by the shared helper, flushed at disconnect. Zero lines on a working scale.

## Tests

Two data tables and one collapse test added to the existing `tst_scaleprotocol.cpp` (no new file); `skalescale.cpp` joins that target. The decode rows are the worked examples from [decaid#712](https://github.com/decentespresso/decaid/issues/712), verified arithmetically before they were written — which caught one row of mine that had the wrong exponent byte.

Suite green: **117 passed, 0 failed, no warnings.**

## Not verified on hardware

There's no Skale here — this is desk-verified against the SDK format and the issue's examples only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)