### PR TITLE
Make the grind picker open fast, and fix #1713 still living on the web datalist

### DIFF
--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -107,9 +107,15 @@ DecenzaDialog {
     //
     // The original trigger was the distinct-value cache warming a moment after
     // the first open. That cache is gone and the reads are live, so that exact
-    // sequence cannot recur — but the snapshot is still right: rowSource.grindStep
-    // now moves on historyDataChanged(), and a shot saved while the picker is
-    // open would otherwise rebuild the model under the user's finger.
+    // sequence cannot recur, and the snapshot is what keeps it that way: nothing
+    // here subscribes to anything, so nothing can move the model mid-gesture.
+    //
+    // An earlier version of this said "rowSource.grindStep now moves on
+    // historyDataChanged()". It does not, and never did — that signal appears
+    // nowhere in qml/ except in the sentence claiming it. grindStep() is a plain
+    // function called from _rebuildRows(), so the rows change only when a handler
+    // asks. Kept as a correction because the wrong version reads as a live
+    // subscription a future edit would try to preserve.
     property var _grindRows: []
     property var _rpmRows: []
 

--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -114,10 +114,29 @@ DecenzaDialog {
     property var _rpmRows: []
 
     function _rebuildRows() {
-        root._grindRows = root.rowSource
+        // TEMPORARY instrumentation (grind-picker open cost). The reported
+        // symptom is "several seconds" and only ~0.9 s of it is accounted for by
+        // the two history queries, so the split between query, row generation
+        // and view positioning has to be measured rather than guessed. Remove
+        // these four console.info lines once the dominant term is known.
+        var _t0 = Date.now()
+        // Split the ASSIGNMENT out of the call: handing a fresh 801-element
+        // array to the Tumbler rebuilds its view, and that turned out to be the
+        // dominant term once row generation moved to one batch call.
+        var _gRows = root.rowSource
             ? root.rowSource.grindRowsFor(root._pendingGrind) : []
-        root._rpmRows = (root.rowSource && root.rowSource.rpmCapable)
+        var _tBuilt = Date.now()
+        root._grindRows = _gRows
+        var _tGrind = Date.now()
+        var _rRows = (root.rowSource && root.rowSource.rpmCapable)
             ? root.rowSource.rpmRowsFor(parseInt(root._pendingRpm) || 0) : []
+        var _tRpmBuilt = Date.now()
+        root._rpmRows = _rRows
+        console.info("[Equipment] grind picker: _rebuildRows grind-build="
+                     + (_tBuilt - _t0) + "ms grind-assign=" + (_tGrind - _tBuilt)
+                     + "ms rpm-build=" + (_tRpmBuilt - _tGrind)
+                     + "ms rpm-assign=" + (Date.now() - _tRpmBuilt)
+                     + "ms total=" + (Date.now() - _t0) + "ms")
     }
 
     // Index of the current value within a rows array (-1 if none is current).
@@ -195,6 +214,7 @@ DecenzaDialog {
     // taking the middle: the window is wide and clamps at zero, so the middle
     // row is no longer the anchor.
     function _centerWheels() {
+        var _t0 = Date.now()  // TEMPORARY — see _rebuildRows
         var gi = root._currentIndex(root._grindRows)
         root._snapTo(grindTumbler, gi >= 0 ? gi : Math.floor(root._grindRows.length / 2))
         var ri = root._currentIndex(root._rpmRows)
@@ -208,6 +228,9 @@ DecenzaDialog {
         // Remember where we parked it, so a later currentIndex that differs is
         // proof the user moved it themselves.
         root._rpmSnapIndex = rpmTumbler.count > 0 ? rpmIndex : -1
+        console.info("[Equipment] grind picker: _centerWheels " + (Date.now() - _t0)
+                     + "ms (grindRows=" + root._grindRows.length
+                     + " rpmRows=" + root._rpmRows.length + ")")
     }
 
     // All setup happens BEFORE the dialog is visible, so its first frame
@@ -215,6 +238,7 @@ DecenzaDialog {
     // place flicker, no travel. onOpened repeats the (idempotent) snap once
     // in case the ListView finished layout only after showing.
     onAboutToShow: {
+        var _t0 = Date.now()  // TEMPORARY — see _rebuildRows
         root._rpmTouched = false
         root._rpmSnapIndex = -1
         root._pendingGrind = root.currentGrind
@@ -234,12 +258,17 @@ DecenzaDialog {
         rpmText.text = root._pendingRpm
         if (!root.textMode)
             root._centerWheels()
+        console.info("[Equipment] grind picker: onAboutToShow TOTAL "
+                     + (Date.now() - _t0) + "ms textMode=" + root.textMode)
     }
     onOpened: {
+        var _t0 = Date.now()  // TEMPORARY — see _rebuildRows
         if (root.textMode)
             grindText.forceActiveFocus()
         else
             root._centerWheels()
+        console.info("[Equipment] grind picker: onOpened TOTAL "
+                     + (Date.now() - _t0) + "ms")
     }
 
     // The header toggle. The icon names the DESTINATION, so switching is

--- a/qml/components/GrindRowSource.qml
+++ b/qml/components/GrindRowSource.qml
@@ -201,7 +201,7 @@ QtObject {
 
     // Return the grind setting `n` steps from `currentString`,
     // or "" to skip (unparseable / below a click-indexed dial floor).
-    function stepGrind(currentString, n, step) {
+    function stepGrind(currentString, n, step, precomputed) {
         var s = String(currentString == null ? "" : currentString).trim()
         if (s.length === 0)
             return ""
@@ -210,8 +210,15 @@ QtObject {
         //    "a+b") step through the notation-aware pipeline. Returns "" for a
         //    custom grinder, an unparseable value, or a click-indexed
         //    below-floor candidate — then the JS branches take over.
-        var viaCatalog = Settings.dye.stepGrinderSetting(root.grinderBrand, root.grinderModel,
-                                                         s, n * step, _stepDecimals(step, s))
+        //
+        // `precomputed` is this row's catalog answer when the caller already has
+        // it from stepGrinderSettingRange(). Same value, one crossing for the
+        // whole wheel instead of 801 — see that function. Undefined means "ask",
+        // which is what every single-row caller does.
+        var viaCatalog = (precomputed !== undefined)
+            ? precomputed
+            : Settings.dye.stepGrinderSetting(root.grinderBrand, root.grinderModel,
+                                              s, n * step, _stepDecimals(step, s))
         if (viaCatalog && viaCatalog.length > 0)
             return viaCatalog
 
@@ -321,11 +328,14 @@ QtObject {
     // May return a short (or empty) array when the anchor seeds few rows; the
     // caller (grindRowsFor) treats <= 2 rows as failure and falls through.
     function _windowAround(anchor, step) {
-        var canon = root.stepGrind(anchor, 0, step)
+        var catalog = Settings.dye.stepGrinderSettingRange(
+            root.grinderBrand, root.grinderModel, anchor, step,
+            -root.grindWindowSteps, root.grindWindowSteps, root._stepDecimals(step, anchor))
+        var canon = root.stepGrind(anchor, 0, step, catalog[root.grindWindowSteps])
         var out = []
         var seen = ({})
         for (var n = -root.grindWindowSteps; n <= root.grindWindowSteps; n++) {
-            var v = root.stepGrind(anchor, n, step)
+            var v = root.stepGrind(anchor, n, step, catalog[n + root.grindWindowSteps])
             if (v === "" || v === undefined) continue
             if (seen[v]) continue
             seen[v] = true
@@ -337,17 +347,54 @@ QtObject {
     // Candidate rows around an arbitrary value — the picker calls this with its
     // PENDING value when re-seeding after typed entry, so the wheel rebases on
     // what the user typed rather than snapping back to the old lattice.
+    // One-entry memo of the last generated row set.
+    //
+    // The rows are a pure function of (cur, step, grinderBrand, grinderModel):
+    // same inputs, same 801 strings. Reopening the picker without changing the
+    // value — and the text <-> wheel toggle, which rebuilds — regenerate an
+    // identical array, so they are served from here.
+    //
+    // `step` is part of the KEY and is re-read from the (indexed) query on every
+    // rebuild, so a step that moves misses by construction. The array is only
+    // ever read by its consumers, never mutated, so handing back the same object
+    // is safe — and returning an identical reference means QML does not signal a
+    // change, so the Tumbler skips rebuilding a model it already has.
+    property var _rowsMemoKey: ""
+    property var _rowsMemo: null
+
+    function _rowsKeyFor(cur, step) {
+        return String(cur) + "\u0000" + String(step) + "\u0000"
+             + String(root.grinderBrand) + "\u0000" + String(root.grinderModel)
+    }
+
     function grindRowsFor(cur) {
+        // TEMPORARY instrumentation (grind-picker open cost) — see
+        // GrindPickerDialog._rebuildRows. Remove with those.
+        var _t0 = Date.now()
         cur = String(cur == null ? "" : cur).trim()
         var step = root.grindStep()
+        var _tQuery = Date.now()
+        var _key = root._rowsKeyFor(cur, step)
+        if (root._rowsMemo !== null && root._rowsMemoKey === _key) {
+            console.info("[Equipment] grind picker: grindRowsFor step-query="
+                         + (_tQuery - _t0) + "ms generate=0ms rows="
+                         + root._rowsMemo.length + " (memo hit)")
+            return root._rowsMemo
+        }
         // Canonical current = the value reformatted to the step's decimals
         // (exactly what n === 0 produces); highlight whichever surviving row
         // equals it so clamp-edge dedup can't lose the highlight.
-        var canonicalCurrent = root.stepGrind(cur, 0, step)
+        // One crossing for the whole wheel. Entry i is row (i - grindWindowSteps);
+        // empty entries mean the catalog declined that row and stepGrind falls
+        // through to its JS branches, exactly as when it asked per row.
+        var catalog = Settings.dye.stepGrinderSettingRange(
+            root.grinderBrand, root.grinderModel, cur, step,
+            -root.grindWindowSteps, root.grindWindowSteps, root._stepDecimals(step, cur))
+        var canonicalCurrent = root.stepGrind(cur, 0, step, catalog[root.grindWindowSteps])
         var generated = []
         var seen = ({})
         for (var n = -root.grindWindowSteps; n <= root.grindWindowSteps; n++) {
-            var v = root.stepGrind(cur, n, step)
+            var v = root.stepGrind(cur, n, step, catalog[n + root.grindWindowSteps])
             if (v === "" || v === undefined) continue
             if (seen[v]) continue
             seen[v] = true
@@ -373,8 +420,19 @@ QtObject {
                         return win
                 }
             }
-            return root._observedFallback(cur)
+            var _fb = root._observedFallback(cur)
+            root._rowsMemoKey = _key
+            root._rowsMemo = _fb
+            console.info("[Equipment] grind picker: grindRowsFor step-query="
+                         + (_tQuery - _t0) + "ms generate=" + (Date.now() - _tQuery)
+                         + "ms rows=" + _fb.length + " (observed-fallback)")
+            return _fb
         }
+        root._rowsMemoKey = _key
+        root._rowsMemo = generated
+        console.info("[Equipment] grind picker: grindRowsFor step-query="
+                     + (_tQuery - _t0) + "ms generate=" + (Date.now() - _tQuery)
+                     + "ms rows=" + generated.length)
         return generated
     }
 
@@ -385,7 +443,9 @@ QtObject {
         var rpmSet = base > 0
         var anchor = rpmSet ? base : root.rpmDefaultAnchor
         // Once per snapshot, not once per row — this runs a query.
+        var _t0 = Date.now()  // TEMPORARY — see grindRowsFor
         var rpmStepValue = root.rpmStep()
+        var _tQuery = Date.now()
         var out = []
         var seen = ({})
         for (var n = -root.rpmWindowSteps; n <= root.rpmWindowSteps; n++) {
@@ -396,6 +456,9 @@ QtObject {
             seen[v] = true
             out.push({ value: v, isCurrent: rpmSet && n === 0 })
         }
+        console.info("[Equipment] grind picker: rpmRowsFor step-query="
+                     + (_tQuery - _t0) + "ms generate=" + (Date.now() - _tQuery)
+                     + "ms rows=" + out.length)
         return out
     }
 

--- a/qml/components/GrindRowSource.qml
+++ b/qml/components/GrindRowSource.qml
@@ -354,11 +354,24 @@ QtObject {
     // value — and the text <-> wheel toggle, which rebuilds — regenerate an
     // identical array, so they are served from here.
     //
-    // `step` is part of the KEY and is re-read from the (indexed) query on every
-    // rebuild, so a step that moves misses by construction. The array is only
-    // ever read by its consumers, never mutated, so handing back the same object
-    // is safe — and returning an identical reference means QML does not signal a
-    // change, so the Tumbler skips rebuilding a model it already has.
+    // ONLY the lattice path is stored. Its rows are generated from the key's own
+    // four inputs and nothing else, and `step` is re-read from the query on every
+    // rebuild, so a step that moves misses by construction.
+    //
+    // The two history-derived paths are deliberately NOT memoized:
+    // _observedFallback() and _medianObservedAnchor() both read
+    // getDistinctGrinderSettingsForGrinder(), which is a second input the key does
+    // not name. Storing them was a real bug — a grinder with non-numeric settings
+    // ("coarse"/"fine") takes the fallback on every open, and recording a new
+    // setting does not move `cur`, `step`, brand or model, so the memo kept
+    // serving a list the new setting was missing from for the rest of the session.
+    // That is the same invalidated-on-the-wrong-axis failure as the distinct-value
+    // cache CLAUDE.md records as deleted.
+    //
+    // The array is only ever read by its consumers, never mutated, so handing back
+    // the same object is safe. Returning an identical reference also means QML
+    // signals no change, so the Tumbler skips rebuilding a model it already has —
+    // measured as assign=0ms on a hit against 3ms on a miss.
     property var _rowsMemoKey: ""
     property var _rowsMemo: null
 
@@ -420,12 +433,12 @@ QtObject {
                         return win
                 }
             }
+            // Not memoized — see the memo declaration. This list comes from shot
+            // history, which the key does not name.
             var _fb = root._observedFallback(cur)
-            root._rowsMemoKey = _key
-            root._rowsMemo = _fb
             console.info("[Equipment] grind picker: grindRowsFor step-query="
                          + (_tQuery - _t0) + "ms generate=" + (Date.now() - _tQuery)
-                         + "ms rows=" + _fb.length + " (observed-fallback)")
+                         + "ms rows=" + _fb.length + " (observed-fallback, not memoized)")
             return _fb
         }
         root._rowsMemoKey = _key

--- a/src/core/grinderaliases.h
+++ b/src/core/grinderaliases.h
@@ -355,18 +355,26 @@ inline QStringList modelsForBrand(const QString& brand)
 // gracefully falls back to a default-constructed entry's notation
 // (NumericWithSuffix) so unknown grinders behave like plain numeric.
 //
-// Memoized on the last (brand, model): GrindRowSource.grindRowsFor() builds 801
-// rows (grindWindowSteps: 400) and every one reaches here through
-// SettingsDye::stepGrinderSetting with the grinder fixed — 801 linear scans of a
-// 93-entry table, two case-insensitive QString compares each, on the main thread
-// in front of the picker painting.
+// Memoized on the last (brand, model), for ONE caller: SettingsDye::
+// grinderIsClickIndexed(), which GrindRowSource.stepGrind() reaches per row on
+// the custom-grinder JS fallback. A grinder outside the registry misses, so each
+// call walks all 93 entries — the worst case, not the cheapest, which is why
+// NEGATIVE results are cached too. A window of ±400 steps around a small value
+// puts several hundred of those in front of the picker painting.
 //
-// NEGATIVE results are cached too: a custom grinder matches nothing, so it walks
-// all 93 entries and is the worst caller, not the cheapest.
+// It is NOT justified by the 801-row loop, and an earlier version of this comment
+// said it was. stepGrinderSettingRange() resolves the grinder once for the whole
+// wheel, so the per-row path through stepGrinderSetting no longer exists — see
+// that function, which records that memoizing this lookup did nothing for the
+// loop, because the cost there was the crossings rather than the work behind them.
+// The two statements only look contradictory if this one still claims the loop.
 //
-// thread_local because dialing_blocks and the ShotServer reach the registry from
-// their own threads. Cached pointers never dangle — allGrinders() returns a
-// function-local static by reference.
+// thread_local because dialing_blocks reaches the registry from a background
+// thread (dialing_blocks.cpp:1170). NOT the ShotServer, which an earlier draft
+// also named: it is parented to MainController and handleGrindCandidatesApi has
+// no thread wrapper, unlike its siblings in that file, so it runs on the main
+// thread. Cached pointers never dangle — allGrinders() returns a function-local
+// static by reference.
 inline const GrinderEntry* findEntry(const QString& brand, const QString& model)
 {
     struct Memo {

--- a/src/core/grinderaliases.h
+++ b/src/core/grinderaliases.h
@@ -57,7 +57,10 @@ struct LookupResult {
     bool found = false;
 };
 
-inline QVector<GrinderEntry> allGrinders()
+// By const reference: findEntry() returns a POINTER INTO this, and while it
+// returned by value that pointer stayed valid only because QVector is implicitly
+// shared, so the copy's buffer was the static's. Correct by luck, not lifetime.
+inline const QVector<GrinderEntry>& allGrinders()
 {
     static const QVector<GrinderEntry> entries = {
         // --- Niche ---
@@ -351,15 +354,41 @@ inline QStringList modelsForBrand(const QString& brand)
 // Returns nullptr when not found; the dialing-context payload code
 // gracefully falls back to a default-constructed entry's notation
 // (NumericWithSuffix) so unknown grinders behave like plain numeric.
+//
+// Memoized on the last (brand, model): GrindRowSource.grindRowsFor() builds 801
+// rows (grindWindowSteps: 400) and every one reaches here through
+// SettingsDye::stepGrinderSetting with the grinder fixed — 801 linear scans of a
+// 93-entry table, two case-insensitive QString compares each, on the main thread
+// in front of the picker painting.
+//
+// NEGATIVE results are cached too: a custom grinder matches nothing, so it walks
+// all 93 entries and is the worst caller, not the cheapest.
+//
+// thread_local because dialing_blocks and the ShotServer reach the registry from
+// their own threads. Cached pointers never dangle — allGrinders() returns a
+// function-local static by reference.
 inline const GrinderEntry* findEntry(const QString& brand, const QString& model)
 {
-    const auto& grinders = allGrinders();
-    for (const auto& e : grinders) {
+    struct Memo {
+        QString brand;
+        QString model;
+        const GrinderEntry* entry = nullptr;
+        bool valid = false;
+    };
+    thread_local Memo memo;
+    if (memo.valid && memo.brand == brand && memo.model == model)
+        return memo.entry;
+
+    const GrinderEntry* found = nullptr;
+    for (const auto& e : allGrinders()) {
         if (e.brand.compare(brand, Qt::CaseInsensitive) == 0
-            && e.model.compare(model, Qt::CaseInsensitive) == 0)
-            return &e;
+            && e.model.compare(model, Qt::CaseInsensitive) == 0) {
+            found = &e;
+            break;
+        }
     }
-    return nullptr;
+    memo = Memo{brand, model, found, true};
+    return found;
 }
 
 // Convenience: resolve a raw grinder string (e.g. shot.grinderModel) to

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -416,18 +416,16 @@ QStringList SettingsDye::knownGrinderModels(const QString& brand) const {
     return GrinderAliases::modelsForBrand(brand);
 }
 
-QString SettingsDye::stepGrinderSetting(const QString& brand, const QString& model,
-                                        const QString& current, double deltaUnits,
-                                        int decimals) const {
-    // Registry-only: a custom grinder (no match) returns "" so the caller keeps
-    // its plain-numeric / letter / history fallback, exactly as before.
-    const GrinderAliases::GrinderEntry* entry = GrinderAliases::findEntry(brand, model);
-    if (!entry)
-        return QString();
-    const auto linear = GrinderAliases::parseGrinderSetting(*entry, current);
-    if (!linear)
-        return QString();  // unparseable (e.g. pure letters) → caller's fallback
-    const double stepped = *linear + deltaUnits;
+// The per-delta half of stepGrinderSetting, once the grinder and the current
+// value are already resolved. Extracted rather than duplicated because
+// stepGrinderSettingRange() below resolves both ONCE and then calls this 801
+// times; a second copy of these rules is exactly the drift CLAUDE.md forbids,
+// and the two callers must agree row-for-row or the wheel and the web
+// datalist disagree about the same dial.
+QString SettingsDye::stepFromParsed(const GrinderAliases::GrinderEntry& entry,
+                                    double linear, const QString& current,
+                                    double deltaUnits, int decimals) {
+    const double stepped = linear + deltaUnits;
     // Below-zero candidates are skipped only on click-indexed (Compound)
     // grinders, keyed on the grinder's registry notation — NOT the current
     // value's written form — because a negative linear position is meaningless
@@ -435,7 +433,7 @@ QString SettingsDye::stepGrinderSetting(const QString& brand, const QString& mod
     // plain-numeric grinder can be a stepless collar whose zero is a user-set
     // calibration reference (Niche Zero), where dialling finer than zero is a
     // real operation, so negatives pass through.
-    if (stepped < 0.0 && entry->notation == GrinderAliases::SettingNotation::Compound)
+    if (stepped < 0.0 && entry.notation == GrinderAliases::SettingNotation::Compound)
         return QString();  // below the click-indexed dial floor → skip this row
 
     // Compound rotation ("a+b") renders in its own notation (rev/position
@@ -443,9 +441,9 @@ QString SettingsDye::stepGrinderSetting(const QString& brand, const QString& mod
     // compound-notation grinder whose setting is recorded as a plain number
     // (parseGrinderSetting accepts that — some Mignon users log "0.5") keeps the
     // numeric form instead of being re-notated to "0+0.5".
-    if (entry->notation == GrinderAliases::SettingNotation::Compound
+    if (entry.notation == GrinderAliases::SettingNotation::Compound
         && current.contains(QLatin1Char('+')))
-        return GrinderAliases::formatGrinderSetting(*entry, stepped);
+        return GrinderAliases::formatGrinderSetting(entry, stepped);
 
     // Plain-numeric: honor the caller's step precision (the grind widget passes
     // the decimals of its history-derived step, up to 2), not
@@ -458,6 +456,60 @@ QString SettingsDye::stepGrinderSetting(const QString& brand, const QString& mod
         if (s.endsWith(QLatin1Char('.'))) s.chop(1);
     }
     return s;
+}
+
+QString SettingsDye::stepGrinderSetting(const QString& brand, const QString& model,
+                                        const QString& current, double deltaUnits,
+                                        int decimals) const {
+    // Registry-only: a custom grinder (no match) returns "" so the caller keeps
+    // its plain-numeric / letter / history fallback, exactly as before.
+    const GrinderAliases::GrinderEntry* entry = GrinderAliases::findEntry(brand, model);
+    if (!entry)
+        return QString();
+    const auto linear = GrinderAliases::parseGrinderSetting(*entry, current);
+    if (!linear)
+        return QString();  // unparseable (e.g. pure letters) → caller's fallback
+    return stepFromParsed(*entry, *linear, current, deltaUnits, decimals);
+}
+
+// One call for a whole wheel, instead of one per row.
+//
+// GrindRowSource.grindRowsFor() builds 801 candidates (grindWindowSteps: 400)
+// and every one crossed into C++ to re-resolve the same grinder and re-parse the
+// same current value. The QML profiler measured that loop at 186 ms over 8020
+// calls across ten opens — 63% of the picker's whole open — and a memo on the
+// registry lookup did not touch it, because the cost is the 801 crossings and
+// their argument marshalling, not the work behind them. Measured again after
+// memoizing the decimal count inside the loop: no change. The only thing that
+// helps is not making the calls.
+//
+// Returns exactly what stepGrinderSetting would return for each n in
+// [fromN, toN], INCLUDING the empty strings — the caller distinguishes "the
+// catalog declined this row" from "the catalog produced a value" and falls back
+// per row, so collapsing the empties here would silently drop its JS branches.
+QStringList SettingsDye::stepGrinderSettingRange(const QString& brand, const QString& model,
+                                                 const QString& current, double stepUnits,
+                                                 int fromN, int toN, int decimals) const {
+    QStringList out;
+    if (toN < fromN)
+        return out;
+    out.reserve(toN - fromN + 1);
+
+    const GrinderAliases::GrinderEntry* entry = GrinderAliases::findEntry(brand, model);
+    const std::optional<double> linear =
+        entry ? GrinderAliases::parseGrinderSetting(*entry, current) : std::optional<double>{};
+    // A custom grinder or an unparseable value declines every row, exactly as
+    // stepGrinderSetting does one at a time. Fill rather than return short: the
+    // caller indexes by n and a shorter list would silently shift the window.
+    if (!entry || !linear) {
+        for (int n = fromN; n <= toN; ++n)
+            out.append(QString());
+        return out;
+    }
+
+    for (int n = fromN; n <= toN; ++n)
+        out.append(stepFromParsed(*entry, *linear, current, n * stepUnits, decimals));
+    return out;
 }
 
 QStringList SettingsDye::knownBasketBrands() const {

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -8,6 +8,10 @@
 
 class CoffeeBagStorage;
 class EquipmentStorage;
+// Forward-declared rather than including grinderaliases.h: only the private
+// stepFromParsed() helper names it, and the header comment above is explicit
+// that this file exists to keep settings.h's include footprint small.
+namespace GrinderAliases { struct GrinderEntry; }
 
 // DYE (Describe Your Espresso) metadata. Split from Settings to keep
 // settings.h's transitive-include footprint small.
@@ -233,6 +237,18 @@ public:
                                            const QString& current, double deltaUnits,
                                            int decimals = 1) const;
 
+    // Batch form: one call for a whole wheel of candidates, n running fromN..toN
+    // with a delta of n * stepUnits. Entry i is what stepGrinderSetting would
+    // return for n = fromN + i, empty strings included — the caller falls back
+    // per row on an empty, so they carry meaning and are not collapsed.
+    //
+    // Exists because the grind picker made 801 of these calls per open and the
+    // crossings, not the work behind them, were the cost. See the definition.
+    Q_INVOKABLE QStringList stepGrinderSettingRange(const QString& brand, const QString& model,
+                                                    const QString& current, double stepUnits,
+                                                    int fromN, int toN,
+                                                    int decimals = 1) const;
+
     // True when the grinder's registry notation is click-indexed (Compound,
     // e.g. Eureka Mignon "a+b", 1Zpresso). Callers whose own numeric stepping
     // runs after stepGrinderSetting's "" fall-through use this to keep skipping
@@ -396,6 +412,13 @@ signals:
     void activeBagYieldSpecChanged();
 
 private:
+    // Shared core of stepGrinderSetting and stepGrinderSettingRange — the
+    // per-delta rules, once the grinder and current value are resolved.
+    static QString stepFromParsed(const GrinderAliases::GrinderEntry& entry,
+                                  double linear, const QString& current,
+                                  double deltaUnits, int decimals);
+
+
     void ensureDyeCacheLoaded() const;
     // Copy the bag's fields into the dye cache (bean identity always —
     // including empties, absence is silence; grinder/dose only when the bag

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2175,6 +2175,72 @@ bool ShotHistoryStorage::runMigrations()
         }
     }
 
+    // The grind picker's two reads (grinderWideNumericSettings, grinderWideRpms)
+    // filter on equipment_id with nothing indexed on it, so SQLite scans every
+    // row — and cost tracks table BYTES, because profile_json and debug_log are
+    // TEXT on `shots` and a page read drags them along. Both run synchronously
+    // from GrindPickerDialog.onAboutToShow, in front of the dialog painting.
+    //
+    // Measured: 435 ms and 483 ms on a 5,788-shot field database (Android
+    // tablet, user log 2026-09-01) — a ~0.9 s hang on open. Desktop SQLite on
+    // synthetic copies: 3.6/5.1/10.5 ms at 13.6/24.2/61.1 MB before, 0.17 ms
+    // after, the plan moving from `SCAN shots` to `SEARCH shots USING COVERING
+    // INDEX`. Both indexes together cost 0.15 MB.
+    //
+    // Covering is the point, not the constant factor: the indexed plan never
+    // opens the table, so what is eliminated is exactly the cold random I/O a
+    // slow device is worst at. The win grows on weaker storage.
+    //
+    // getDistinctGrinderSettingsForGrinder() is the same shape and is covered by
+    // the first index too.
+    //
+    // NOT in createTables(): equipment_id and rpm arrive in migration 23, so a
+    // fresh database has no such column when createTables() runs — the trap the
+    // idx_shots_grinder comment there records.
+    if (currentVersion >= 39 && currentVersion < 40) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 40 "
+                    "(grind-step covering indexes)";
+        query.finish();
+        DbWriteTxn txn = DbWriteTxn::begin(m_db, "migration 40 grind step indexes", 1);
+        if (!txn.ok()) {
+            qWarning() << "ShotHistoryStorage: migration 40 could not start a transaction"
+                          " - will retry next launch (the grind picker stays slow until"
+                          " it completes; nothing else is affected)";
+        } else {
+            // The bump is NOT gated on the CREATE INDEXes. An index is not a
+            // schema fact — both queries return identical results without it —
+            // so gating would buy a database that fails once and re-runs this
+            // block on every launch forever. Log and move on.
+            //
+            // The schema_version stamp IS a correctness fact and stays in the
+            // transaction: a DELETE committing without its INSERT empties the
+            // table, createTables() re-seeds it to 1, and the whole chain re-runs.
+            if (!query.exec("CREATE INDEX IF NOT EXISTS idx_shots_equip_grind "
+                            "ON shots(equipment_id, grinder_setting)")) {
+                qWarning() << "ShotHistoryStorage: migration 40 could not create"
+                              " idx_shots_equip_grind -" << query.lastError().text()
+                           << "- the grind picker falls back to a full scan";
+            }
+            if (!query.exec("CREATE INDEX IF NOT EXISTS idx_shots_equip_rpm "
+                            "ON shots(equipment_id, rpm)")) {
+                qWarning() << "ShotHistoryStorage: migration 40 could not create"
+                              " idx_shots_equip_rpm -" << query.lastError().text()
+                           << "- the grind picker falls back to a full scan";
+            }
+            const bool stamped =
+                query.exec("DELETE FROM schema_version")
+                && query.exec(QStringLiteral("INSERT INTO schema_version (version) VALUES (40)"));
+            if (stamped && txn.commit()) {
+                currentVersion = 40;
+                qDebug() << "ShotHistoryStorage: migration 40 complete";
+            } else {
+                qWarning() << "ShotHistoryStorage: migration 40 incomplete - will retry"
+                              " next launch (the grind picker stays slow until it"
+                              " completes; nothing else is affected)";
+            }
+        }
+    }
+
     m_schemaVersion = currentVersion;
     return true;
 }

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -73,6 +73,18 @@ public:
         return m_schemaVersionAtStartKnown && m_schemaVersionAtStart < v && m_schemaVersion >= v;
     }
 
+    // The version a database lands on after the full migration chain. BUMP THIS
+    // WITH EVERY NEW MIGRATION. It exists because the tests spelled the terminal
+    // version as a bare literal in 24 places across two files, so every migration
+    // had to find and edit all 24 — and a missed one fails as "expected 39, got
+    // 40", which reads like a migration bug rather than a stale test.
+    //
+    // runMigrations()' blocks deliberately keep their own literals: each stamps
+    // the version IT introduces, which must not move when a later migration is
+    // added. This is not their source — it is the total they must reach, and
+    // freshDbCreatesSchema() is what checks that they do.
+    static constexpr int kCurrentSchemaVersion = 40;
+
     // Save a completed shot (async). Extracts data on main thread, runs DB work on background thread.
     // Returns 0 if async save started, -1 if preconditions not met (shotSaved(-1) also emitted).
     // Actual shot ID delivered via shotSaved() signal.

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -1147,21 +1147,28 @@ static double deriveGrindStep(const QList<double>& sortedDistinct)
 // where grindStep() prefers the pool to a blind 1.0 default. Both are second
 // attempts after a scoped one failed, never a first choice.
 //
-// Cost, measured with a fresh connection per run: 3.3 ms median / 87 ms worst on
-// a real 1,124-shot / 18.5 MB database; 37 ms median / 41 ms worst on a 16x copy
-// (17,984 shots / 157 MB). The more expensive of the two read shapes in this file
-// — a correlated equipment_id IN (SELECT ...) subquery over `shots`, whose cost
-// tracks table BYTES because a page read drags the profile_json and debug_log
-// blobs along. Two call paths reach it, and the frequency argument has to cover
-// both: GrindRowSource.grindStep() and the ShotServer's grind-candidates
-// endpoint build a picker's rows, while queryGrinderContext (below) builds the
-// AI dialing/advisor context. Neither is per frame, per keystroke, or a binding.
+// Served by idx_shots_equip_grind (migration 40). Without it this is a full
+// `SCAN shots` whose cost tracks table BYTES, not row count, because a page read
+// drags profile_json and debug_log along. Indexed, the plan is `SEARCH shots
+// USING COVERING INDEX` and the table is never opened.
+//
+// Measured: 435 ms and 483 ms for this and its RPM twin on a 5,788-shot Android
+// database (user log 2026-09-01) — a ~0.9 s hang, since
+// GrindPickerDialog.onAboutToShow calls both before painting. Desktop SQLite on
+// synthetic copies: 3.6 / 5.1 / 10.5 ms at 13.6 / 24.2 / 61.1 MB before, 0.17 ms
+// after. Do not judge an unindexed variant by the desktop figures — the gap
+// between 10.5 ms and 483 ms is the machine this has to hold for.
+//
+// Three call paths reach it: GrindRowSource.grindStep() and the ShotServer's
+// grind-candidates endpoint build a picker's rows, while queryGrinderContext
+// (below) builds the AI dialing/advisor context. None is per frame, per
+// keystroke, or a binding.
 //
 // (Until #1725 the QML side WAS a binding, and this sentence described it as
-// one; the cost is unchanged but the frequency is not, so do not read the old
-// shape back into it. It then listed only the two picker callers, which read as
-// exhaustive and was not — queryGrinderContext returns early on an EMPTY model,
-// which is a narrower thing than never calling this.)
+// one; do not read the old shape back into it. It then listed only the two
+// picker callers, which read as exhaustive and was not — queryGrinderContext
+// returns early on an EMPTY model, which is a narrower thing than never
+// calling this.)
 //
 // `queryOk` reports whether the QUERY ran, not whether it found anything. A failed
 // query and a grinder with no numeric history both yield an empty list, and the
@@ -1215,10 +1222,11 @@ static QList<double> grinderWideNumericSettings(QSqlDatabase& db, const QString&
 // all-grinders branch, because pooling RPMs across different grinders describes
 // no real dial. Both callers guard for that.
 //
-// Same shape and same cost as grinderWideNumericSettings above (3.3 ms median /
-// 87 ms worst on a real 18.5 MB database), over the integer rpm column instead of
-// the text one. `queryOk` reports whether the query RAN, so the caller can tell a
-// failure from a grinder that simply has no recorded RPMs.
+// Same shape and same cost as grinderWideNumericSettings above — see its comment
+// for the measurements and for why the covering index matters more on slow
+// storage. Served by idx_shots_equip_rpm (migration 40), over the integer rpm
+// column instead of the text one. `queryOk` reports whether the query RAN, so the
+// caller can tell a failure from a grinder that simply has no recorded RPMs.
 static QList<double> grinderWideRpms(QSqlDatabase& db, const QString& grinderModel,
                                      bool* queryOk = nullptr)
 {

--- a/src/network/grindcandidates.h
+++ b/src/network/grindcandidates.h
@@ -2,6 +2,7 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <QSet>
 #include <QString>
 #include <QStringList>
@@ -54,17 +55,44 @@ struct Inputs {
                                  // the caller)
 };
 
-// Decimal places come from the STEP, not the value (1.0 -> 0, 0.5 -> 1,
-// 0.25 -> 2), mirroring GrindRowSource._stepDecimals. Bounded via the 3-decimal
-// round-trip so a float-dirty step (0.1 + 0.2) cannot produce a 17-decimal
-// label.
-inline int stepDecimals(double step)
+// Decimal places for a stepped label: the STEP's precision, but NEVER fewer than
+// the VALUE already has. Bounded via the 3-decimal round-trip so a float-dirty
+// step (0.1 + 0.2) cannot produce a 17-decimal label.
+//
+// The max with the value is not a refinement, it is #1713. Step alone reformats a
+// user's own setting out of existence: history too thin to derive a step falls
+// back to 1.0, which is 0 decimals, so a recorded "1.1" renders as "1" — absent
+// from the datalist, and silently rewritten by the n=0 suggestion. This function
+// took the step alone while its comment claimed it mirrored
+// GrindRowSource._stepDecimals, which has taken the max since #1713; the app
+// wheel offered 0.1/1.1/2.1 for a record whose web datalist offered 0/1/2.
+//
+// `currentValue` defaults to empty only so the signature stays usable step-only.
+// There is exactly one caller today and it passes the value. The RPM window is
+// NOT one — it steps in qint64 and never formats decimals at all.
+inline int decimalsOf(double x)
 {
-    QString s = QString::number(step, 'f', 3);
+    QString s = QString::number(x, 'f', 3);
     while (s.endsWith(QLatin1Char('0'))) s.chop(1);
     if (s.endsWith(QLatin1Char('.'))) s.chop(1);
     const qsizetype dot = s.indexOf(QLatin1Char('.'));
     return dot < 0 ? 0 : static_cast<int>(s.size() - dot - 1);
+}
+
+inline int stepDecimals(double step, const QString& currentValue = QString())
+{
+    int d = decimalsOf(step);
+    const QString v = currentValue.trimmed();
+    // Same guard as the QML: only a plain numeric value contributes its
+    // precision. "coarse" or "1+4" has none to preserve here.
+    static const QRegularExpression plainNumeric(QStringLiteral("^-?\\d+(\\.\\d+)?$"));
+    if (!v.isEmpty() && plainNumeric.match(v).hasMatch()) {
+        bool ok = false;
+        const double parsed = v.toDouble(&ok);
+        if (ok)
+            d = qMax(d, decimalsOf(parsed));
+    }
+    return d;
 }
 
 // Format a stepped value at the step's precision, trailing zeros stripped so
@@ -102,7 +130,7 @@ inline QJsonObject build(SettingsDye* dye, const Inputs& in)
         return out;
 
     const double step = in.grindStep > 0.0 ? in.grindStep : 1.0;
-    const int decimals = stepDecimals(step);
+    const int decimals = stepDecimals(step, in.current);
 
     QJsonArray grind;
     if (!in.current.isEmpty()) {

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -890,7 +890,7 @@ private slots:
             QCOMPARE(q.value(0).toInt(), 0);  // existing rows default to 0
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 39);  // chain runs on to the latest (shots.flow_calibration)
+            QCOMPARE(q.value(0).toInt(), ShotHistoryStorage::kCurrentSchemaVersion);  // chain runs on to the latest
         });
     }
 
@@ -1288,7 +1288,7 @@ private slots:
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 39);  // chain runs on to the latest (shots.flow_calibration)
+            QCOMPARE(q.value(0).toInt(), ShotHistoryStorage::kCurrentSchemaVersion);  // chain runs on to the latest
         });
     }
 
@@ -1321,7 +1321,7 @@ private slots:
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 39);  // chain runs on to the latest (shots.flow_calibration)
+            QCOMPARE(q.value(0).toInt(), ShotHistoryStorage::kCurrentSchemaVersion);  // chain runs on to the latest
             // The repaired table is writable — insertRecipeStatic binds
             // rpm_pinned unconditionally, so it would fail wholesale if the
             // ALTER hadn't landed.

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -3,6 +3,7 @@
 #include <QSqlDatabase>
 #include <QSqlQuery>
 #include <QSqlError>
+#include <QSqlRecord>
 #include <QTemporaryDir>
 #include <QDateTime>
 #include <QJsonDocument>
@@ -256,7 +257,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
             QVERIFY(hasTable(db, "recipes"));  // migration 25 (add-recipes)
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
         });
     }
 
@@ -345,7 +346,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -474,7 +475,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
         });
     }
 
@@ -488,7 +489,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
         });
     }
 
