### PR TITLE
Match each ShotSettings read-back to the write it answers

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -233,7 +233,7 @@ void BleTransport::subscribeAll() {
     // SHOT_SETTINGS is intentionally NOT subscribed: the DE1 firmware does
     // not push notifications on writes (confirmed in de1app's de1_comms.tcl).
     // Verification happens via explicit read() after each write in
-    // DE1Device::setShotSettings().
+    // DE1Device::setShotSettings() and resendLastShotSettings().
 
     submitReadyMarker();
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -277,6 +277,8 @@ void DE1Device::onTransportDisconnected() {
     m_commandedGroupTargetC = -1.0;
     m_lastShotSettingsWriteMs = 0;
     m_lastShotSettingsPayload.clear();
+    m_pendingShotSettings.clear();
+    m_expectedShotSettings = {};
     // Clear the MMR dedup cache so a reconnect re-writes real values rather
     // than trusting cached values from the previous session (the DE1 may have
     // power-cycled or had its firmware state reset between sessions).
@@ -2581,6 +2583,9 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     m_commandedGroupTargetC = groupTemp;
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
     m_lastShotSettingsPayload = data;
+    // Queue what the read below is expected to bring back.
+    m_pendingShotSettings.append({steamTemp, steamDuration, hotWaterTemp,
+                                  hotWaterVolume, groupTemp});
 
     // Trace every write so the timeline of commanded values is visible in the
     // debug log alongside the DE1-reported values from parseShotSettings().
@@ -2640,6 +2645,17 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
         .arg(groupTargetC, 0, 'f', 2)
         .arg(data.size()));
 
+    // Match this report to the write it answers. Empty means nothing is in
+    // flight — an unsolicited report, or the connect-time read — and the last
+    // commanded values are then the right expectation.
+    if (!m_pendingShotSettings.isEmpty()) {
+        m_expectedShotSettings = m_pendingShotSettings.takeFirst();
+    } else {
+        m_expectedShotSettings = {m_commandedSteamTargetC, m_commandedSteamDurationSec,
+                                  m_commandedHotWaterTempC, m_commandedHotWaterVolMl,
+                                  m_commandedGroupTargetC};
+    }
+
     m_deviceSteamTargetC = steamTargetC;
     m_deviceSteamDurationSec = steamDurationSec;
     m_deviceHotWaterTempC = hotWaterTempC;
@@ -2680,5 +2696,11 @@ void DE1Device::resendLastShotSettings() {
         .arg(m_commandedHotWaterVolMl)
         .arg(m_commandedGroupTargetC, 0, 'f', 2));
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
+    m_pendingShotSettings.append({m_commandedSteamTargetC, m_commandedSteamDurationSec,
+                                  m_commandedHotWaterTempC, m_commandedHotWaterVolMl,
+                                  m_commandedGroupTargetC});
     m_transport->write(DE1::Characteristic::SHOT_SETTINGS, m_lastShotSettingsPayload);
+    // Read back, as setShotSettings() does: without it the ladder can only
+    // advance on a read some earlier write happened to leave in flight.
+    m_transport->read(DE1::Characteristic::SHOT_SETTINGS);
 }

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1593,6 +1593,10 @@ void DE1Device::clearCommandQueue() {
         const qsizetype dropped = m_transport->clearQueue();
         if (dropped > 0) {
             m_lastMMRValues.clear();
+            // Same reason, one characteristic over: a discarded read-back is an
+            // answer that will never come, and a write left unconfirmed here can
+            // only make a later report look like an echo of it.
+            m_pendingShotSettings.clear();
         }
     }
 }
@@ -2583,9 +2587,8 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     m_commandedGroupTargetC = groupTemp;
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
     m_lastShotSettingsPayload = data;
-    // Queue what the read below is expected to bring back.
-    m_pendingShotSettings.append({steamTemp, steamDuration, hotWaterTemp,
-                                  hotWaterVolume, groupTemp});
+    pushPendingShotSettings({steamTemp, steamDuration, hotWaterTemp,
+                             hotWaterVolume, groupTemp});
 
     // Trace every write so the timeline of commanded values is visible in the
     // debug log alongside the DE1-reported values from parseShotSettings().
@@ -2611,6 +2614,34 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     m_transport->read(DE1::Characteristic::SHOT_SETTINGS);
 }
 
