### PR TITLE
fix(scale): restore the Skale keep-alive, and let OK restart the reconnect ramp

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1753,7 +1753,11 @@ T.ApplicationWindow {
                 text: trCommonOk.text
                 accessibleName: trCommonDismissDialog.text
                 anchors.horizontalCenter: parent.horizontalCenter
-                onClicked: flowScaleDialog.close()
+                onClicked: {
+                    flowScaleDialog.close()
+                    BLEManager.requestScaleReconnectRampRestart(
+                        "No-scale notice dismissed")
+                }
             }
         }
     }
@@ -1808,8 +1812,9 @@ T.ApplicationWindow {
                 accessibleName: trCommonDismissDialog.text
                 anchors.horizontalCenter: parent.horizontalCenter
                 onClicked: {
-                    BLEManager.requestScaleReconnectRampRestart()
                     scaleDisconnectedDialog.close()
+                    BLEManager.requestScaleReconnectRampRestart(
+                        "Scale-disconnected notice dismissed")
                 }
             }
         }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1807,7 +1807,10 @@ T.ApplicationWindow {
                 text: trCommonOk.text
                 accessibleName: trCommonDismissDialog.text
                 anchors.horizontalCenter: parent.horizontalCenter
-                onClicked: scaleDisconnectedDialog.close()
+                onClicked: {
+                    BLEManager.requestScaleReconnectRampRestart()
+                    scaleDisconnectedDialog.close()
+                }
             }
         }
     }

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -2961,8 +2961,8 @@ void BLEManager::startReconnectBrowseIfNeeded() {
     m_reconnectDiscovery->browse(kReconnectBrowseTimeoutMs);
 }
 