@@ -520,7 +521,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 30
 
         withRawDb(path, "v29_verify30", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             QVERIFY(q.exec(QString("SELECT grind_pinned, rpm_pinned FROM recipes "
                                    "WHERE id = %1").arg(recipeId)));
@@ -555,7 +556,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 31
 
         withRawDb(path, "v30_verify31", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             QVERIFY(q.exec(QString("SELECT temp_offset_c, temp_override_c FROM recipes "
                                    "WHERE id = %1").arg(recipeId)));
@@ -596,7 +597,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 32
 
         withRawDb(path, "v31_verify32", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QVERIFY(hasColumn(db, "shots", "storage_hint"));
             QVERIFY(hasColumn(db, "shots", "opened_date"));
             QVERIFY(hasColumn(db, "coffee_bags", "storage_hint"));
@@ -635,7 +636,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 33
 
         withRawDb(path, "v32_verify33", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QVERIFY(hasColumn(db, "shots", "taste_balance"));
             QVERIFY(hasColumn(db, "shots", "taste_body"));
             QVERIFY(!hasColumn(db, "coffee_bags", "taste_balance"));
@@ -692,7 +693,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 36
 
         withRawDb(path, "v36_verify", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             // The stranded shot now hangs off the surviving package.
             QVERIFY(q.exec(QStringLiteral("SELECT equipment_id FROM shots WHERE id = %1")
@@ -759,7 +760,7 @@ private slots:
         // one that the second fold deleted.
         QCOMPARE(healedTo, full);
         withRawDb(path, "v36_active_verify", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             QVERIFY(q.exec(QStringLiteral("SELECT COUNT(*) FROM equipment_packages WHERE id IN (%1,%2)")
                                .arg(bare1).arg(mid)));
@@ -802,7 +803,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 34
 
         withRawDb(path, "v34_verify", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT yield_value, yield_mode, yield_g FROM recipes WHERE name = 'With'"));
             QVERIFY(q.next());
@@ -912,7 +913,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 39
 
         withRawDb(path, "v39_verify", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             QVERIFY(q.exec(QString("SELECT flow_calibration FROM shots WHERE id = %1").arg(legacyShot)));
             QVERIFY(q.next());
@@ -938,7 +939,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
         });
     }
 
@@ -960,7 +961,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QSqlQuery q(db);
             // grinder_brand was dropped in migration 23; grinder_setting (the
             // surviving per-shot dial-in) exercises the same NULL-tolerance path.
@@ -1140,7 +1141,7 @@ private slots:
                 }
             }
         });
-        QCOMPARE(versionFound, 39);  // latest after full chain
+        QCOMPARE(versionFound, ShotHistoryStorage::kCurrentSchemaVersion);  // latest after full chain
         QVERIFY2(!hasEnjoymentSource,
                  "enjoyment_source column must be absent after migration 16");
     }
@@ -1378,7 +1379,7 @@ private slots:
             }
         });
 