+// Index of the oldest unconfirmed write this report could be the answer to, or
+// -1. Compared field-by-field rather than by raw payload because bytes 5-6 are
+// hardcoded on write and we only ever assert the five values we control.
+qsizetype DE1Device::indexOfPendingShotSettings(const ShotSettingsValues& v) const {
+    for (qsizetype i = 0; i < m_pendingShotSettings.size(); ++i) {
+        const ShotSettingsValues& p = m_pendingShotSettings.at(i);
+        if (std::abs(p.steamTargetC - v.steamTargetC) <= kShotSettingsTempToleranceC
+            && p.steamDurationSec == v.steamDurationSec
+            && std::abs(p.hotWaterTempC - v.hotWaterTempC) <= kShotSettingsTempToleranceC
+            && p.hotWaterVolMl == v.hotWaterVolMl
+            && std::abs(p.groupTargetC - v.groupTargetC) <= kShotSettingsTempToleranceC) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Record a write as unconfirmed. Bounded because nothing guarantees an answer
+// for every write: SerialTransport sends no read at all, and a BLE read can be
+// abandoned. An unanswered entry would otherwise sit here for the connection,
+// and enough of them would let a stale value keep passing as an echo.
+void DE1Device::pushPendingShotSettings(const ShotSettingsValues& v) {
+    m_pendingShotSettings.append(v);
+    if (m_pendingShotSettings.size() > kMaxPendingShotSettings) {
+        m_pendingShotSettings.removeFirst();
+    }
+}
+
 void DE1Device::parseShotSettings(const QByteArray& data) {
     // Wire format matches de1app's hotwater_steam_settings_spec:
     //   byte 0   SteamSettings flags (u8)
@@ -2623,6 +2654,7 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
     //   bytes 7-8 TargetGroupTemp    (u16p8 big-endian, °C)
     if (data.size() < 9) {
         DEVICE_WARN(QStringLiteral("parseShotSettings: short payload, size=%1").arg(data.size()));
+        m_expectedShotSettings = {};
         return;
     }
     const auto d = reinterpret_cast<const uint8_t*>(data.constData());
@@ -2645,11 +2677,17 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
         .arg(groupTargetC, 0, 'f', 2)
         .arg(data.size()));
 
-    // Match this report to the write it answers. Empty means nothing is in
-    // flight — an unsolicited report, or the connect-time read — and the last
-    // commanded values are then the right expectation.
-    if (!m_pendingShotSettings.isEmpty()) {
-        m_expectedShotSettings = m_pendingShotSettings.takeFirst();
+    // Score this report against the write it plausibly answers. A match on any
+    // still-unconfirmed write means it is an in-flight echo; everything written
+    // before that one has been superseded, so drop those too. No match means the
+    // report is answering our newest write (or nothing of ours at all), which is
+    // the case the drift check exists for. See m_pendingShotSettings.
+    const ShotSettingsValues reported{steamTargetC, steamDurationSec,
+                                      hotWaterTempC, hotWaterVolMl, groupTargetC};
+    const qsizetype echoed = indexOfPendingShotSettings(reported);
+    if (echoed >= 0) {
+        m_expectedShotSettings = m_pendingShotSettings.at(echoed);
+        m_pendingShotSettings.remove(0, echoed + 1);
     } else {
         m_expectedShotSettings = {m_commandedSteamTargetC, m_commandedSteamDurationSec,
                                   m_commandedHotWaterTempC, m_commandedHotWaterVolMl,
@@ -2678,7 +2716,7 @@ void DE1Device::resendLastShotSettings() {
     // "never wrote one": disconnect clears the payload AND resets the commanded
     // values together (see onTransportDisconnected). So the tier has to suit the
     // benign reading. MainController's own path cannot reach here empty anyway —
-    // it only resends once haveCommanded is true, which requires a prior write.
+    // it only resends once it has an expectation, which requires a prior write.
     if (!m_transport || m_lastShotSettingsPayload.isEmpty()) {
         SHOTSETTINGS_LOG(QStringLiteral(
             "resend requested but nothing was sent — %1")
@@ -2696,11 +2734,11 @@ void DE1Device::resendLastShotSettings() {
         .arg(m_commandedHotWaterVolMl)
         .arg(m_commandedGroupTargetC, 0, 'f', 2));
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
-    m_pendingShotSettings.append({m_commandedSteamTargetC, m_commandedSteamDurationSec,
-                                  m_commandedHotWaterTempC, m_commandedHotWaterVolMl,
-                                  m_commandedGroupTargetC});
+    pushPendingShotSettings({m_commandedSteamTargetC, m_commandedSteamDurationSec,
+                             m_commandedHotWaterTempC, m_commandedHotWaterVolMl,
+                             m_commandedGroupTargetC});
     m_transport->write(DE1::Characteristic::SHOT_SETTINGS, m_lastShotSettingsPayload);
-    // Read back, as setShotSettings() does: without it the ladder can only
-    // advance on a read some earlier write happened to leave in flight.
+    // Read back, as setShotSettings() does, so the resend has an answer of its
+    // own and the drift ladder can reach its own terminal line.
     m_transport->read(DE1::Characteristic::SHOT_SETTINGS);
 }

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -136,14 +136,23 @@ public:
     int deviceHotWaterVolMl() const { return m_deviceHotWaterVolMl; }
     double deviceGroupTargetC() const { return m_deviceGroupTargetC; }
     // Last ShotSettings values we actually wrote over BLE (-1 if none yet).
-    // Used by MainController's drift check to distinguish "DE1 dropped the
-    // write" from "DE1 reported its power-on state before we wrote anything".
     double commandedSteamTargetC() const { return m_commandedSteamTargetC; }
     int commandedSteamDurationSec() const { return m_commandedSteamDurationSec; }
     double commandedHotWaterTempC() const { return m_commandedHotWaterTempC; }
     int commandedHotWaterVolMl() const { return m_commandedHotWaterVolMl; }
     double commandedGroupTargetC() const { return m_commandedGroupTargetC; }
     qint64 lastShotSettingsWriteMs() const { return m_lastShotSettingsWriteMs; }
+
+    // What the CURRENT report was expected to carry: the payload whose read-back
+    // it answers, which is NOT necessarily the most recent write. -1 when it
+    // answered no write of ours. Valid from the shotSettingsReported() emission
+    // until the next report. See m_pendingShotSettings.
+    double expectedSteamTargetC() const { return m_expectedShotSettings.steamTargetC; }
+    int expectedSteamDurationSec() const { return m_expectedShotSettings.steamDurationSec; }
+    double expectedHotWaterTempC() const { return m_expectedShotSettings.hotWaterTempC; }
+    int expectedHotWaterVolMl() const { return m_expectedShotSettings.hotWaterVolMl; }
+    double expectedGroupTargetC() const { return m_expectedShotSettings.groupTargetC; }
+    qsizetype pendingShotSettingsReads() const { return m_pendingShotSettings.size(); }
     double waterLevel() const { return m_waterLevel; }
     double waterLevelMm() const { return m_waterLevelMm; }
     int waterLevelMl() const { return m_waterLevelMl; }
@@ -576,6 +585,24 @@ private:
     int m_commandedHotWaterVolMl = -1;
     double m_commandedGroupTargetC = -1.0;
     qint64 m_lastShotSettingsWriteMs = 0;
+    // One ShotSettings payload, as the five values the drift check compares.
+    // -1 members mean "no expectation" (see expectedSteamTargetC()).
+    struct ShotSettingsValues {
+        double steamTargetC = -1.0;
+        int steamDurationSec = -1;
+        double hotWaterTempC = -1.0;
+        int hotWaterVolMl = -1;
+        double groupTargetC = -1.0;
+    };
+    // FIFO of writes awaiting their read-back, and the entry the most recent
+    // report answered. Every write queues a read behind itself on the same
+    // serial GATT queue, so reports arrive one per write, in write order, each
+    // carrying the state after ITS OWN write. Profile activation issues three
+    // writes ~10 ms apart; checking each report against the NEWEST write made
+    // the first two look like dropped writes, and shipped as a WARN accusing
+    // the machine of a fault it never had.
+    QList<ShotSettingsValues> m_pendingShotSettings;
+    ShotSettingsValues m_expectedShotSettings;
     // Raw 9-byte payload of the most recent ShotSettings write, used by
     // resendLastShotSettings() to re-emit the exact bytes we originally sent.
     // This is the only way to resend bytes 5-6 (TargetHotWaterLength,

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -143,16 +143,32 @@ public:
     double commandedGroupTargetC() const { return m_commandedGroupTargetC; }
     qint64 lastShotSettingsWriteMs() const { return m_lastShotSettingsWriteMs; }
 
-    // What the CURRENT report was expected to carry: the payload whose read-back
-    // it answers, which is NOT necessarily the most recent write. -1 when it
-    // answered no write of ours. Valid from the shotSettingsReported() emission
-    // until the next report. See m_pendingShotSettings.
+    // The five ShotSettings values the drift check compares. All -1 means
+    // "nothing to compare against"; entries in m_pendingShotSettings always
+    // hold real written values.
+    struct ShotSettingsValues {
+        double steamTargetC = -1.0;
+        int steamDurationSec = -1;
+        double hotWaterTempC = -1.0;
+        int hotWaterVolMl = -1;
+        double groupTargetC = -1.0;
+    };
+
+    // What the CURRENT report should have carried. -1 in every field until our
+    // first write. Valid from the shotSettingsReported() emission until the next
+    // report. See m_pendingShotSettings for why this is not always the newest
+    // write.
     double expectedSteamTargetC() const { return m_expectedShotSettings.steamTargetC; }
     int expectedSteamDurationSec() const { return m_expectedShotSettings.steamDurationSec; }
     double expectedHotWaterTempC() const { return m_expectedShotSettings.hotWaterTempC; }
     int expectedHotWaterVolMl() const { return m_expectedShotSettings.hotWaterVolMl; }
     double expectedGroupTargetC() const { return m_expectedShotSettings.groupTargetC; }
-    qsizetype pendingShotSettingsReads() const { return m_pendingShotSettings.size(); }
+    qsizetype pendingShotSettingsWrites() const { return m_pendingShotSettings.size(); }
+
+    // Temperatures round-trip through u8p0 / u16p8, so 0.5C absorbs the encoding
+    // quantum and FP noise. One definition: the drift check in MainController
+    // compares with the same tolerance this class matches echoes with.
+    static constexpr double kShotSettingsTempToleranceC = 0.5;
     double waterLevel() const { return m_waterLevel; }
     double waterLevelMm() const { return m_waterLevelMm; }
     int waterLevelMl() const { return m_waterLevelMl; }
@@ -471,6 +487,8 @@ private:
     void parseStateInfo(const QByteArray& data);
     void parseShotSample(const QByteArray& data);
     void parseShotSettings(const QByteArray& data);
+    qsizetype indexOfPendingShotSettings(const ShotSettingsValues& v) const;
+    void pushPendingShotSettings(const ShotSettingsValues& v);
     void parseWaterLevel(const QByteArray& data);
     void parseVersion(const QByteArray& data);
     void parseMMRResponse(const QByteArray& data);
@@ -585,22 +603,28 @@ private:
     int m_commandedHotWaterVolMl = -1;
     double m_commandedGroupTargetC = -1.0;
     qint64 m_lastShotSettingsWriteMs = 0;
-    // One ShotSettings payload, as the five values the drift check compares.
-    // -1 members mean "no expectation" (see expectedSteamTargetC()).
-    struct ShotSettingsValues {
-        double steamTargetC = -1.0;
-        int steamDurationSec = -1;
-        double hotWaterTempC = -1.0;
-        int hotWaterVolMl = -1;
-        double groupTargetC = -1.0;
-    };
-    // FIFO of writes awaiting their read-back, and the entry the most recent
-    // report answered. Every write queues a read behind itself on the same
-    // serial GATT queue, so reports arrive one per write, in write order, each
-    // carrying the state after ITS OWN write. Profile activation issues three
-    // writes ~10 ms apart; checking each report against the NEWEST write made
-    // the first two look like dropped writes, and shipped as a WARN accusing
-    // the machine of a fault it never had.
+    // Writes we have not yet seen the DE1 confirm, oldest first, and what the
+    // most recent report should have carried.
+    //
+    // A report can be the answer to an OLDER write than our newest: the app
+    // writes ShotSettings several times in a burst (profile activation goes
+    // through uploadCurrentProfile, applySteamSettings and applyHotWaterSettings
+    // in ~12 ms, measured in the log on issue #1900's debug-2.log), and the
+    // answers come back one at a time behind them. Scoring every report against
+    // the NEWEST write therefore accused the DE1 of dropping writes it had
+    // honoured — 12 such WARNs in that one log, every one "resolving" by itself
+    // once the last answer landed.
+    //
+    // So a report is an in-flight echo, not drift, when it matches ANY write
+    // still unconfirmed. Deliberately a match rather than a positional pop:
+    // a pop assumes exactly one answer per write, which is true only of
+    // BleTransport (it queues a read behind each write) and false on
+    // SerialTransport, whose read() is a no-op once subscribed
+    // (serialtransport.cpp:115) — and breakable even on BLE by clearCommandQueue()
+    // or an abandoned read. A positional queue that slips stays slipped for the
+    // connection; matching cannot slip, and when nothing matches it falls back
+    // to the newest write, which is what this code did before the FIFO existed.
+    static constexpr qsizetype kMaxPendingShotSettings = 8;
     QList<ShotSettingsValues> m_pendingShotSettings;
     ShotSettingsValues m_expectedShotSettings;
     // Raw 9-byte payload of the most recent ShotSettings write, used by

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -609,11 +609,12 @@ private:
     // A report can be the answer to an OLDER write than our newest: the app
     // writes ShotSettings several times in a burst (profile activation goes
     // through uploadCurrentProfile, applySteamSettings and applyHotWaterSettings
-    // in ~12 ms, measured in the log on issue #1900's debug-2.log), and the
-    // answers come back one at a time behind them. Scoring every report against
-    // the NEWEST write therefore accused the DE1 of dropping writes it had
-    // honoured — 12 such WARNs in that one log, every one "resolving" by itself
-    // once the last answer landed.
+    // in ~12 ms) and the answers come back one at a time behind them. Scoring
+    // every report against the NEWEST write therefore accused the DE1 of
+    // dropping writes it had honoured. Measured on a user-submitted debug log,
+    // 2026-09-01: 12 such WARNs across six bursts, in every case the reported
+    // payload equal to an earlier write of ours and the episode "resolving" by
+    // itself once the last answer landed.
     //
     // So a report is an in-flight echo, not drift, when it matches ANY write
     // still unconfirmed. Deliberately a match rather than a positional pop:

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2527,10 +2527,9 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
     // down cannot fire, because nothing between it and the WARN above pumps the
     // event loop.
     if (!m_device || !m_device->isConnected() || !m_settings) {
-        if (m_shotSettingsResendInFlight || m_shotSettingsDriftResendCount > 0) {
+        if (m_shotSettingsDriftResendCount > 0) {
             DRIFT_INFO(QStringLiteral(
                 "device gone with a resend outstanding — ladder abandoned, drift unresolved"));
-            m_shotSettingsResendInFlight = false;
             m_shotSettingsDriftResendCount = 0;
             flushDriftGiveUpLog();
         }
@@ -2557,10 +2556,9 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         return;
     }
 
-    // Tolerances cover BLE encoding rounding. Temperatures use u8p0 (1°C
-    // quantum) or u16p8; 0.5°C absorbs FP noise. Integer fields (duration,
-    // volume) must match exactly.
-    constexpr double kTempToleranceC = 0.5;
+    // Same tolerance DE1Device matches in-flight echoes with — one definition,
+    // so the two cannot disagree about whether a value came back unchanged.
+    constexpr double kTempToleranceC = DE1Device::kShotSettingsTempToleranceC;
 
     // Compare reported against what WE WROTE — "did the DE1 honor this write?"
     // — never against a Settings-derived value. Several paths deliberately
@@ -2623,13 +2621,11 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         // which is what flush() itself tests, and coupling it to a counter it
         // does not depend on is how the next edit to that counter breaks this.
         flushDriftGiveUpLog();
-        m_shotSettingsResendInFlight = false;
         return;
     }
 
-    // Drift detected: the DE1 answered a specific write of ours with something
-    // other than what that write carried. Reports for writes still in flight
-    // have not arrived yet and cannot be mistaken for this one.
+    // Drift: the report matched no write still awaiting confirmation, so it is
+    // the DE1's answer to our newest one and it does not carry what we sent.
 
     // Classify for the log so we can scan `grep SettingsDrift` in bug
     // reports and immediately see what happened.
@@ -2686,33 +2682,14 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         .arg(expectedHotWaterVol)
         .arg(expectedGroup, 0, 'f', 2));
 
-    // If a resend is already in flight (we sent one and haven't yet received
-    // its indication), wait for that to resolve before firing another. This
-    // is the event-based replacement for a 2s wall-clock rate limit.
-    if (m_shotSettingsResendInFlight) {
-        // A drifting report while a resend is outstanding still shows the DE1
-        // not holding what we sent. Consume it by clearing the flag, so the
-        // NEXT report can fire attempt N+1.
-        //
-        // Without this clear the flag was set once and never reset on a drifting
-        // path (the only other resets are the no-drift branch and a reconnect),
-        // so the ladder stalled at one attempt: kMaxResendAttempts was never
-        // reached and the "giving up" WARN below could not execute on any
-        // connection. What a user saw instead was DE1-dropped-write re-warned on
-        // every indication, forever, with no terminal line.
-        //
-        // de1app has no ShotSettings drift detection to compare against. Its
-        // nearest equivalent — confirm_de1_send_shot_frames_worked — detects the
-        // same class of fault and then deliberately does NOT auto-resend
-        // (de1plus/de1_comms.tcl:1566, commented out to avoid a 500ms retry
-        // loop). That hazard does not apply here: this ladder is bounded at
-        // kMaxResendAttempts and advances only when the DE1 sends an
-        // indication, so it cannot spin.
-        m_shotSettingsResendInFlight = false;
-        DRIFT_LOG(QStringLiteral("resend already in flight — this report answers it, still drifting"));
-        return;
-    }
-
+    // No rate limiter here. Each resend queues its own read-back
+    // (DE1Device::resendLastShotSettings), so a still-drifting report is that
+    // resend's answer and must advance the ladder to the next rung. Gating on an
+    // "is a resend in flight" flag consumed exactly that report without counting
+    // it, so the ladder stalled at attempt 1, kMaxResendAttempts was never
+    // reached, and the episode ended on a WARN with no terminal line — the
+    // failure half of a narrative, which LOGGING.md exists to prevent. The ladder
+    // cannot spin: it is bounded below and advances only on a report.
     constexpr int kMaxResendAttempts = 3;
     if (m_shotSettingsDriftResendCount >= kMaxResendAttempts) {
         // Collapsed, because this branch returns without latching and is
@@ -2744,7 +2721,6 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
     }
 
     m_shotSettingsDriftResendCount++;
-    m_shotSettingsResendInFlight = true;
     DRIFT_WARN(QString(
         "resending last ShotSettings payload (attempt %1 of %2)")
         .arg(m_shotSettingsDriftResendCount).arg(kMaxResendAttempts));
@@ -2789,8 +2765,8 @@ void MainController::sendMachineSettings(const QString& reason) {
     qDebug() << "sendMachineSettings: steam=" << steamTemp << "°C, groupTemp=" << groupTemp << "°C";
 
     // 1. ShotSettings (single write with all temperatures).
-    // DE1Device::setShotSettings() internally records the commanded values
-    // so onShotSettingsReported() can compare reported against commanded.
+    // DE1Device::setShotSettings() records the write so onShotSettingsReported()
+    // can score the DE1's answer against it.
     m_device->setShotSettings(
         steamTemp,
         m_settings->brew()->steamTimeout(),
@@ -2987,14 +2963,13 @@ void MainController::applyAllSettings() {
     // report, because that line is gated on the counter being non-zero — so a
     // drift that ended in a reconnect left the WARN as the last word a reader
     // ever saw.
-    if (m_shotSettingsDriftResendCount > 0 || m_shotSettingsResendInFlight) {
+    if (m_shotSettingsDriftResendCount > 0) {
         DRIFT_INFO(QString("drift ladder reset by reconnect after %1 resend(s) — "
                            "the previous session's drift was never resolved")
                        .arg(m_shotSettingsDriftResendCount));
     }
     flushDriftGiveUpLog();
     m_shotSettingsDriftResendCount = 0;
-    m_shotSettingsResendInFlight = false;
 
     // 1. Upload current profile (espresso)
     if (m_profileManager->currentProfile().mode() == Profile::Mode::FrameBased) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2537,14 +2537,17 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         return;
     }
 
-    const double commandedSteam = m_device->commandedSteamTargetC();
-    const int commandedDuration = m_device->commandedSteamDurationSec();
-    const double commandedHotWaterTemp = m_device->commandedHotWaterTempC();
-    const int commandedHotWaterVol = m_device->commandedHotWaterVolMl();
-    const double commandedGroup = m_device->commandedGroupTargetC();
-    const bool haveCommanded = (commandedSteam >= 0.0 && commandedDuration >= 0
-                                && commandedHotWaterTemp >= 0.0 && commandedHotWaterVol >= 0
-                                && commandedGroup >= 0.0);
+    // What THIS report was expected to carry, not the newest write — reading
+    // commanded* here is what made a burst of writes warn about a dropped write
+    // that never happened. See DE1Device::m_pendingShotSettings.
+    const double expectedSteam = m_device->expectedSteamTargetC();
+    const int expectedDuration = m_device->expectedSteamDurationSec();
+    const double expectedHotWaterTemp = m_device->expectedHotWaterTempC();
+    const int expectedHotWaterVol = m_device->expectedHotWaterVolMl();
+    const double expectedGroup = m_device->expectedGroupTargetC();
+    const bool haveExpected = (expectedSteam >= 0.0 && expectedDuration >= 0
+                               && expectedHotWaterTemp >= 0.0 && expectedHotWaterVol >= 0
+                               && expectedGroup >= 0.0);
 
     // Sentinel values emitted by DE1Device on disconnect — skip, there's
     // nothing to compare against.
@@ -2559,28 +2562,27 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
     // volume) must match exactly.
     constexpr double kTempToleranceC = 0.5;
 
-    // Compare reported against COMMANDED — "did the DE1 honor our last
-    // write?" This is the authoritative question for #746, and it correctly
-    // handles code paths that write values diverging from Settings
-    // (startSteamHeating forces heater on regardless of the resolved heater policy,
-    // softStopSteam writes a 1s timeout, etc.). Comparing against
-    // Settings-derived "expected" would make the drift handler clobber
-    // those writes.
-    const bool steamDrift = haveCommanded &&
-        std::abs(deviceSteamTargetC - commandedSteam) > kTempToleranceC;
-    const bool durationDrift = haveCommanded &&
-        deviceSteamDurationSec != commandedDuration;
-    const bool hotWaterTempDrift = haveCommanded &&
-        std::abs(deviceHotWaterTempC - commandedHotWaterTemp) > kTempToleranceC;
-    const bool hotWaterVolDrift = haveCommanded &&
-        deviceHotWaterVolMl != commandedHotWaterVol;
-    const bool groupDrift = haveCommanded &&
-        std::abs(deviceGroupTargetC - commandedGroup) > kTempToleranceC;
+    // Compare reported against what WE WROTE — "did the DE1 honor this write?"
+    // — never against a Settings-derived value. Several paths deliberately
+    // write values diverging from Settings (startSteamHeating forces the heater
+    // on regardless of the resolved heater policy, softStopSteam writes a 1s
+    // timeout), and re-deriving would make the drift handler clobber them.
+    // #746.
+    const bool steamDrift = haveExpected &&
+        std::abs(deviceSteamTargetC - expectedSteam) > kTempToleranceC;
+    const bool durationDrift = haveExpected &&
+        deviceSteamDurationSec != expectedDuration;
+    const bool hotWaterTempDrift = haveExpected &&
+        std::abs(deviceHotWaterTempC - expectedHotWaterTemp) > kTempToleranceC;
+    const bool hotWaterVolDrift = haveExpected &&
+        deviceHotWaterVolMl != expectedHotWaterVol;
+    const bool groupDrift = haveExpected &&
+        std::abs(deviceGroupTargetC - expectedGroup) > kTempToleranceC;
 
     // Skip before we've ever written — DE1's initial indication on subscribe
     // reflects its power-on state, not ours, and racing against that would
     // log a bogus drift on every connect.
-    if (!haveCommanded) {
+    if (!haveExpected) {
         DRIFT_LOG(QString(
             "pre-commanded report ignored: "
             "reported(steam=%1C dur=%2s hw=%3C vol=%4ml group=%5C) — waiting for first write")
@@ -2625,45 +2627,46 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         return;
     }
 
-    // Drift detected. The received indication is the post-write state
-    // (read is queued after the write), so any mismatch is real drift.
+    // Drift detected: the DE1 answered a specific write of ours with something
+    // other than what that write carried. Reports for writes still in flight
+    // have not arrived yet and cannot be mistaken for this one.
 
     // Classify for the log so we can scan `grep SettingsDrift` in bug
     // reports and immediately see what happened.
     QString summary;
     if (steamDrift) {
-        if (commandedSteam == 0.0 && deviceSteamTargetC > 0.0) {
+        if (expectedSteam == 0.0 && deviceSteamTargetC > 0.0) {
             summary = QStringLiteral("steam heater ON at %1C but we commanded OFF")
                           .arg(deviceSteamTargetC, 0, 'f', 0);
-        } else if (commandedSteam > 0.0 && deviceSteamTargetC == 0.0) {
+        } else if (expectedSteam > 0.0 && deviceSteamTargetC == 0.0) {
             summary = QStringLiteral("steam heater OFF but we commanded %1C")
-                          .arg(commandedSteam, 0, 'f', 0);
+                          .arg(expectedSteam, 0, 'f', 0);
         } else {
             summary = QStringLiteral("steam target %1C but we commanded %2C")
                           .arg(deviceSteamTargetC, 0, 'f', 0)
-                          .arg(commandedSteam, 0, 'f', 0);
+                          .arg(expectedSteam, 0, 'f', 0);
         }
     }
     if (durationDrift) {
         QString note = QStringLiteral("steam duration %1s but we commanded %2s")
-                           .arg(deviceSteamDurationSec).arg(commandedDuration);
+                           .arg(deviceSteamDurationSec).arg(expectedDuration);
         summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
     }
     if (hotWaterTempDrift) {
         QString note = QStringLiteral("hot water temp %1C but we commanded %2C")
                            .arg(deviceHotWaterTempC, 0, 'f', 1)
-                           .arg(commandedHotWaterTemp, 0, 'f', 1);
+                           .arg(expectedHotWaterTemp, 0, 'f', 1);
         summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
     }
     if (hotWaterVolDrift) {
         QString note = QStringLiteral("hot water vol %1ml but we commanded %2ml")
-                           .arg(deviceHotWaterVolMl).arg(commandedHotWaterVol);
+                           .arg(deviceHotWaterVolMl).arg(expectedHotWaterVol);
         summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
     }
     if (groupDrift) {
         QString note = QStringLiteral("group target %1C but we commanded %2C")
                            .arg(deviceGroupTargetC, 0, 'f', 2)
-                           .arg(commandedGroup, 0, 'f', 2);
+                           .arg(expectedGroup, 0, 'f', 2);
         summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
     }
 
@@ -2677,19 +2680,19 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         .arg(deviceHotWaterTempC, 0, 'f', 1)
         .arg(deviceHotWaterVolMl)
         .arg(deviceGroupTargetC, 0, 'f', 2)
-        .arg(commandedSteam, 0, 'f', 1)
-        .arg(commandedDuration)
-        .arg(commandedHotWaterTemp, 0, 'f', 1)
-        .arg(commandedHotWaterVol)
-        .arg(commandedGroup, 0, 'f', 2));
+        .arg(expectedSteam, 0, 'f', 1)
+        .arg(expectedDuration)
+        .arg(expectedHotWaterTemp, 0, 'f', 1)
+        .arg(expectedHotWaterVol)
+        .arg(expectedGroup, 0, 'f', 2));
 
     // If a resend is already in flight (we sent one and haven't yet received
     // its indication), wait for that to resolve before firing another. This
     // is the event-based replacement for a 2s wall-clock rate limit.
     if (m_shotSettingsResendInFlight) {
-        // This indication IS that resend's answer — the read is queued after the
-        // write, per the comment above — and it still shows drift. Consume it by
-        // clearing the flag, so the NEXT report can fire attempt N+1.
+        // A drifting report while a resend is outstanding still shows the DE1
+        // not holding what we sent. Consume it by clearing the flag, so the
+        // NEXT report can fire attempt N+1.
         //
         // Without this clear the flag was set once and never reset on a drifting
         // path (the only other resets are the no-drift branch and a reconnect),

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -747,17 +747,11 @@ private:
     int m_frameWeightSkipSent = -1;  // Frame number for which we've sent a weight-based skip command
     double m_frameStartTime = 0;     // Shot-relative time when current frame started
 
-    // ShotSettings drift auto-heal tracking. The commanded values live on
-    // DE1Device (so every call site — MainController, ProfileManager —
-    // feeds the same tracker); we only keep the retry
-    // bookkeeping here. Both fields are reset in applyAllSettings() so every
-    // reconnect / initial-settings cycle starts with a fresh retry budget.
+    // ShotSettings drift auto-heal tracking. The written values live on
+    // DE1Device (so every call site — MainController, ProfileManager — feeds
+    // the same tracker); only the retry bookkeeping is here. Reset in
+    // applyAllSettings() so every reconnect starts with a fresh budget.
     int m_shotSettingsDriftResendCount = 0;
-    // Event-based "is a resend in flight?" flag, cleared when the DE1's
-    // next indication matches commanded (in onShotSettingsReported). Replaces
-    // a wall-clock rate limiter — see CLAUDE.md's "never timers as guards"
-    // rule.
-    bool m_shotSettingsResendInFlight = false;
     // Closes a "giving up" episode and reports its tally — see m_driftGiveUpLog.
     void flushDriftGiveUpLog();
     // The "giving up after N resend attempts" WARN, collapsed.

--- a/tests/mocks/MockTransport.h
+++ b/tests/mocks/MockTransport.h
@@ -20,6 +20,8 @@ public:
 
     // Captured writes
     QList<QPair<QBluetoothUuid, QByteArray>> writes;
+    // Captured reads, in submission order.
+    QList<QBluetoothUuid> reads;
 
     // Captured subscribe() calls. Firmware update uses on-demand A009
     // subscription (not always-on) — tests verify subscribe/unsubscribe
@@ -42,7 +44,9 @@ public:
     void write(const QBluetoothUuid& uuid, const QByteArray& data) override {
         writes.append({uuid, data});
     }
-    void read(const QBluetoothUuid&) override {}
+    // Recorded, not answered: a read on the real transport queues behind the
+    // write and comes back as dataReceived() later, which tests drive by hand.
+    void read(const QBluetoothUuid& uuid) override { reads.append(uuid); }
     void subscribe(const QBluetoothUuid& uuid) override { subscribes.append(uuid); }
     void subscribeAll() override {}
     void disconnect() override {

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -39,6 +39,22 @@ private:
             device.setShotSettings(steamTemp, steamDuration, hotWaterTemp, hotWaterVolume, groupTemp);
             return transport.lastWriteData();
         }
+
+        // Deliver one SHOT_SETTINGS read-back, as the DE1 answering a write.
+        void report(double steamTemp, int steamDuration,
+                    double hotWaterTemp, int hotWaterVolume, double groupTemp) {
+            QByteArray payload(9, 0);
+            payload[1] = char(BinaryCodec::encodeU8P0(steamTemp));
+            payload[2] = char(BinaryCodec::encodeU8P0(steamDuration));
+            payload[3] = char(BinaryCodec::encodeU8P0(hotWaterTemp));
+            payload[4] = char(BinaryCodec::encodeU8P0(hotWaterVolume));
+            payload[5] = char(60);
+            payload[6] = char(200);
+            const uint16_t groupRaw = BinaryCodec::encodeU16P8(groupTemp);
+            payload[7] = char((groupRaw >> 8) & 0xFF);
+            payload[8] = char(groupRaw & 0xFF);
+            emit transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
+        }
     };
 
 private slots:
@@ -373,6 +389,110 @@ private slots:
         f.transport.clearWrites();
         f.device.setShotSettings(160, 120, 80, 200, 93.0);  // same values
         QCOMPARE(f.transport.writes.size(), 1);  // fired despite same values
+    }
+
+    // ===== Read-backs are matched to the write they answer =====
+    //
+    // Writes queue a read behind themselves on a serial GATT queue, so N rapid
+    // writes produce N reports in write order, each carrying the state after
+    // its own write. The drift check must compare each report against THAT
+    // write, not against the newest one — comparing against the newest is what
+    // made a profile activation (three writes ~10 ms apart) warn twice that the
+    // DE1 had dropped a write it had in fact honoured.
+
+    void burstOfWritesMatchesEachReportToItsOwnWrite() {
+        TestFixture f;
+        f.device.setShotSettings(160, 43, 76, 0, 88.0);   // write 1
+        f.device.setShotSettings(0, 43, 76, 0, 88.0);     // write 2
+        f.device.setShotSettings(0, 43, 72, 0, 88.0);     // write 3
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(3));
+
+        f.report(160, 43, 76, 0, 88.0);                   // answers write 1
+        QCOMPARE(f.device.expectedSteamTargetC(), 160.0);
+        QCOMPARE(f.device.expectedHotWaterTempC(), 76.0);
+
+        f.report(0, 43, 76, 0, 88.0);                     // answers write 2
+        QCOMPARE(f.device.expectedSteamTargetC(), 0.0);
+        QCOMPARE(f.device.expectedHotWaterTempC(), 76.0);
+
+        f.report(0, 43, 72, 0, 88.0);                     // answers write 3
+        QCOMPARE(f.device.expectedSteamTargetC(), 0.0);
+        QCOMPARE(f.device.expectedHotWaterTempC(), 72.0);
+        QCOMPARE(f.device.expectedSteamDurationSec(), 43);
+        QCOMPARE(f.device.expectedHotWaterVolMl(), 0);
+        QCOMPARE(f.device.expectedGroupTargetC(), 88.0);
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+    }
+
+    void dedupedWriteQueuesNoReadBack() {
+        // A write elided as unchanged issues no BLE write and therefore no
+        // read, so it must not add an expectation — one that never gets popped
+        // would offset every later report by one.
+        TestFixture f;
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);  // identical, elided
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(1));
+    }
+
+    void unsolicitedReportComparesAgainstLastCommanded() {
+        // With nothing in flight, a report the DE1 volunteered (or the
+        // connect-time read) has no queued write to answer. The last commanded
+        // values are then the right expectation — nothing outstanding can make
+        // them stale.
+        TestFixture f;
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        f.report(160, 120, 80, 200, 93.0);
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+
+        f.report(0, 120, 80, 200, 93.0);
+        QCOMPARE(f.device.expectedSteamTargetC(), 160.0);  // what we commanded
+        QCOMPARE(f.device.deviceSteamTargetC(), 0.0);      // what it reported
+    }
+
+    void reportBeforeAnyWriteHasNoExpectation() {
+        // The DE1's power-on state, read on connect. -1 tells MainController
+        // there is nothing to compare against.
+        TestFixture f;
+        f.report(160, 120, 80, 200, 93.0);
+        QCOMPARE(f.device.expectedSteamTargetC(), -1.0);
+        QCOMPARE(f.device.expectedSteamDurationSec(), -1);
+        QCOMPARE(f.device.expectedHotWaterTempC(), -1.0);
+        QCOMPARE(f.device.expectedHotWaterVolMl(), -1);
+        QCOMPARE(f.device.expectedGroupTargetC(), -1.0);
+    }
+
+    void resendQueuesItsOwnReadBack() {
+        // The resend has to be verifiable on its own. Before it queued a read,
+        // the drift ladder could only advance on a read some earlier write
+        // happened to have left in flight, so a genuine drop with nothing else
+        // outstanding produced a resend and then no terminal line at all.
+        TestFixture f;
+        f.device.setShotSettings(160, 43, 76, 0, 88.0);
+        f.report(160, 43, 76, 0, 88.0);
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+
+        f.device.resendLastShotSettings();
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(1));
+
+        f.report(160, 43, 76, 0, 88.0);
+        QCOMPARE(f.device.expectedSteamTargetC(), 160.0);
+        QCOMPARE(f.device.expectedHotWaterTempC(), 76.0);
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+    }
+
+    void disconnectClearsPendingReadBacks() {
+        // Reads for the old connection will never arrive. Left queued, the
+        // first report after reconnect would be matched to a write from the
+        // previous session.
+        TestFixture f;
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(1));
+
+        f.transport.setConnectedSim(false);
+
+        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+        QCOMPARE(f.device.expectedSteamTargetC(), -1.0);
+        QCOMPARE(f.device.expectedGroupTargetC(), -1.0);
     }
 };
 

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -391,21 +391,22 @@ private slots:
         QCOMPARE(f.transport.writes.size(), 1);  // fired despite same values
     }
 
-    // ===== Read-backs are matched to the write they answer =====
+    // ===== Reports are scored against the write they plausibly answer =====
     //
-    // Writes queue a read behind themselves on a serial GATT queue, so N rapid
-    // writes produce N reports in write order, each carrying the state after
-    // its own write. The drift check must compare each report against THAT
-    // write, not against the newest one — comparing against the newest is what
-    // made a profile activation (three writes ~10 ms apart) warn twice that the
-    // DE1 had dropped a write it had in fact honoured.
+    // The app writes ShotSettings several times in a burst, and the DE1's
+    // answers come back one at a time behind them. A report matching a write
+    // still awaiting confirmation is an in-flight echo, not drift. See
+    // DE1Device::m_pendingShotSettings.
 
-    void burstOfWritesMatchesEachReportToItsOwnWrite() {
+    void burstOfWritesScoresEachReportAgainstItsOwnWrite() {
         TestFixture f;
         f.device.setShotSettings(160, 43, 76, 0, 88.0);   // write 1
         f.device.setShotSettings(0, 43, 76, 0, 88.0);     // write 2
         f.device.setShotSettings(0, 43, 72, 0, 88.0);     // write 3
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(3));
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(3));
+        // Each write queues its own read-back; that is what produces one
+        // answer per write on BLE.
+        QCOMPARE(f.transport.reads.size(), 3);
 
         f.report(160, 43, 76, 0, 88.0);                   // answers write 1
         QCOMPARE(f.device.expectedSteamTargetC(), 160.0);
@@ -421,32 +422,44 @@ private slots:
         QCOMPARE(f.device.expectedSteamDurationSec(), 43);
         QCOMPARE(f.device.expectedHotWaterVolMl(), 0);
         QCOMPARE(f.device.expectedGroupTargetC(), 88.0);
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(0));
     }
 