-void BLEManager::requestScaleReconnectRampRestart() {
-    emit scaleReconnectRampRestartRequested();
+void BLEManager::requestScaleReconnectRampRestart(const QString& reason, int firstDelayMs) {
+    emit scaleReconnectRampRestartRequested(reason, firstDelayMs);
 }
 
 void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -2961,6 +2961,10 @@ void BLEManager::startReconnectBrowseIfNeeded() {
     m_reconnectDiscovery->browse(kReconnectBrowseTimeoutMs);
 }
 
+void BLEManager::requestScaleReconnectRampRestart() {
+    emit scaleReconnectRampRestartRequested();
+}
+
 void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
     // See connectToSavedScale: the DE1 simulator must not gate real scale connects.
     // This early-return on m_disabled is why a WiFi scale could never recover

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -706,7 +706,11 @@ public slots:
     // still auto-connects via onDeviceDiscovered when it's seen advertising.
     Q_INVOKABLE void tryDirectConnectToScale(bool allowDirectConnect = true);
 
-    Q_INVOKABLE void requestScaleReconnectRampRestart();
+    // Ask main.cpp, which owns the reconnect ladder, to restart it from the top.
+    // firstDelayMs < 0 means the ramp's own first step.
+    Q_INVOKABLE void requestScaleReconnectRampRestart(
+        const QString& reason = QStringLiteral("Scale notice dismissed"),
+        int firstDelayMs = -1);
     /**
      * The DE1's connect attempt started or ended. OBSERVABILITY ONLY.
      *
@@ -787,7 +791,7 @@ signals:
     void scaleRetryNeeded();   // Emitted on EVERY connection-failure path (including the post-WiFi→BLE-fallback give-up), regardless of the flowScaleFallback gate, so the persistent reconnect ladder in main.cpp survives the scale-type-change timer stop. Don't bind UI to this — it's for re-arming the retry timer only.
     void scaleDisconnected();  // Emitted when physical scale disconnects
     void scaleConnected();     // Emitted when a physical scale (re)connects — lets the UI dismiss the scale-disconnect / no-scale notice
-    void scaleReconnectRampRestartRequested();
+    void scaleReconnectRampRestartRequested(const QString& reason, int firstDelayMs);
     void scanStarted();  // Emitted when BLE scan actually begins
     // Emitted when a saved WiFi scale fails to connect within the connection
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -705,6 +705,8 @@ public slots:
     // Connecting for ~30s and starves the DE1 link (issue #1303). A saved scale
     // still auto-connects via onDeviceDiscovered when it's seen advertising.
     Q_INVOKABLE void tryDirectConnectToScale(bool allowDirectConnect = true);
+
+    Q_INVOKABLE void requestScaleReconnectRampRestart();
     /**
      * The DE1's connect attempt started or ended. OBSERVABILITY ONLY.
      *
@@ -785,6 +787,7 @@ signals:
     void scaleRetryNeeded();   // Emitted on EVERY connection-failure path (including the post-WiFi→BLE-fallback give-up), regardless of the flowScaleFallback gate, so the persistent reconnect ladder in main.cpp survives the scale-type-change timer stop. Don't bind UI to this — it's for re-arming the retry timer only.
     void scaleDisconnected();  // Emitted when physical scale disconnects
     void scaleConnected();     // Emitted when a physical scale (re)connects — lets the UI dismiss the scale-disconnect / no-scale notice
+    void scaleReconnectRampRestartRequested();
     void scanStarted();  // Emitted when BLE scan actually begins
     // Emitted when a saved WiFi scale fails to connect within the connection
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds

--- a/src/ble/scales/skalescale.cpp
+++ b/src/ble/scales/skalescale.cpp
@@ -162,8 +162,11 @@ void SkaleScale::sendCommand(uint8_t cmd) {
 }
 
 void SkaleScale::sendKeepAlive() {
-    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
-    // Re-writing the CCCD risks AuthorizationError disconnects.
+    // Skale-only exception to #1092; see #1896.
+    if (m_transport && m_characteristicsReady) {
+        m_transport->enableNotifications(Scale::Skale::SERVICE, Scale::Skale::WEIGHT);
+        m_transport->enableNotifications(Scale::Skale::SERVICE, Scale::Skale::BUTTON);
+    }
 }
 
 void SkaleScale::tare() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2588,6 +2588,18 @@ int main(int argc, char *argv[])
                              QStringLiteral("main"));
     });
 
+    QObject::connect(&bleManager, &BLEManager::scaleReconnectRampRestartRequested,
+                     handlerScope.get(),
+                     [&settings, &physicalScale, &scaleReconnectTimer,
+                      &scaleReconnectAttempt, &reconnectDelays,
+                      &scaleAutoReconnectSuppressed]() {
+        if (physicalScale && physicalScale->isConnected()) return;
+        if (!scaleAddressIsLadderDialable(settings.scaleAddress())) return;
+        if (scaleAutoReconnectSuppressed) return;
+        scaleReconnectAttempt = 0;
+        scaleReconnectTimer.start(reconnectDelays[0]);
+    });
+
     // === Proactive switch-back to the WiFi primary scale ===
     // When the saved primary is a WiFi scale but we're currently on the BLE
     // backup (the WiFi->BLE fallback connected after WiFi was unreachable),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2588,16 +2588,28 @@ int main(int argc, char *argv[])
                              QStringLiteral("main"));
     });
 
+    // Every "a scale might be here now" event restarts the ladder through here.
+    // The gates were previously spelled out at each site and had drifted: four
+    // tested the `usb:` prefix instead of scaleAddressIsLadderDialable(), which
+    // also excludes the simulator's `sim:` entry, so they armed a ladder the
+    // first tick permanently terminates. Callers that mean "the user is back"
+    // clear scaleAutoReconnectSuppressed before calling; that is a judgement
+    // about intent, not a gate, so it stays with them.
     QObject::connect(&bleManager, &BLEManager::scaleReconnectRampRestartRequested,
                      handlerScope.get(),
-                     [&settings, &physicalScale, &scaleReconnectTimer,
+                     [&settings, &physicalScale, &bleManager, &scaleReconnectTimer,
                       &scaleReconnectAttempt, &reconnectDelays,
-                      &scaleAutoReconnectSuppressed]() {
+                      &scaleAutoReconnectSuppressed](const QString& reason,
+                                                     int firstDelayMs) {
         if (physicalScale && physicalScale->isConnected()) return;
         if (!scaleAddressIsLadderDialable(settings.scaleAddress())) return;
         if (scaleAutoReconnectSuppressed) return;
+        const int delayMs = firstDelayMs >= 0 ? firstDelayMs : reconnectDelays[0];
         scaleReconnectAttempt = 0;
-        scaleReconnectTimer.start(reconnectDelays[0]);
+        scaleReconnectTimer.start(delayMs);
+        bleManager.scaleInfo(QStringLiteral("%1 — restarting scale reconnect ramp, first retry in %2 ms")
+                                 .arg(reason).arg(delayMs),
+                             QStringLiteral("main"));
     });
 
     // === Proactive switch-back to the WiFi primary scale ===
@@ -2837,7 +2849,7 @@ int main(int argc, char *argv[])
 
     // Connect to any supported scale when discovered
     QObject::connect(&bleManager, &BLEManager::scaleDiscovered, handlerScope.get(),
-                     [&physicalScale, &flowScale, &machineState, &mainController, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleProxy, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &scaleLcdRestorePending
+                     [&physicalScale, &flowScale, &machineState, &mainController, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleProxy, &scaleReconnectTimer, &scaleReconnectAttempt, &scaleAutoReconnectSuppressed, &scaleLcdRestorePending
                      // By value: this lambda outlives nothing, but the scale
                      // connection it makes below needs the same lifetime guard.
                      , handlerScopePtr = handlerScope.get()
@@ -3089,7 +3101,7 @@ int main(int argc, char *argv[])
 
         // When physical scale connects/disconnects, switch between physical and FlowScale
         QObject::connect(physicalScale.get(), &ScaleDevice::connectedChanged, handlerScopePtr,
-                         [&physicalScale, &flowScale, &machineState, &bleManager, &mainController, &timingController, &weightProcessor, &scaleProxy, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &settings, &scaleAutoReconnectSuppressed, &scaleLcdRestorePending]() {
+                         [&physicalScale, &flowScale, &machineState, &bleManager, &mainController, &timingController, &weightProcessor, &scaleProxy, &scaleReconnectTimer, &scaleReconnectAttempt, &settings, &scaleAutoReconnectSuppressed, &scaleLcdRestorePending]() {
             if (physicalScale && physicalScale->isConnected()) {
                 // Scale connected - stop any pending reconnect attempts
                 scaleReconnectTimer.stop();
@@ -3155,11 +3167,9 @@ int main(int argc, char *argv[])
                 // DE1-wake handler re-arms the reconnect.
                 if (scaleAutoReconnectSuppressed) {
                     qDebug() << "Scale disconnect was deliberate (DE1-sleep) - auto-reconnect suppressed until DE1 wakes";
-                } else if (scaleAddressIsLadderDialable(settings.scaleAddress())) {
-                    // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
-                    scaleReconnectAttempt = 0;
-                    scaleReconnectTimer.start(reconnectDelays[0]);
-                    qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms";
+                } else {
+                    bleManager.requestScaleReconnectRampRestart(
+                        QStringLiteral("Scale disconnected"));
                 }
             }
         });
@@ -4312,7 +4322,7 @@ int main(int argc, char *argv[])
     // when app is suspended/resumed. Neither DE1 nor scale are put to sleep when
     // backgrounded — users may switch apps while the machine heats up.
     QObject::connect(&app, &QGuiApplication::applicationStateChanged, handlerScope.get(),
-                     [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt, &scaleAutoReconnectSuppressed, &refractometerReconnectTimer, &refractometerReconnectAttempt, &mainController](Qt::ApplicationState state) {
+                     [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt, &scaleAutoReconnectSuppressed, &refractometerReconnectTimer, &refractometerReconnectAttempt, &mainController](Qt::ApplicationState state) {
         static bool wasSuspended = false;
 
         // Log every state transition so the debug log captures pre-suspend
@@ -4437,19 +4447,8 @@ int main(int argc, char *argv[])
             scaleAutoReconnectSuppressed = false;
             if (physicalScale && physicalScale->isConnected()) {
                 qDebug() << "App resumed - scale still connected";
-            } else if (!settings.scaleAddress().isEmpty()
-                       && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
-                // Scale disconnected while suspended - restart reconnect sequence.
-                // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
-                // Deliberately NOT gated on !scaleReconnectTimer.isActive(): the
-                // timer is single-shot and re-armed every tick, so it is always
-                // active while the ladder runs, and that gate made this branch
-                // dead for the one case that matters — returning to the app after
-                // the ladder has slowed to the 5-min tail. start() on an active
-                // single-shot timer restarts it, so re-arming is safe.
-                scaleReconnectAttempt = 0;
-                scaleReconnectTimer.start(reconnectDelays[0]);
-                qDebug() << "App resumed - starting scale reconnect sequence";
+            } else {
+                bleManager.requestScaleReconnectRampRestart(QStringLiteral("App resumed"));
             }
 
             // Refractometer disconnected while suspended - (re)start its
@@ -4493,9 +4492,8 @@ int main(int argc, char *argv[])
     // refractometer restart only does real work while the review-page hunt is
     // active — off that page its tick fires once and self-stops.
     QObject::connect(&screensaverManager, &ScreensaverVideoManager::screensaverActiveChanged,
-                     handlerScope.get(), [&screensaverManager, &physicalScale, &bleManager, &settings,
-                      &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays,
-                      &scaleAutoReconnectSuppressed,
+                     handlerScope.get(), [&screensaverManager, &bleManager, &settings,
+                      &scaleReconnectTimer, &reconnectDelays,
                       &refractometerReconnectTimer, &refractometerReconnectAttempt]() {
         const bool active = screensaverManager.screensaverActive();
         if (active) {
@@ -4510,23 +4508,10 @@ int main(int argc, char *argv[])
             return;
         }
 
-        // Screensaver dismissed — resume scanning under the same gates the
-        // app-resume path uses. We deliberately do NOT clear
-        // scaleAutoReconnectSuppressed here: a brief glance at the tablet
-        // isn't the same signal as switching back from another app, and DE1
-        // sleep semantics already manage that flag.
-        // (No !scaleReconnectTimer.isActive() gate — screensaver ENTRY above stops
-        // the timer, so it would be redundant here, and relying on that made the
-        // identical gate on the app-resume path silently dead. Restarting an
-        // already-armed single-shot timer is safe.)
-        if (!(physicalScale && physicalScale->isConnected())
-            && !settings.scaleAddress().isEmpty()
-            && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)
-            && !scaleAutoReconnectSuppressed) {
-            scaleReconnectAttempt = 0;
-            scaleReconnectTimer.start(reconnectDelays[0]);
-            qDebug() << "Screensaver exited - resuming scale reconnect sequence";
-        }
+        // We deliberately do NOT clear scaleAutoReconnectSuppressed here: a brief
+        // glance at the tablet isn't the same signal as switching back from
+        // another app, and DE1 sleep semantics already manage that flag.
+        bleManager.requestScaleReconnectRampRestart(QStringLiteral("Screensaver exited"));
 
         if (!bleManager.isRefractometerConnected()
             && !settings.savedRefractometerAddress().isEmpty()
@@ -4573,9 +4558,8 @@ int main(int argc, char *argv[])
     // handler can clear them when the user swaps to a different scale.
     QObject::connect(&machineState, &MachineState::phaseChanged, handlerScope.get(),
                      [&physicalScale, &machineState, &settings, &de1EverAwake,
-                      &wasInSleep, &scaleLcdRestorePending,
-                      &scaleAutoReconnectSuppressed, &scaleReconnectTimer,
-                      &scaleReconnectAttempt, &reconnectDelays]() {
+                      &wasInSleep, &scaleLcdRestorePending, &bleManager,
+                      &scaleAutoReconnectSuppressed, &scaleReconnectTimer]() {
         auto phase = machineState.phase();
         if (phase == MachineState::Phase::Disconnected) {
             de1EverAwake = false;
@@ -4651,27 +4635,15 @@ int main(int argc, char *argv[])
                     // close path above. Re-arm the reconnect sequence now that
                     // the DE1 is back. A fresh reconnect's onConnected() will
                     // send `display on` itself, so no wake() needed here.
-                    qDebug() << "DE1 woke up - re-arming scale reconnect";
                     scaleAutoReconnectSuppressed = false;
-                    // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
-                    // (No !isActive() gate — see the ladder comment near
-                    // kScaleFastTailAttempts; it is always active while the ladder
-                    // runs, and skipping here after clearing the suppression flag
-                    // would leave nothing armed at all.)
-                    if (!settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
-                        scaleReconnectAttempt = 0;
-                        // Short first-attempt delay for the wake-from-sleep path:
-                        // the WiFi scale is known alive (we closed the WS ourselves
-                        // and the HDS is still up), and a powered-off BT scale will
-                        // fail this attempt quickly and fall into the normal
-                        // reconnectDelays backoff for retry #2 onward. The full 5 s
-                        // default (reconnectDelays[0]) was sized for unexpected
-                        // drops where the radio/firmware might need to settle —
-                        // neither applies here. Saves ~4.8 s of perceived
-                        // "scale disconnected" UI time after DE1 wake.
-                        constexpr int kWakeReconnectFirstAttemptMs = 200;
-                        scaleReconnectTimer.start(kWakeReconnectFirstAttemptMs);
-                    }
+                    // Short first attempt on this path only: the WiFi scale is
+                    // known alive (we closed the WS ourselves) and a powered-off
+                    // BT scale fails fast into the normal backoff. reconnectDelays[0]
+                    // was sized for unexpected drops where the radio might need to
+                    // settle; neither applies here.
+                    constexpr int kWakeReconnectFirstAttemptMs = 200;
+                    bleManager.requestScaleReconnectRampRestart(
+                        QStringLiteral("DE1 woke up"), kWakeReconnectFirstAttemptMs);
                 } else {
                     // Neither branch fired: scale exists but is mid-reconnect
                     // (BT link dropped during sleep — connectedChanged armed a
@@ -4691,12 +4663,12 @@ int main(int argc, char *argv[])
                     // rather than up to 5 min. Only when the ladder is actually
                     // running: with no saved scale, or a USB primary (owned by
                     // UsbScaleManager), there is nothing to re-arm.
-                    if (scaleReconnectTimer.isActive()
-                        && !(physicalScale && physicalScale->isConnected())
-                        && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
-                        scaleReconnectAttempt = 0;
-                        scaleReconnectTimer.start(reconnectDelays[0]);
-                        qDebug() << "DE1 woke up - restarting scale reconnect ramp from 5 s";
+                    // isActive stays a caller gate: the ladder is deliberately
+                    // stopped while the screensaver runs, and a DE1 wake behind it
+                    // should not resurrect it.
+                    if (scaleReconnectTimer.isActive()) {
+                        bleManager.requestScaleReconnectRampRestart(
+                            QStringLiteral("DE1 woke up"));
                     }
                 }
             }


### PR DESCRIPTION
Fixes #1896.

## What the log shows

From the reporter's `1 sept debug.zip` (18,752 lines, four sessions, 2026-08-28 → 09-01).

The scale is powered from USB, so battery drain is not the mechanism. What the log does show is the scale ending the link itself, twice, in the same state both times: DE1 asleep, LCD blanked by us, and no write from us since.

| | last app→scale write | link drops | gap | DE1 |
|---|---|---|---|---|
| 08-28 | `0xEE` at 12309 (DE1 sleep) | 32021 | 5h29m | asleep throughout |
| 08-30 | `0xEE` at 2294 (DE1 sleep) | 5491 | 53m | asleep throughout |

Neither drop logs a BLE error — a clean peer-side close. The first rescan runs 5 s later and finds nothing, so the scale had already stopped advertising. That is a peer that powered itself down, not a link that failed. Both nights the log fully covers, it survived connected, which matches the reporter's "sometimes".

`keepScaleOn` is on (the default) — the log line `DE1 going to sleep - disabling scale LCD (keepScaleOn=true)` is only emitted on that branch. So every night the scale is left connected, blanked, and never written to again.

## Change 1: restore the Skale keep-alive

#1092 turned `sendKeepAlive()` into a no-op on nine drivers at once. It was right about what it measured — a CCCD re-write is not needed to keep notifications flowing, and it caused `AuthorizationError` disconnects on the Eureka Precisa and SmartChef. It did not ask whether any scale switches *itself* off when the host stops writing, and the Skale's 30 s CCCD re-write was the only periodic app→scale traffic it ever saw. That traffic stopped in May; these reports are recent.

This restores exactly what #1092 removed, on that one driver. `0xEC` ("display weight") was considered and rejected: it would relight the LCD we deliberately blank on DE1 sleep, which is the state the failure occurs in.

**This is a hypothesis, not a proven fix.** The alternative — that the Skale's inactivity timer counts host writes rather than its own notifications — has not been confirmed against firmware, and the failure fired twice in four days with two clean nights in between, so a quiet week is not evidence either way. Left for the reporter to verify in beta; no test, because a test could only assert that we call `enableNotifications` on a timer, which is testing the mock rather than whether the scale stays awake.

## Change 2: OK restarts the reconnect ramp

The ladder is `5s, 30s, 60s ×8`, then holds at **5 minutes forever** (`kScaleFastTailAttempts = 10`, `kScaleSlowTailMs = 300000`). Each tick is one 15 s passive scan, so in the tail the app is deaf for 285 s at a stretch. That is the reporter's "turning it on and pressing OK does not reconnect, I have to tap the red button" — OK was `dialog.close()` and nothing else, while the red indicator forces a scan.

`BLEManager::requestScaleReconnectRampRestart()` is a QML-callable forwarder; the ladder is `main()`'s local, so the handler there applies the same gates the existing restart sites use (not connected, address dialable, not suppressed) and re-arms at the ramp's first step.

## Change 3: one ramp restart for every caller

Review of the first commit found the restart gates had been spelled out at each of the sites that arm the ladder, and had drifted three ways. Four of them tested `startsWith("usb:")` instead of the ladder tick's own `scaleAddressIsLadderDialable()`, which additionally rejects the simulator's `sim:` entry — so with the simulator's synthetic scale saved, app resume, screensaver exit and both DE1-wake paths armed a ladder that the first tick refuses, and that early return does not re-arm a single-shot timer, so the ladder was dead for the rest of the session.

Every restart now goes through `BLEManager::scaleReconnectRampRestartRequested(reason, firstDelayMs)`: scale disconnected, app resume, screensaver exit, both DE1-wake paths, and the two dialogs. Callers keep only what is genuinely theirs — clearing `scaleAutoReconnectSuppressed` (a judgement about what the event means), the DE1-wake path's 200 ms first attempt, and the wake-fallthrough's `isActive()` guard, which exists so a wake behind a running screensaver does not resurrect a deliberately stopped ladder. The startup-failure and simulator-switched-off sites keep their own `isActive()` skip and are left alone. Net −79/+60 in `main.cpp`.

Two more review findings fixed in the same commit: the dialog now closes *before* the call, so a throw cannot strand a modal whose only other dismissal is an Escape key a tablet does not have; and the `flowScaleDialog` ("No scale detected") OK does the same restart, which matters because that is the dialog a morning app restart shows — the reporter's log restarts the app every morning.

The restart also logs one line naming the trigger and delay, replacing the four differently-worded lines the individual sites carried.

## Not in this PR

- **The tail decays while the DE1 is awake.** On wake the ramp restarts, then 8.6 minutes later it is back to 5-minute gaps with the machine awake and in use — visible in the log at 84932 (wake) through attempt 11 at 85746, +300 s. `kScaleFastTailAttempts` is unconditional; the comment reasons about an app "sitting untouched" but nothing tests whether it is. The 5-minute tail was sized for a WiFi scale whose host is off the network, where a cycle costs an mDNS resolve plus a 15 s BLE-scan fallback; a BT-only saved scale costs one passive scan. Those should not share a ladder.
- **We discover the Skale's battery service (`0x180f`) and never read it**, so there is no low-battery signal for scales that do run on cells.

## Testing

Local build clean, full suite 117/117 with no warnings, on both commits. Skale hardware is Android-only and not on the dev machine, so change 1 needs the reporter to confirm over several nights in beta.