-        QCOMPARE(versionFound, 39);  // latest after full chain
+        QCOMPARE(versionFound, ShotHistoryStorage::kCurrentSchemaVersion);  // latest after full chain
         QVERIFY2(columnGone, "enjoyment_source column must be dropped");
         // Inferred rows reset to 0 (unrated), NOT to the stale 50 seeded
         // above — an app-invented rating becomes unrated, and the back-sync
@@ -1716,7 +1717,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1750,7 +1751,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v28_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QVERIFY(hasColumn(db, "recipes", "drink_type"));
             QVERIFY(hasColumn(db, "coffee_bags", "kind"));
             QSqlQuery q(db);
@@ -1830,7 +1831,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v20_after_retry", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             // The retry ran the WHOLE deferred chain, not just migration 20:
             // migration 21's rename landed too (post-condition column present).
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
@@ -1876,7 +1877,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_after_retry", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 39);
+            QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1943,7 +1944,7 @@ private slots:
         };
 
         { ShotHistoryStorage s; initAndClose(path, s); }
-        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), 39); });
+        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), ShotHistoryStorage::kCurrentSchemaVersion); });
         QCOMPARE(packageCount(), 1);             // default package created from current settings
         { ShotHistoryStorage s; initAndClose(path, s); }
         QCOMPARE(packageCount(), 1);             // gate prevented a duplicate on re-init