-    void dedupedWriteQueuesNoReadBack() {
-        // A write elided as unchanged issues no BLE write and therefore no
-        // read, so it must not add an expectation — one that never gets popped
-        // would offset every later report by one.
+    void dedupedWriteQueuesNothing() {
+        // An elided write issues no BLE write and no read, so it must not be
+        // recorded as awaiting confirmation.
         TestFixture f;
         f.device.setShotSettings(160, 120, 80, 200, 93.0);
         f.device.setShotSettings(160, 120, 80, 200, 93.0);  // identical, elided
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(1));
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(1));
+        QCOMPARE(f.transport.reads.size(), 1);
     }
 
-    void unsolicitedReportComparesAgainstLastCommanded() {
-        // With nothing in flight, a report the DE1 volunteered (or the
-        // connect-time read) has no queued write to answer. The last commanded
-        // values are then the right expectation — nothing outstanding can make
-        // them stale.
+    void reportMatchingNoPendingWriteIsScoredAgainstTheNewest() {
+        // The drift case: the DE1 answers with something we never wrote.
         TestFixture f;
-        f.device.setShotSettings(160, 120, 80, 200, 93.0);
-        f.report(160, 120, 80, 200, 93.0);
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+        f.device.setShotSettings(160, 43, 76, 0, 88.0);
+        f.device.setShotSettings(160, 43, 72, 0, 88.0);
 
-        f.report(0, 120, 80, 200, 93.0);
-        QCOMPARE(f.device.expectedSteamTargetC(), 160.0);  // what we commanded
-        QCOMPARE(f.device.deviceSteamTargetC(), 0.0);      // what it reported
+        f.report(160, 43, 55, 0, 88.0);                   // never written
+        QCOMPARE(f.device.expectedHotWaterTempC(), 72.0);  // newest write
+        QCOMPARE(f.device.deviceHotWaterTempC(), 55.0);
+    }
+
+    void anEchoDropsTheWritesItSuperseded() {
+        // Matching write 3 means the answers for 1 and 2 are never coming —
+        // holding them would let a later report pass as an echo of a value the
+        // machine has long since moved off.
+        TestFixture f;
+        f.device.setShotSettings(160, 43, 76, 0, 88.0);
+        f.device.setShotSettings(0, 43, 76, 0, 88.0);
+        f.device.setShotSettings(0, 43, 72, 0, 88.0);
+
+        f.report(0, 43, 72, 0, 88.0);                     // answers write 3
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(0));
+
+        f.report(160, 43, 76, 0, 88.0);                   // write 1's value, stale
+        QCOMPARE(f.device.expectedHotWaterTempC(), 72.0);  // scored as drift
     }
 
     void reportBeforeAnyWriteHasNoExpectation() {
@@ -462,36 +475,62 @@ private slots:
     }
 
     void resendQueuesItsOwnReadBack() {
-        // The resend has to be verifiable on its own. Before it queued a read,
-        // the drift ladder could only advance on a read some earlier write
-        // happened to have left in flight, so a genuine drop with nothing else
-        // outstanding produced a resend and then no terminal line at all.
+        // Without a read of its own the resend has no answer, so the drift
+        // ladder cannot advance to its own terminal line.
         TestFixture f;
         f.device.setShotSettings(160, 43, 76, 0, 88.0);
         f.report(160, 43, 76, 0, 88.0);
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+        f.transport.reads.clear();
 
         f.device.resendLastShotSettings();
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(1));
 