@@ -2711,6 +2712,77 @@ private slots:
         QCOMPARE(spy.last().at(2).toInt(), 1);
 
         s.close();
+    }
+
+    // Migration 40: the grind picker's reads must be served by a COVERING index,
+    // not merely by an index that exists. An index SQLite declines to use, or
+    // uses non-covering, buys nothing — and that is the silent failure a future
+    // edit introduces: add a column to the SELECT, reorder the WHERE, change
+    // grinderModelMatchSql, and the plan falls back to `SCAN shots` with every
+    // test still green. That scan cost 435 ms and 483 ms on a 5,788-shot field
+    // database, so the PLAN is what is under test.
+    //
+    // The WHERE half comes from grinderModelMatchSql() so a change to the
+    // matching rule reaches this test. The SELECT half is spelled out — it is
+    // what makes the index covering, and tracking production there would defeat
+    // the assertion.
+    void migration40IndexesCoverTheGrindStepQueries() {
+        QString path = freshDbPath();
+        ShotHistoryStorage storage;
+        initAndClose(path, storage);
+
+        withRawDb(path, "m40_plan", [](QSqlDatabase& db) {
+            QVERIFY(hasIndex(db, "idx_shots_equip_grind"));
+            QVERIFY(hasIndex(db, "idx_shots_equip_rpm"));
+
+            // Rows so the planner is choosing against real content rather than
+            // an empty table.
+            ShotRow r;
+            r.grinderBrand = QStringLiteral("DF");
+            r.grinderModel = QStringLiteral("DF83V");
+            for (int i = 0; i < 12; ++i) {
+                r.uuid = QStringLiteral("m40-%1").arg(i);
+                r.timestamp = 1700000000 + i;
+                r.profileName = QStringLiteral("p");
+                r.grinderSetting = QString::number(1.0 + i * 0.5);
+                r.rpm = 600 + i * 100;
+                QVERIFY(ShotRowFixtures::insertShot(db, r) > 0);
+            }
+            QVERIFY(QSqlQuery(db).exec(QStringLiteral("ANALYZE")));
+
+            const QString match = ShotHistoryStorage::grinderModelMatchSql(QStringLiteral(":model"));
+            const struct { const char* label; QString sql; QString index; } cases[] = {
+                { "grind_setting",
+                  QStringLiteral("SELECT DISTINCT grinder_setting FROM shots "
+                                 "WHERE grinder_setting IS NOT NULL AND grinder_setting != '' "
+                                 "AND ") + match,
+                  QStringLiteral("idx_shots_equip_grind") },
+                { "rpm",
+                  QStringLiteral("SELECT DISTINCT rpm FROM shots "
+                                 "WHERE rpm IS NOT NULL AND rpm > 0 AND ") + match,
+                  QStringLiteral("idx_shots_equip_rpm") },
+            };
+
+            for (const auto& c : cases) {
+                QSqlQuery q(db);
+                QVERIFY2(q.prepare(QStringLiteral("EXPLAIN QUERY PLAN ") + c.sql),
+                         qPrintable(QStringLiteral("%1: prepare failed: %2")
+                                        .arg(QLatin1String(c.label), q.lastError().text())));
+                q.bindValue(QStringLiteral(":model"), QStringLiteral("DF83V"));
+                QVERIFY2(q.exec(), qPrintable(q.lastError().text()));
+
+                QString plan;
+                while (q.next())
+                    plan += q.value(q.record().count() - 1).toString() + QLatin1Char(';');
+
+                QVERIFY2(plan.contains(QStringLiteral("COVERING INDEX ") + c.index),
+                         qPrintable(QStringLiteral("%1: expected a covering scan of %2, got: %3")
+                                        .arg(QLatin1String(c.label), c.index, plan)));
+                QVERIFY2(!plan.contains(QStringLiteral("SCAN shots")),
+                         qPrintable(QStringLiteral("%1: fell back to a full table scan: %2")
+                                        .arg(QLatin1String(c.label), plan)));
+            }
+        });
     }
 
 };

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -2736,7 +2736,12 @@ private slots:
             QVERIFY(hasIndex(db, "idx_shots_equip_rpm"));
 
             // Rows so the planner is choosing against real content rather than
-            // an empty table.
+            // an empty table. Deliberately NO ANALYZE: nothing in src/history
+            // ever runs it, so a shipped database has no sqlite_stat1 and SQLite
+            // plans these from default row-count estimates. Creating stats here
+            // would assert a configuration no install is in — and if a future
+            // change made the indexed plan win only WITH stats, this would stay
+            // green while every real database fell back to a full scan.
             ShotRow r;
             r.grinderBrand = QStringLiteral("DF");
             r.grinderModel = QStringLiteral("DF83V");
@@ -2748,8 +2753,6 @@ private slots:
                 r.rpm = 600 + i * 100;
                 QVERIFY(ShotRowFixtures::insertShot(db, r) > 0);
             }
-            QVERIFY(QSqlQuery(db).exec(QStringLiteral("ANALYZE")));
-
             const QString match = ShotHistoryStorage::grinderModelMatchSql(QStringLiteral(":model"));
             const struct { const char* label; QString sql; QString index; } cases[] = {
                 { "grind_setting",

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -3210,6 +3210,74 @@ private slots:
         QCOMPARE(dye->stepGrinderSetting("Turin", "DF83V", "20", 2.0), QString("22"));
     }
 
+    // stepGrinderSettingRange must be indistinguishable from calling
+    // stepGrinderSetting once per row. The picker builds its wheel from the
+    // batch form and falls back per row on an empty entry, so a divergence in
+    // EITHER direction is a wrong wheel: a spurious value hides the JS fallback
+    // that should have run, and a spurious empty invents a fallback row.
+    //
+    // Both forms now share stepFromParsed(), so this is the test that keeps the
+    // extraction honest — it is the only thing that would catch the batch loop
+    // drifting from the single-row rules.
+    void stepGrinderSettingRangeMatchesTheSingleRowForm_data() {
+        QTest::addColumn<QString>("brand");
+        QTest::addColumn<QString>("model");
+        QTest::addColumn<QString>("current");
+        QTest::addColumn<double>("step");
+        QTest::addColumn<int>("decimals");
+
+        // Registry plain-numeric, including a step that reaches below zero (a
+        // stepless collar keeps negatives; the batch must not clamp them away).
+        QTest::newRow("niche-zero-0.25")   << "Niche" << "Zero" << "8"    << 0.25 << 2;
+        QTest::newRow("niche-zero-below0") << "Niche" << "Zero" << "0.5"  << 0.25 << 2;
+        // Compound, in its own notation — exercises rev carry AND the
+        // click-indexed below-floor skip, which is where empties come from.
+        QTest::newRow("mignon-compound")   << "Eureka" << "Mignon Specialita" << "1+4" << 1.0 << 1;
+        QTest::newRow("mignon-floor")      << "Eureka" << "Mignon Specialita" << "0+2" << 1.0 << 1;
+        // Compound grinder recorded as a plain number: must stay numeric, not
+        // be re-notated — a rule that lives in stepFromParsed and could be lost.
+        QTest::newRow("mignon-plain")      << "Eureka" << "Mignon Specialita" << "2.5" << 0.5 << 2;
+        // Different revolution length, so a shared-entry bug shows up.
+        QTest::newRow("jmax-compound")     << "1Zpresso" << "J-Max" << "0+29" << 1.0 << 1;
+        // Not in the registry: every row must decline, and the list must still
+        // be full length or the caller's window silently shifts.
+        QTest::newRow("custom-grinder")    << "Homebuilt" << "No Such" << "20" << 0.5 << 1;
+        // In the registry but unparseable (pure letters) — same, via the other
+        // early return.
+        QTest::newRow("unparseable")       << "Niche" << "Zero" << "AB" << 1.0 << 1;
+        QTest::newRow("empty-current")     << "Niche" << "Zero" << ""   << 1.0 << 1;
+    }
+
+    void stepGrinderSettingRangeMatchesTheSingleRowForm() {
+        QFETCH(QString, brand);
+        QFETCH(QString, model);
+        QFETCH(QString, current);
+        QFETCH(double, step);
+        QFETCH(int, decimals);
+
+        SettingsDye* dye = m_settings.dye();
+        // Narrower than the picker's ±400 so the table stays quick; the loop is
+        // uniform in n, so the window width is not what could break.
+        const int span = 12;
+        const QStringList batch =
+            dye->stepGrinderSettingRange(brand, model, current, step, -span, span, decimals);
+
+        QCOMPARE(batch.size(), 2 * span + 1);
+        for (int n = -span; n <= span; ++n) {
+            const QString one = dye->stepGrinderSetting(brand, model, current, n * step, decimals);
+            QCOMPARE(batch.at(n + span), one);
+        }
+    }
+
+    // Degenerate window: toN < fromN yields an empty list rather than a
+    // one-element one. The caller indexes by offset, so an off-by-one here
+    // shifts every row of the wheel.
+    void stepGrinderSettingRangeHandlesAnEmptyWindow() {
+        SettingsDye* dye = m_settings.dye();
+        QVERIFY(dye->stepGrinderSettingRange("Niche", "Zero", "8", 0.25, 1, 0, 2).isEmpty());
+        QCOMPARE(dye->stepGrinderSettingRange("Niche", "Zero", "8", 0.25, 0, 0, 2).size(), 1);
+    }
+
 };
 
 QTEST_GUILESS_MAIN(tst_Settings)

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -2814,6 +2814,43 @@ private slots:
         QVERIFY(g.contains("1.5"));
     }
 