-        f.report(160, 43, 76, 0, 88.0);
-        QCOMPARE(f.device.expectedSteamTargetC(), 160.0);
-        QCOMPARE(f.device.expectedHotWaterTempC(), 76.0);
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+        QCOMPARE(f.transport.reads.size(), 1);
+        QCOMPARE(f.transport.reads.first(), DE1::Characteristic::SHOT_SETTINGS);
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(1));
     }
 
-    void disconnectClearsPendingReadBacks() {
-        // Reads for the old connection will never arrive. Left queued, the
-        // first report after reconnect would be matched to a write from the
-        // previous session.
+    void unansweredWritesAreBounded() {
+        // SerialTransport sends no read at all and a BLE read can be abandoned,
+        // so writes can go unanswered indefinitely. Unbounded, they would let a
+        // stale value keep passing as an echo.
+        TestFixture f;
+        for (int i = 0; i < 20; ++i) {
+            f.device.setShotSettings(160, 20 + i, 76, 0, 88.0);
+        }
+        QVERIFY(f.device.pendingShotSettingsWrites() <= qsizetype(8));
+        // The newest write survives the trim — it is the one a report is most
+        // likely to be answering.
+        f.report(160, 39, 76, 0, 88.0);
+        QCOMPARE(f.device.expectedSteamDurationSec(), 39);
+    }
+
+    void clearCommandQueueDropsUnconfirmedWrites() {
+        // clearCommandQueue() discards our queued read-backs, so their answers
+        // are never coming. Left behind, the first write after a shot would be
+        // scored against one from before it.
+        TestFixture f;
+        f.device.setShotSettings(160, 43, 76, 0, 88.0);
+        f.device.setShotSettings(0, 43, 76, 0, 88.0);
+        f.transport.pendingQueueSize = 2;
+
+        f.device.clearCommandQueue();
+
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(0));
+    }
+
+    void disconnectClearsUnconfirmedWrites() {
+        // Reads for the old connection will never arrive.
         TestFixture f;
         f.device.setShotSettings(160, 120, 80, 200, 93.0);
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(1));
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(1));
 
         f.transport.setConnectedSim(false);
 