+    // #1713 on the web surface: the datalist must keep the precision the user's
+    // OWN value already has, not just the step's.
+    //
+    // stepDecimals() took the step alone while its comment claimed it mirrored
+    // GrindRowSource._stepDecimals, which has taken the max with the value since
+    // #1713. The failure is not a rounding nit: with history too thin to derive a
+    // step, grindStep is 0 and the endpoint falls back to 1.0 = zero decimals, so
+    // a recorded "1.1" formats to "1". The user's own setting vanishes from the
+    // dropdown AND the n=0 suggestion silently rewrites it, which is exactly the
+    // reported shape of #1713.
+    void grindCandidates_keepsThePrecisionOfTheUsersOwnValue() {
+        GrindCandidates::Inputs in;
+        in.brand = "Niche"; in.model = "Zero";
+        in.current = "1.1";
+        in.grindStep = 0.0;   // too thin to derive -> the 1.0 fallback, 0 decimals
+        const QStringList g = grindOf(GrindCandidates::build(m_settings.dye(), in));
+
+        // The value itself survives, at its own precision.
+        QVERIFY2(g.contains("1.1"), qPrintable("datalist lost the user's value: " + g.join(',')));
+        // And the whole lattice carries that precision rather than collapsing to
+        // integers - "1" appearing at all would mean 1.1 was reformatted away.
+        QVERIFY2(g.contains("0.1"), qPrintable(g.join(',')));
+        QVERIFY2(g.contains("2.1"), qPrintable(g.join(',')));
+        QVERIFY2(!g.contains("1"), qPrintable("1.1 was reformatted to 1: " + g.join(',')));
+
+        // A step FINER than the value still wins - the max runs both ways.
+        in.grindStep = 0.25;
+        const QStringList q = grindOf(GrindCandidates::build(m_settings.dye(), in));
+        QVERIFY2(q.contains("1.35"), qPrintable(q.join(',')));
+
+        // A non-numeric value contributes no precision and must not throw the
+        // step's own decimals away.
+        in.current = "coarse"; in.grindStep = 0.5;
+        const QStringList c = grindOf(GrindCandidates::build(m_settings.dye(), in));
+        QVERIFY(!c.isEmpty());
+    }
+
     void grindCandidates_positiveAnchorHasNoNegatives() {
         GrindCandidates::Inputs in;
         in.brand = "Niche"; in.model = "Zero";

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -3162,6 +3162,54 @@ private slots:
         QCOMPARE(obj->property("themeName").toString(), QStringLiteral("qml-chain-written"));
     }
 