-        QCOMPARE(f.device.pendingShotSettingsReads(), qsizetype(0));
+        QCOMPARE(f.device.pendingShotSettingsWrites(), qsizetype(0));
         QCOMPARE(f.device.expectedSteamTargetC(), -1.0);
+        QCOMPARE(f.device.expectedSteamDurationSec(), -1);
+        QCOMPARE(f.device.expectedHotWaterTempC(), -1.0);
+        QCOMPARE(f.device.expectedHotWaterVolMl(), -1);
         QCOMPARE(f.device.expectedGroupTargetC(), -1.0);
     }
 };


### PR DESCRIPTION
## The bug

Every `setShotSettings()` write queues a read behind itself on the same serial GATT queue, so N rapid writes produce N reports in write order, each carrying the state after **its own** write. The drift detector compared every report against the *newest* commanded values instead, so any burst of writes looked like the DE1 had dropped one.

Profile activation issues three writes ~10 ms apart (`uploadCurrentProfile`, `applySteamSettings`, `applyHotWaterSettings`), which is why this fired constantly.

## Evidence

From a user debug log — 12 `DE1-dropped-write` WARNs across six bursts. The clearest:

```
[3991.369] write: steam=160 dur=43 hw=76 group=88   (#1)
[3991.377] write: steam=0   dur=43 hw=76 group=88   (#2)
[3991.381] write: steam=0   dur=43 hw=72 group=88   (#3)
[3992.179] reported: steam=160 dur=43 hw=76 ...     <- answers #1
[3992.184] WARN DE1-dropped-write: steam heater ON at 160C but we commanded OFF
[3992.405] reported: steam=0 dur=43 hw=76 ...       <- answers #2
[3992.630] reported: steam=0 dur=43 hw=72 ...       <- answers #3, "resolved"
```