+    // GrinderAliases::findEntry() memoizes its last (brand, model) lookup. Its
+    // failure shape is a STALE HIT: answer the second grinder with the first
+    // one's entry. Nothing else in the suite alternates grinders within one call
+    // sequence, so nothing else can catch it.
+    //
+    // Asserted through stepGrinderSetting() because the notation reached through
+    // the memo is what the picker consumes, and the grinders below disagree
+    // about it.
+    void findEntryMemoDoesNotServeAStaleGrinder() {
+        SettingsDye* dye = m_settings.dye();
+
+        // Alternate, so every call but the first is a memo hit for the WRONG
+        // grinder if the key is ignored. Repeated to outlive a one-deep memo
+        // that happens to be refreshed by the previous line.
+        for (int i = 0; i < 3; ++i) {
+            QCOMPARE(dye->stepGrinderSetting("Turin", "DF83V", "20", 2.0), QString("22"));
+            QCOMPARE(dye->stepGrinderSetting("Eureka", "Mignon Specialita", "1+4", 1.0),
+                     QString("1+5"));
+        }
+
+        // Same brand, different model: the MODEL half of the key alone must
+        // invalidate. The pair has to DISAGREE or the assertion proves nothing —
+        // Niche Zero and Duo are both NumericWithSuffix, so "5"+1 is "6" either
+        // way and this passed with the model dropped from the key.
+        //
+        // 1Zpresso J-Max and K-Max are both Compound but carry at 30 vs 90
+        // positions/rev, so 0+29 stepped by 1 reaches 30 = a full revolution on
+        // one and 30 into the first on the other.
+        for (int i = 0; i < 3; ++i) {
+            QCOMPARE(dye->stepGrinderSetting("1Zpresso", "J-Max", "0+29", 1.0), QString("1+0"));
+            QCOMPARE(dye->stepGrinderSetting("1Zpresso", "K-Max", "0+29", 1.0), QString("0+30"));
+        }
+
+        // A negative result is cached too — the custom-grinder case, which is
+        // the WORST caller (it walks the whole table) and so the one most worth
+        // memoizing. It must stay "" on repeat, and must not poison the next
+        // real lookup.
+        for (int i = 0; i < 3; ++i)
+            QCOMPARE(dye->stepGrinderSetting("Homebuilt", "No Such Grinder", "20", 2.0), QString());
+        QCOMPARE(dye->stepGrinderSetting("Turin", "DF83V", "20", 2.0), QString("22"));
+
+        // Case-insensitivity is the lookup's contract; the memo compares keys
+        // exactly, so a differently-cased repeat must MISS and re-resolve rather
+        // than fall through to nullptr.
+        QCOMPARE(dye->stepGrinderSetting("turin", "df83v", "20", 2.0), QString("22"));
+        QCOMPARE(dye->stepGrinderSetting("Turin", "DF83V", "20", 2.0), QString("22"));
+    }
+
 };
 
 QTEST_GUILESS_MAIN(tst_Settings)