In all six bursts the report count equals the non-elided write count, and each reported payload equals the Nth write's payload, in order. No report ever carried a value we had not written. Every episode "resolved after 1 resend" on its own once the last report landed — the resend was not what fixed it.

Cost of the false positive: a hardware accusation at WARN (which field AIs read over MCP and act on), plus a redundant BLE write per episode into a GATT queue already warning about depth 40 during connect.

## The fix

`DE1Device` keeps a FIFO of the values each queued read-back is expected to bring, pops one per report, and exposes it as `expected*()`. An empty FIFO means nothing is in flight, so the last commanded values are the right expectation (the connect-time read). Elided writes push nothing. Cleared on disconnect. `MainController`'s drift check reads `expected*()` instead of `commanded*()`.

## Second, independent defect fixed here

`resendLastShotSettings()` wrote blind — it queued no read of its own. The drift ladder could therefore only advance on a read some earlier write happened to have left in flight; a genuine dropped write with nothing else outstanding would resend and then produce **no terminal line at all**. The log could not show this because a pending read always happened to be there. It now queues its own read-back, pinned by `resendQueuesItsOwnReadBack`.

## Testing

Six slots added to the existing `tests/tst_shotsettings.cpp` (no new TU): burst matching, elided write queues no expectation, unsolicited report falls back to commanded, pre-first-write report has no expectation, resend queues its own read, disconnect clears the queue.

Verified the tests can fail: breaking the pop reproduces the log's exact phantom —

```
FAIL!  : burstOfWritesMatchesEachReportToItsOwnWrite()
   Actual   (expectedSteamTargetC()): 0
   Expected (160.0)                 : 160
```

— which is write 1's report judged against write 3's `steam=0`, i.e. `[3992.184]` above. Restored and green.

Full suite via Qt Creator: **117 passed, 0 failed, 0 warnings**. `check_log_markers.py`, `check_test_source_duplication.py` and `check_mcp_tool_budget.py` all pass.

No manual or release-note change: this is log-only behaviour, nothing on screen changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)