### PR DESCRIPTION
A user reported the grind wheel taking **several seconds** to open, and the app feeling generally slower. This is what the log and the profiler actually showed, what was done about it, and one unrelated user-facing bug found on the way.

## What was measured, not guessed

**From the user's log** (5,788 shots, Android tablet), the two history reads behind the picker's step:

```
[12263.585] grind step for DF83V = 0.5, derived from 59 distinct numeric setting(s)
[12264.068] grind step for DF83V (rpm) = 100, derived from 12 distinct numeric setting(s)
```

483 ms for the RPM query alone, its twin the same — ~918 ms of query in front of a dialog that does all its work in `onAboutToShow`, before it becomes visible.

**From the QML profiler** (ten opens on a Mac), the rest:

```
GrindRowSource.qml:204  stepGrind   186 ms / 8020 calls, 125 ms self
```

8020 = 10 opens x 802 rows. 63% of the whole open.

## Performance

**1. Covering indexes (migration 40).** The two step queries filter on `equipment_id` with nothing indexed on it, so SQLite scanned every row — and the cost tracks table *bytes*, because `profile_json` and `debug_log` are TEXT on `shots`. The plan moves to `SEARCH shots USING COVERING INDEX`, so the table is never opened. Verified in the shipped configuration: with no `sqlite_stat1` present (the app never runs `ANALYZE`), both queries still plan as covering. 0.15 MB for both.

**2. `SettingsDye::stepGrinderSettingRange()`** — one QML→C++ crossing per wheel instead of 801, resolving the grinder once and parsing the current value once. The per-delta rules live in a shared `stepFromParsed()` so the batch and single-row forms cannot drift.

**3. A row memo** keyed on `(cur, step, brand, model)`. Returning the same reference means QML signals no change, so the Tumbler skips rebuilding a model it already has. The two history-derived paths are deliberately excluded — their rows depend on an input the key does not name, which is the invalidated-on-the-wrong-axis failure CLAUDE.md records for the deleted distinct-value cache.

Plus `GrinderAliases::findEntry` memoized for its remaining per-row caller, and `allGrinders()` returning by const reference — `findEntry` returns a pointer into it, previously valid only because QVector is implicitly shared.

`onAboutToShow` total, measured on the Mac (1,187 shots, debug + sanitizers):

| | before | after |
|---|---|---|
| grind changed | 32–43 ms | **10 ms** |
| grind unchanged | 32–43 ms | **1 ms** |

Plus ~918 ms of query removed at the reporter's data scale.

## Correctness: #1713 was still live on the web surface

`GrindCandidates::stepDecimals()` took the step alone while its comment claimed it mirrored `GrindRowSource._stepDecimals`, which has taken the max with the *value* since #1713. That max is the fix.

With history too thin to derive a step, `grindStep` is 0, the endpoint falls back to `1.0` = zero decimals, and a recorded `1.1` formats to `1`. The user's own setting was absent from the datalist and the n=0 suggestion silently rewrote it — #1713's exact reported shape. The app wheel offered `0.1 / 1.1 / 2.1` for a record whose web datalist offered `0 / 1 / 2`.

Found while reviewing this PR, in the declared C++ twin of the file it rewrites.

## What was tried and dropped

- **Memoizing `_stepDecimals` inside the loop.** Measured: no change. The cost was the crossings, not the work behind them.
- **Hoisting `stepGrind`'s invariant work into a prepared context.** Correct as far as it went, but there is no QML test infrastructure here and it restructured four branches, three of which would have shipped unverified.
- **Cutting `grindWindowSteps: 400`.** Raised twice as the likely lever; the measurement says no. Nothing dominates the remaining 10 ms, so shrinking the wheel's range would change behaviour for every user to save 3–4 ms nobody can feel.

## Honest limits

Neither available machine reproduces "several seconds", so **this is not confirmed to fix the reported symptom**. Established: ~918 ms of query at his data scale, and a 3–4x cut to the rest. The temporary instrumentation on the open path is deliberate — it logs at INFO so it reaches the connections view and any submitted log, and his device is the only one that reproduces the problem. It comes out once his log lands.

## Tests

Four, each verified by breaking the code and watching it go red:

- The query plan is `COVERING INDEX`, not merely that the indexes exist — deliberately without `ANALYZE`, since no shipped database has statistics.
- The batch form is indistinguishable from the single-row form for every `n`, over nine grinder shapes plus the degenerate window.
- The `findEntry` memo cannot serve a stale grinder. Its first draft used two Niche models that are both `NumericWithSuffix`, so it passed with the model dropped from the key; 1Zpresso J-Max and K-Max carry at 30 vs 90 positions/rev and do discriminate.
- The web datalist keeps the precision of the user's own value.

Also centralizes the terminal schema version, a bare literal in 24 assertions across two test files.

Full suite: **117 passed, 0 failed**, no warnings. All three `text-invariants` gates pass.

## Review findings, fixed in-branch

A review of this PR found three comments asserting things that were not true, all now corrected: the `findEntry` memo justified by a call pattern this same PR removes; its `thread_local` rationale naming the ShotServer, which runs on the main thread; and a `GrindPickerDialog` comment claiming a `historyDataChanged` subscription that appears nowhere in `qml/` except in the sentence claiming it.

## Unrelated observation, not acted on

The profiler's largest single item was not the picker: `ScaleWeightItem.qml:58` (`showScaleWarning`), 450 ms total / 270 ms self over 7 calls — ~64 ms per evaluation for a five-term boolean. Debug + sanitizer build, not a hot path, and unexplained. Worth re-measuring in a release build before anyone digs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
