### PR TITLE
fix(scale): stop the cadence estimator latching onto a catch-up window

### DIFF
--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -2500,11 +2500,6 @@ void ProfileManager::uploadProfile(const QVariantMap& profileData) {
         }
         // Replace all steps atomically
         m_currentProfile.setSteps(newSteps);
-
-        qDebug() << "uploadProfile: Updated" << newSteps.size() << "steps";
-        for (int i = 0; i < newSteps.size(); i++) {
-            qDebug() << "  Frame" << i << ":" << newSteps[i].name << "temp=" << newSteps[i].temperature;
-        }
     }
 
     // Mark as modified

--- a/src/core/logcollapse.h
+++ b/src/core/logcollapse.h
@@ -194,6 +194,18 @@ public:
             .arg(c.spanMs / 1000);
     }
 
+    // For a caller whose key is a BUCKET rather than the whole line: the suppressed
+    // lines were alike, not identical, and saying "identical" would tell a reader the
+    // numbers never moved when they moved within the bucket.
+    static QString suffixSimilar(const Collapsed& c)
+    {
+        if (c.suppressed <= 0)
+            return QString();
+        return QStringLiteral(" (+%1 similar in the preceding %2 s)")
+            .arg(c.suppressed)
+            .arg(c.spanMs / 1000);
+    }
+
 private:
     struct Entry
     {

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -6,7 +6,6 @@
 #include <QDebug>
 #include <algorithm>
 #include <chrono>
-#include <utility>
 
 // Aliases, not copies — see sawlogging.h. This class runs on a worker thread and
 // carries no logMessage signal, so the STDERR forms are the right ones here.
@@ -24,10 +23,11 @@
 // line's text, and m_constantSampleLog's declaration says why: the text carries
 // the weight, so keying on it would open a run per value and close none of them.
 constexpr auto kConstantSampleLogKey = QLatin1String("constantWeightAlive");
-// Split high/low so both halves of one hitch survive the collapse — see the
-// m_rateDisagreeLog declaration.
-constexpr auto kRateDisagreeSlowKey = QLatin1String("dejitterWindowSlow");
-constexpr auto kRateDisagreeFastKey = QLatin1String("dejitterWindowFast");
+// Collapse key for the disagreement line: measured interval in 50 ms buckets, capped.
+// Bucketed rather than constant so an episode's worst window still speaks; capped
+// because logcollapse.h requires a caller keying on measured data to bound its keys.
+constexpr int kRateDisagreeBucketMs = 50;
+constexpr int kRateDisagreeMaxBucket = 20;
 
 // Largest pre-shot zero we will treat as drift and subtract. Measured drift is
 // 0.1-0.5 g; 2 g leaves room for a worse scale while staying far below any cup, so a
@@ -267,10 +267,10 @@ void WeightProcessor::processWeight(double weight)
     if (m_rateWindowStartMs == 0 || sinceLast > kReconnectGapMs) {
         // Measurements from before a reconnect describe a different stream.
         // Through the helper, never field-by-field: m_rateRecentCount is a FILL
-        // count that the minimum loop below uses as an index bound, which is only
+        // count that the median below uses as an index bound, which is only
         // valid while writes restart at zero. Clearing the count here and leaving
         // m_rateRecentNext where it was is a two-line edit that reads correct and
-        // is not — the next window writes at the stale index, the loop reads
+        // is not — the next window writes at the stale index, the median reads
         // [0, count) and so reads the pre-reconnect value it was just told to
         // discard while never reading the fresh one. Two windows, ~2 s, of the
         // wrong cadence, arriving exactly when a feed has just come back.
@@ -284,59 +284,38 @@ void WeightProcessor::processWeight(double weight)
         // every synthetic timestamp identical, the exact failure being fixed here.
         const int measured =
             qMax(1, static_cast<int>(rateSpanMs / (m_rateWindowCount - 1)));
-        // MEDIAN of the last few windows, not the minimum, not an average, not the
-        // latest.
+        // MEDIAN of the last few windows, not the minimum and not the latest.
         //
-        // This was a MINIMUM, justified by a claim that reads well and is false:
-        // that a hiccup "can only ever push `measured` UP, since nothing delivers
-        // more samples than the scale sent". True of the whole stream, false of one
-        // window. A stalled transport does not DROP samples, it QUEUES them, and the
-        // backlog lands in the next window — which then holds roughly twice the
-        // arrivals its span deserves and measures roughly half the true interval.
-        // The minimum latched onto exactly that value and held it for the ring's
-        // full depth. From a field log, one main-thread hitch:
+        // A stalled transport does not DROP samples, it QUEUES them: the backlog lands
+        // in one window that then holds twice the arrivals its span deserves and
+        // measures half the true interval. The minimum this replaced assumed
+        // contamination could only push `measured` UP — true of the stream, false of
+        // one window — and latched onto that catch-up value for the ring's full depth.
+        // From a field log, one main-thread hitch:
         //
         //     measured=609 committed=99  (arrivals=4  over 1828 ms)  starved window
         //     measured=96  committed=42  (arrivals=12 over 1066 ms)  42 latched
         //     measured=100 committed=42  (arrivals=11 over 1004 ms)  still latched
         //
-        // 42 ms against a true ~100 ms is the batched branch below spacing synthetic
-        // timestamps 2.4x too tightly for ~3 s, i.e. flow over-read 2.4x, arriving
-        // right after a hitch. Simulated over a 10 Hz feed with a 500 ms stall every
-        // 10 s, mean |committed - truth| is 10.2 ms under the minimum and 0.0 under
-        // the median, worst committed 66 ms against 100.
+        // 42 ms against a true ~100 ms spaces synthetic timestamps 2.4x too tightly
+        // for ~3 s — flow over-read 2.4x, right after a hitch.
         //
-        // An EMA is worse than either: on a 10 Hz feed with one 1.5 s hiccup it
-        // pulled the estimate to 145 ms and ~1 s of pour read 1.38-1.53 g/s against
-        // a true 2.00.
-        //
-        // What the median does NOT fix is the burst oscillation held as a
-        // QEXPECT_FAIL by cadenceEstimateDoesNotTrackTheLowTail — measured at
-        // matching sample positions there, minimum reads 2.25 2.92 2.92 2.25 0.04
-        // and median 2.16 2.96 2.96 2.16 0.04. Same shape, same near-zero at the
-        // burst boundary. That fixture has a majority of contaminated windows, which
-        // is the one shape a median cannot reject; do not read this change as
-        // addressing it.
+        // Does NOT address the burst oscillation held as a QEXPECT_FAIL by
+        // cadenceEstimateDoesNotTrackTheLowTail: that fixture has a majority of
+        // contaminated windows, the one shape a median cannot reject.
         m_rateRecent[m_rateRecentNext] = measured;
         m_rateRecentNext = (m_rateRecentNext + 1) % kRateRecentWindows;
         if (m_rateRecentCount < kRateRecentWindows) ++m_rateRecentCount;
-        // Upper of the two while the ring is still filling, deliberately: a larger
-        // interval spreads synthetic timestamps wider and UNDER-reads flow, which is
-        // the safe direction for a stop-at-weight decision.
+        // Upper of the two while filling. Pinned so it cannot flip silently, NOT argued
+        // as safer: a larger interval under-reads flow, so SAW fires late.
         int sorted[kRateRecentWindows];
         std::copy(m_rateRecent, m_rateRecent + m_rateRecentCount, sorted);
         std::sort(sorted, sorted + m_rateRecentCount);
         const int committed = sorted[m_rateRecentCount / 2];
 
-        // Disagreement between this window and what we are committing to. Silent
-        // while the estimator is stable, which is most of the time.
-        //
-        // Under the old minimum this could only ever fire on a window SLOWER than
-        // the commit — `measured` was in the ring, so committed <= measured always —
-        // which meant the window that did the damage was the one window that could
-        // not speak. The 42 ms window above appears in that log only as somebody
-        // else's `committed`. A median removes the asymmetry for free: both tails
-        // now log, and the two innocent windows after an outlier go quiet.
+        // Silent while the estimator is stable. Both tails speak: a starved window and
+        // the catch-up window behind it are one episode, and the catch-up one moves
+        // the estimate.
         if (committed > 0
             && qAbs(measured - committed) * 100 > kRateDisagreementPct * committed) {
             // SCALEFEED, not SAWW: this answers "were the readings timed right",
@@ -345,20 +324,26 @@ void WeightProcessor::processWeight(double weight)
             // filed under [SAW] first, where a reader chasing a stop-at-weight
             // problem would meet rate-estimator noise and a reader checking feed
             // health would never see it.
-            //
-            // The collapse decides only WHETHER to speak; the wording stays here and
-            // keeps the real numbers, so a constant decision text is right — the
-            // direction is already carried by the key.
-            const QString key = measured > committed ? QString(kRateDisagreeSlowKey)
-                                                     : QString(kRateDisagreeFastKey);
+            const QString key =
+                QString::number(qMin(measured / kRateDisagreeBucketMs, kRateDisagreeMaxBucket));
             LogCollapse::Collapsed collapsed;
-            if (m_rateDisagreeLog.shouldLog(key, QStringLiteral("disagree"), wallClock,
-                                            &collapsed)) {
+            if (m_rateDisagreeLog.shouldLog(key, key, wallClock, &collapsed)) {
                 SCALEFEED_LOG(QStringLiteral("De-jitter rate window disagrees: measured=%1 ms "
                                         "committed=%2 ms (arrivals=%3 over %4 ms)")
                              .arg(measured).arg(committed)
                              .arg(m_rateWindowCount).arg(rateSpanMs)
-                             + LogCollapse::suffix(collapsed));
+                             + LogCollapse::suffixSimilar(collapsed));
+            }
+        } else if (committed > 0) {
+            // An agreeing window ends the episode. Event-based and within one window of
+            // the real end, which is what keeps the span honest: flush() dates a tally
+            // to the moment it fires, so deferring to a shot boundary printed an idle
+            // episode inside the next shot (the bug m_constantSampleLog already carries).
+            for (const auto& [bucket, collapsed] : m_rateDisagreeLog.flushAll(wallClock)) {
+                SCALEFEED_LOG(QStringLiteral("De-jitter rate window disagreement run ended "
+                                             "(measured ~%1 ms)")
+                                  .arg(bucket.toInt() * kRateDisagreeBucketMs)
+                              + LogCollapse::suffixSimilar(collapsed));
             }
         }
         m_estimatedIntervalMs = committed;
@@ -928,21 +913,6 @@ void WeightProcessor::resetRateCalibration(qint64 windowStartMs)
     m_rateRecentCount = 0;
     m_rateRecentNext = 0;
     m_burstFrames = 0;
-
-    // Run end for the disagreement collapse. Two named keys rather than flushAll():
-    // the key space here is fixed at two and naming them keeps the tally line able to
-    // say which direction it stood for.
-    const qint64 nowMs = m_wallClock();
-    for (const auto& entry : {std::pair{kRateDisagreeSlowKey, "slower"},
-                              std::pair{kRateDisagreeFastKey, "faster"}}) {
-        const LogCollapse::Collapsed collapsed =
-            m_rateDisagreeLog.flush(QString(entry.first), nowMs);
-        if (collapsed.suppressed > 0) {
-            SCALEFEED_LOG(QStringLiteral("De-jitter rate window disagreement run ended (%1)")
-                              .arg(QLatin1String(entry.second))
-                          + LogCollapse::suffix(collapsed));
-        }
-    }
 }
 
 void WeightProcessor::checkScaleFeedStall(int frameNumber)

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -4,7 +4,9 @@
 #include "sawprediction.h"
 #include <QtMath>
 #include <QDebug>
+#include <algorithm>
 #include <chrono>
+#include <utility>
 
 // Aliases, not copies — see sawlogging.h. This class runs on a worker thread and
 // carries no logMessage signal, so the STDERR forms are the right ones here.
@@ -22,6 +24,10 @@
 // line's text, and m_constantSampleLog's declaration says why: the text carries
 // the weight, so keying on it would open a run per value and close none of them.
 constexpr auto kConstantSampleLogKey = QLatin1String("constantWeightAlive");
+// Split high/low so both halves of one hitch survive the collapse — see the
+// m_rateDisagreeLog declaration.
+constexpr auto kRateDisagreeSlowKey = QLatin1String("dejitterWindowSlow");
+constexpr auto kRateDisagreeFastKey = QLatin1String("dejitterWindowFast");
 
 // Largest pre-shot zero we will treat as drift and subtract. Measured drift is
 // 0.1-0.5 g; 2 g leaves room for a worse scale while staying far below any cup, so a
@@ -278,55 +284,59 @@ void WeightProcessor::processWeight(double weight)
         // every synthetic timestamp identical, the exact failure being fixed here.
         const int measured =
             qMax(1, static_cast<int>(rateSpanMs / (m_rateWindowCount - 1)));
-        // MINIMUM of the last few windows, not an average and not the latest.
+        // MEDIAN of the last few windows, not the minimum, not an average, not the
+        // latest.
         //
-        // Contamination here is one-directional: a dropped frame or a sub-reconnect
-        // hiccup removes arrivals from a window and can only ever push `measured`
-        // UP, since nothing delivers more samples than the scale sent. So the
-        // smallest recent window is the least contaminated, and taking it discards a
-        // bad window outright instead of blending its error in. An EMA was tried
-        // first and is worse: simulated on a 10 Hz feed with one 1.5 s hiccup it
+        // This was a MINIMUM, justified by a claim that reads well and is false:
+        // that a hiccup "can only ever push `measured` UP, since nothing delivers
+        // more samples than the scale sent". True of the whole stream, false of one
+        // window. A stalled transport does not DROP samples, it QUEUES them, and the
+        // backlog lands in the next window — which then holds roughly twice the
+        // arrivals its span deserves and measures roughly half the true interval.
+        // The minimum latched onto exactly that value and held it for the ring's
+        // full depth. From a field log, one main-thread hitch:
+        //
+        //     measured=609 committed=99  (arrivals=4  over 1828 ms)  starved window
+        //     measured=96  committed=42  (arrivals=12 over 1066 ms)  42 latched
+        //     measured=100 committed=42  (arrivals=11 over 1004 ms)  still latched
+        //
+        // 42 ms against a true ~100 ms is the batched branch below spacing synthetic
+        // timestamps 2.4x too tightly for ~3 s, i.e. flow over-read 2.4x, arriving
+        // right after a hitch. Simulated over a 10 Hz feed with a 500 ms stall every
+        // 10 s, mean |committed - truth| is 10.2 ms under the minimum and 0.0 under
+        // the median, worst committed 66 ms against 100.
+        //
+        // An EMA is worse than either: on a 10 Hz feed with one 1.5 s hiccup it
         // pulled the estimate to 145 ms and ~1 s of pour read 1.38-1.53 g/s against
-        // a true 2.00 g/s.
+        // a true 2.00.
         //
-        // A MEDIAN was tried, and the honest answer is that IT MAKES NO DIFFERENCE
-        // to the problem it was reached for. The argument was that ordinary jitter
-        // is two-directional, so the minimum of three noisy windows sits on their
-        // low tail. Measured at matching sample positions on the jittered bursty
-        // fixture in cadenceEstimateDoesNotTrackTheLowTail, one burst reads:
-        //
-        //     minimum   2.25  2.92  2.92  2.25  0.04
-        //     median    2.16  2.96  2.96  2.16  0.04
-        //
-        // Same shape, same magnitude, same near-zero at the burst boundary. An
-        // earlier version of this comment claimed the median was "twice as wrong"
-        // at 2.96 against 2.25; that was two different FRAMES of the oscillation
-        // above compared against each other, not one measurement under two
-        // statistics. Recorded because the wrong comparison looked convincing.
-        //
-        // The real defect is the oscillation itself — flow swinging from 0.04 to
-        // ~2.9 g/s inside a single burst on a true 2.00 g/s feed, with the last
-        // sample of every burst reading near zero. Which statistic is committed to
-        // does not touch it, so do not spend another pass on the statistic. It is
-        // held by cadenceEstimateDoesNotTrackTheLowTail as a QEXPECT_FAIL.
-        //
-        // A genuine rate change still lands asymmetrically: a scale speeding UP
-        // takes effect on the next closed window, since a smaller value wins the
-        // minimum immediately, while a slowdown waits for the stale entries to age
-        // out.
+        // What the median does NOT fix is the burst oscillation held as a
+        // QEXPECT_FAIL by cadenceEstimateDoesNotTrackTheLowTail — measured at
+        // matching sample positions there, minimum reads 2.25 2.92 2.92 2.25 0.04
+        // and median 2.16 2.96 2.96 2.16 0.04. Same shape, same near-zero at the
+        // burst boundary. That fixture has a majority of contaminated windows, which
+        // is the one shape a median cannot reject; do not read this change as
+        // addressing it.
         m_rateRecent[m_rateRecentNext] = measured;
         m_rateRecentNext = (m_rateRecentNext + 1) % kRateRecentWindows;
         if (m_rateRecentCount < kRateRecentWindows) ++m_rateRecentCount;
-        int committed = m_rateRecent[0];
-        for (int i = 1; i < m_rateRecentCount; ++i) {
-            committed = qMin(committed, m_rateRecent[i]);
-        }
+        // Upper of the two while the ring is still filling, deliberately: a larger
+        // interval spreads synthetic timestamps wider and UNDER-reads flow, which is
+        // the safe direction for a stop-at-weight decision.
+        int sorted[kRateRecentWindows];
+        std::copy(m_rateRecent, m_rateRecent + m_rateRecentCount, sorted);
+        std::sort(sorted, sorted + m_rateRecentCount);
+        const int committed = sorted[m_rateRecentCount / 2];
 
         // Disagreement between this window and what we are committing to. Silent
-        // while the estimator is stable, which is most of the time — it exists to
-        // catch the shape that was invisible until now: the per-window measurements
-        // are the input, and only their aggregate was ever logged, so an estimator
-        // walking the low tail of its own noise could not be seen from a field log.
+        // while the estimator is stable, which is most of the time.
+        //
+        // Under the old minimum this could only ever fire on a window SLOWER than
+        // the commit — `measured` was in the ring, so committed <= measured always —
+        // which meant the window that did the damage was the one window that could
+        // not speak. The 42 ms window above appears in that log only as somebody
+        // else's `committed`. A median removes the asymmetry for free: both tails
+        // now log, and the two innocent windows after an outlier go quiet.
         if (committed > 0
             && qAbs(measured - committed) * 100 > kRateDisagreementPct * committed) {
             // SCALEFEED, not SAWW: this answers "were the readings timed right",
@@ -335,10 +345,21 @@ void WeightProcessor::processWeight(double weight)
             // filed under [SAW] first, where a reader chasing a stop-at-weight
             // problem would meet rate-estimator noise and a reader checking feed
             // health would never see it.
-            SCALEFEED_LOG(QStringLiteral("De-jitter rate window disagrees: measured=%1 ms "
-                                    "committed=%2 ms (arrivals=%3 over %4 ms)")
-                         .arg(measured).arg(committed)
-                         .arg(m_rateWindowCount).arg(rateSpanMs));
+            //
+            // The collapse decides only WHETHER to speak; the wording stays here and
+            // keeps the real numbers, so a constant decision text is right — the
+            // direction is already carried by the key.
+            const QString key = measured > committed ? QString(kRateDisagreeSlowKey)
+                                                     : QString(kRateDisagreeFastKey);
+            LogCollapse::Collapsed collapsed;
+            if (m_rateDisagreeLog.shouldLog(key, QStringLiteral("disagree"), wallClock,
+                                            &collapsed)) {
+                SCALEFEED_LOG(QStringLiteral("De-jitter rate window disagrees: measured=%1 ms "
+                                        "committed=%2 ms (arrivals=%3 over %4 ms)")
+                             .arg(measured).arg(committed)
+                             .arg(m_rateWindowCount).arg(rateSpanMs)
+                             + LogCollapse::suffix(collapsed));
+            }
         }
         m_estimatedIntervalMs = committed;
         if (m_djIntervalMinMs == 0 || committed < m_djIntervalMinMs)
@@ -907,6 +928,21 @@ void WeightProcessor::resetRateCalibration(qint64 windowStartMs)
     m_rateRecentCount = 0;
     m_rateRecentNext = 0;
     m_burstFrames = 0;
+
+    // Run end for the disagreement collapse. Two named keys rather than flushAll():
+    // the key space here is fixed at two and naming them keeps the tally line able to
+    // say which direction it stood for.
+    const qint64 nowMs = m_wallClock();
+    for (const auto& entry : {std::pair{kRateDisagreeSlowKey, "slower"},
+                              std::pair{kRateDisagreeFastKey, "faster"}}) {
+        const LogCollapse::Collapsed collapsed =
+            m_rateDisagreeLog.flush(QString(entry.first), nowMs);
+        if (collapsed.suppressed > 0) {
+            SCALEFEED_LOG(QStringLiteral("De-jitter rate window disagreement run ended (%1)")
+                              .arg(QLatin1String(entry.second))
+                          + LogCollapse::suffix(collapsed));
+        }
+    }
 }
 
 void WeightProcessor::checkScaleFeedStall(int frameNumber)

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -91,6 +91,11 @@ public:
         Q_ASSERT(thread() == QThread::currentThread());
         m_wallClock = std::move(fn);
     }
+    // Test support: the committed cadence estimate. Asserted directly rather than
+    // through flow, because the estimate only reaches flow via the batched branch —
+    // a test that watched flow would pass on any feed that stopped batching, which
+    // is most of them.
+    int estimatedIntervalMsForTest() const { return m_estimatedIntervalMs; }
 #endif
 
 signals:
@@ -323,6 +328,24 @@ private:
     // A closing rate window this far from the committed estimate (percent) is worth
     // a line. Loose enough that ordinary jitter stays silent.
     static constexpr int kRateDisagreementPct = 15;
+    // A WINDOW, not kChangesOnly, and logcollapse.h names this exact case: a source
+    // already gated on a problem wants a real window, because its repeats are
+    // evidence rather than reassurance. kChangesOnly would also do nothing here —
+    // the line carries three changing numbers, so no two are ever byte-identical.
+    //
+    // 5 s because one transport hitch is one episode of 2-3 s: the window is sized
+    // to collapse an episode to a line, not to rate-limit a bad feed. Measured on a
+    // 31 h field log, disagreements fell 93 -> 39; widening to 60 s bought 6 more
+    // lines and would have started merging separate episodes.
+    //
+    // TWO keys, high and low, so an episode's starved window and its catch-up window
+    // both speak — collapsing them together would hide whichever arrived second, and
+    // the catch-up window is the one that moves the estimate.
+    //
+    // EPISODIC: flushed in resetRateCalibration(), the estimator's own run end. Not
+    // in endShotCycle() — this line fires at idle too, so a shot boundary would file
+    // an idle tally under a shot.
+    LogCollapse m_rateDisagreeLog{5000};
 
     // Log throttle timestamps — reset each shot so warnings are never suppressed at shot start
     qint64 m_lastTareWarnMs = 0;

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -91,11 +91,10 @@ public:
         Q_ASSERT(thread() == QThread::currentThread());
         m_wallClock = std::move(fn);
     }
-    // Test support: the committed cadence estimate. Asserted directly rather than
-    // through flow, because the estimate only reaches flow via the batched branch —
-    // a test that watched flow would pass on any feed that stopped batching, which
-    // is most of them.
-    int estimatedIntervalMsForTest() const { return m_estimatedIntervalMs; }
+    // The committed cadence estimate. Asserted directly rather than through flow: the
+    // estimate only reaches flow via the batched branch, so a flow-watching test would
+    // pass on any evenly-paced feed.
+    int estimatedIntervalMsForTesting() const { return m_estimatedIntervalMs; }
 #endif
 
 signals:
@@ -295,11 +294,9 @@ private:
     // WiFi scale until synthetic timestamps outran wall-clock. See processWeight().
     qint64 m_rateWindowStartMs = 0;     // Wall-clock start of the current rate window
     int m_rateWindowCount = 0;          // Arrivals seen in the current rate window
-    // Recent closed-window measurements, of which the MINIMUM is the estimate.
-    // Dropped frames and sub-reconnect hiccups can only inflate a window's
-    // measurement, never deflate it, so the smallest is the least contaminated.
-    // Three windows is the shortest run that survives one bad window while still
-    // following a genuine rate change within a few seconds. See processWeight().
+    // Recent closed-window measurements; the MEDIAN of them is the estimate — see
+    // processWeight() for why not the minimum. Three windows is the shortest run that
+    // rejects one bad window while still following a genuine rate change.
     static constexpr int kRateRecentWindows = 3;
     int m_rateRecent[kRateRecentWindows] = {0, 0, 0};
     int m_rateRecentNext = 0;           // Ring write position
@@ -328,23 +325,11 @@ private:
     // A closing rate window this far from the committed estimate (percent) is worth
     // a line. Loose enough that ordinary jitter stays silent.
     static constexpr int kRateDisagreementPct = 15;
-    // A WINDOW, not kChangesOnly, and logcollapse.h names this exact case: a source
-    // already gated on a problem wants a real window, because its repeats are
-    // evidence rather than reassurance. kChangesOnly would also do nothing here —
-    // the line carries three changing numbers, so no two are ever byte-identical.
-    //
-    // 5 s because one transport hitch is one episode of 2-3 s: the window is sized
-    // to collapse an episode to a line, not to rate-limit a bad feed. Measured on a
-    // 31 h field log, disagreements fell 93 -> 39; widening to 60 s bought 6 more
-    // lines and would have started merging separate episodes.
-    //
-    // TWO keys, high and low, so an episode's starved window and its catch-up window
-    // both speak — collapsing them together would hide whichever arrived second, and
-    // the catch-up window is the one that moves the estimate.
-    //
-    // EPISODIC: flushed in resetRateCalibration(), the estimator's own run end. Not
-    // in endShotCycle() — this line fires at idle too, so a shot boundary would file
-    // an idle tally under a shot.
+    // A WINDOW, not kChangesOnly: a source already gated on a problem wants its
+    // repeats, which are evidence rather than reassurance (logcollapse.h).
+    // 5 s sizes one transport hitch (a 2-3 s episode) to a line rather than
+    // rate-limiting a bad feed — on a 31 h field log, 93 -> 45 with the bucket key.
+    // EPISODIC: flushed by the first agreeing window, in processWeight().
     LogCollapse m_rateDisagreeLog{5000};
 
     // Log throttle timestamps — reset each shot so warnings are never suppressed at shot start

--- a/tests/tst_blegattqueue.cpp
+++ b/tests/tst_blegattqueue.cpp
@@ -276,8 +276,18 @@ private slots:
 
         q.noteFailed(de1());
         q.noteFailed(de1());   // same window, same generation
-        pump(80);
 
+        // QTRY_COMPARE for the arrival, then a settle for the absence — the two
+        // halves need opposite waits and a single fixed pump() cannot serve both.
+        // The retry is a real QTimer::singleShot (blegattqueue.cpp:267), NOT
+        // something advanceQueueClock() can drive: m_testClockSkewMs feeds nowMs()
+        // for the dispatch-wait log and nothing else. So this slot must wait real
+        // time, and a fixed pump(80) against a 40 ms delay left 40 ms of slack that
+        // a full parallel ctest run consumed — observed failing here at issued=1,
+        // i.e. the retry had not fired yet, which is the opposite of the 3 this
+        // slot exists to catch.
+        QTRY_COMPARE(rec.issued.size(), 2);
+        pump(80);
         QCOMPARE(rec.issued.size(), 2);   // not 3
     }
 

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -298,9 +298,8 @@ private slots:
     // kScaleStaleMs and kReconnectGapMs are both 2000, so a 1.5 s gap is by
     // definition neither a stall nor a reconnect, and an averaging estimator folded
     // it in as ordinary spacing: 145 ms learned for a 100 ms feed, and ~1 s of pour
-    // reading 1.38-1.53 g/s. Taking the minimum of recent windows discards the
-    // contaminated one instead — contamination is one-directional, since nothing
-    // can deliver MORE samples than the scale sent.
+    // reading 1.38-1.53 g/s. Taking the median of recent windows discards the
+    // contaminated one instead.
     void subReconnectHiccupDoesNotPoisonTheInterval() {
         WeightProcessor wp;
         installFakeClock(wp);
@@ -316,9 +315,9 @@ private slots:
     // measurement it just discarded.
     //
     // The reconnect branch clears the ring's fill count, and that count doubles as
-    // the index bound for the minimum loop — so it only means anything while the
+    // the index bound for the median — so it only means anything while the
     // write index is also back at zero. Clearing one and not the other left the
-    // next window writing at a stale index: the loop read the pre-reconnect value
+    // next window writing at a stale index: the median read the pre-reconnect value
     // it had been told to drop and never read the fresh one, for two windows, at
     // the exact moment a feed came back. Both fields now move through
     // resetRateCalibration().
@@ -359,20 +358,13 @@ private slots:
     }
 
     // A transport stall must not latch the cadence estimate onto the catch-up burst.
+    // A stall queues samples rather than dropping them, so the backlog lands in one
+    // window measuring half the true interval — see processWeight().
     //
-    // The estimator was a MINIMUM of three windows, justified by a claim that a
-    // hiccup can only push a window's measured interval UP. A stall does not drop
-    // samples, it queues them, so the backlog lands in ONE window that then holds
-    // twice the arrivals its span deserves and measures half the true interval. The
-    // minimum latched onto that and held it for the ring's full depth.
-    //
-    // The window trace this fixture produces, measured: 100 100 100 100, then 240
-    // (starved), then 42 (catch-up), then 100 100. Committed under the minimum is
-    // 42 for the last three; under the median it is 100 throughout.
-    //
-    // 1400 ms of stall on purpose — under kReconnectGapMs (2000), so calibration is
-    // NOT reset and the latch path is live. Above it the estimator starts over and
-    // the fixture proves nothing.
+    // The stall gives a 1500 ms inter-arrival gap (1400 plus the trailing step), under
+    // kReconnectGapMs (2000, weightprocessor.cpp:245): calibration is NOT reset, so the
+    // latch path is live. Above it the estimator starts over and the fixture proves
+    // nothing.
     void stallCatchUpDoesNotLatchTheCadenceEstimateLow() {
         WeightProcessor wp;
         installFakeClock(wp);
@@ -390,20 +382,21 @@ private slots:
         };
 
         for (int i = 0; i < 50; ++i) send(kCadenceMs);   // 5 s even: commits 100 ms
-        QCOMPARE(wp.estimatedIntervalMsForTest(), 100);
+        QCOMPARE(wp.estimatedIntervalMsForTesting(), 100);
 
         m_fakeClock += 1400;                             // transport stalls
         for (int i = 0; i < 14; ++i) send(2);            // backlog released together
 
-        int lowest = wp.estimatedIntervalMsForTest();
-        for (int i = 0; i < 40; ++i) {                   // feed resumes at 10 Hz
-            send(kCadenceMs);
-            lowest = qMin(lowest, wp.estimatedIntervalMsForTest());
-        }
+        // The latching window closes on the 10th sample of the resumed feed, so assert
+        // at a DEFINED point rather than min-tracking a loop whose length is load-
+        // bearing but unstated: at 8 samples the catch-up window never closes and the
+        // test would pass while discriminating nothing.
+        for (int i = 0; i < 12; ++i) send(kCadenceMs);   // feed resumes at 10 Hz
+        const int committed = wp.estimatedIntervalMsForTesting();
 
-        QVERIFY2(lowest >= 90,
-                 qPrintable(QString("cadence estimate fell to %1 ms after a 1.4 s "
-                                    "transport stall on a true 100 ms feed").arg(lowest)));
+        QVERIFY2(committed >= 90,
+                 qPrintable(QString("cadence estimate fell to %1 ms after a 1.5 s "
+                                    "transport stall on a true 100 ms feed").arg(committed)));
     }
 
     // KNOWN DEFECT, held here on purpose: jittered burst timing over-reads flow.
@@ -435,12 +428,11 @@ private slots:
     // irregularly — gaps followed by tight runs — which is a different problem the
     // 65%-fill rule handles badly and which this fixture does not model.
     //
-    // What it is NOT: a choice of averaging statistic. The estimate was switched
-    // from minimum-of-three to median-of-three specifically to fix this. Measured
-    // at MATCHING sample positions the median gives 2.16 2.96 2.96 2.16 0.04 —
-    // the same shape, the same near-zero. An earlier version of this comment
-    // claimed the median was "twice as wrong" at 2.96 against 2.25; those were two
-    // different frames of the oscillation above, compared against each other.
+    // What it is NOT: a choice of averaging statistic. The estimate is a
+    // median-of-three, switched from minimum-of-three to fix the stall latch (a
+    // different defect — see processWeight()), and measured at MATCHING sample
+    // positions the median gives 2.16 2.96 2.96 2.16 0.04 against the minimum's
+    // 2.25 2.92 2.92 2.25 0.04: the same shape, the same near-zero.
     // Recorded because the wrong comparison was convincing enough to ship.
     //
     // Do not compare statistics on a single sample from this fixture. Any one frame
@@ -491,10 +483,10 @@ private slots:
             hi = qMax(hi, f);
         }
         QEXPECT_FAIL("", "Jittered burst timing makes short flow oscillate within "
-                         "each burst (measured 0.04-2.92 g/s on a true 2.00, with the "
+                         "each burst (measured 0.04-2.96 g/s on a true 2.00, with the "
                          "last sample of every burst near zero). Open. NOT a choice "
-                         "of averaging statistic — median measures the same. See the "
-                         "comment above this test.", Abort);
+                         "of averaging statistic — the minimum measures the same. See "
+                         "the comment above this test.", Abort);
         QVERIFY2(hi - lo < 0.2 * kFlow,
                  qPrintable(QString("short flow swung %1 to %2 g/s within one burst "
                                     "on a steady %3 g/s feed").arg(lo).arg(hi).arg(kFlow)));

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -358,6 +358,54 @@ private slots:
         assertShortFlowNear(spy, 2.0, 3, "5 Hz bursty feed after a >2 s reconnect gap");
     }
 
+    // A transport stall must not latch the cadence estimate onto the catch-up burst.
+    //
+    // The estimator was a MINIMUM of three windows, justified by a claim that a
+    // hiccup can only push a window's measured interval UP. A stall does not drop
+    // samples, it queues them, so the backlog lands in ONE window that then holds
+    // twice the arrivals its span deserves and measures half the true interval. The
+    // minimum latched onto that and held it for the ring's full depth.
+    //
+    // The window trace this fixture produces, measured: 100 100 100 100, then 240
+    // (starved), then 42 (catch-up), then 100 100. Committed under the minimum is
+    // 42 for the last three; under the median it is 100 throughout.
+    //
+    // 1400 ms of stall on purpose — under kReconnectGapMs (2000), so calibration is
+    // NOT reset and the latch path is live. Above it the estimator starts over and
+    // the fixture proves nothing.
+    void stallCatchUpDoesNotLatchTheCadenceEstimateLow() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+
+        constexpr int kCadenceMs = 100;
+        constexpr double kFlow = 2.0;
+        qint64 sentMs = 0;
+
+        // Weight follows the time the sample was TAKEN, not the time it arrived —
+        // the queued samples carry the weights they were measured at.
+        auto send = [&](qint64 arrivalStepMs) {
+            wp.processWeight(kFlow * sentMs / 1000.0);
+            sentMs += kCadenceMs;
+            m_fakeClock += arrivalStepMs;
+        };
+
+        for (int i = 0; i < 50; ++i) send(kCadenceMs);   // 5 s even: commits 100 ms
+        QCOMPARE(wp.estimatedIntervalMsForTest(), 100);
+
+        m_fakeClock += 1400;                             // transport stalls
+        for (int i = 0; i < 14; ++i) send(2);            // backlog released together
+
+        int lowest = wp.estimatedIntervalMsForTest();
+        for (int i = 0; i < 40; ++i) {                   // feed resumes at 10 Hz
+            send(kCadenceMs);
+            lowest = qMin(lowest, wp.estimatedIntervalMsForTest());
+        }
+
+        QVERIFY2(lowest >= 90,
+                 qPrintable(QString("cadence estimate fell to %1 ms after a 1.4 s "
+                                    "transport stall on a true 100 ms feed").arg(lowest)));
+    }
+
     // KNOWN DEFECT, held here on purpose: jittered burst timing over-reads flow.
     //
     // This test FAILS by design (QEXPECT_FAIL). It reproduces a real defect that


### PR DESCRIPTION
## What

The de-jitter rate estimator committed the **minimum** of its last three windows. Its justification reads well and is false:

> a dropped frame or a sub-reconnect hiccup removes arrivals from a window and can only ever push `measured` **UP**, since nothing delivers more samples than the scale sent

True of the whole stream, false of one window. A stalled transport does not *drop* samples, it *queues* them. The backlog lands in the next window, which then holds roughly twice the arrivals its span deserves and measures roughly half the true interval. The minimum latched onto that and held it for the ring's full depth.

Switched to the median of the same three windows.

## Evidence

From a 31 h field log on real hardware. Every occurrence is a triple, and every one sits beside a main-thread hitch (screensaver exit, DE1 wake, settings-page construction):

```
measured=609 committed=99  (arrivals=4  over 1828 ms)   starved window
measured=96  committed=42  (arrivals=12 over 1066 ms)   42 latched
measured=100 committed=42  (arrivals=11 over 1004 ms)   still latched
```

42 ms against a true ~100 ms is the batched branch spacing synthetic timestamps 2.4× too tightly for ~3 s — flow over-read 2.4×, arriving right after a hitch.

Simulated over a 10 Hz feed, per 1000 closed windows:

| feed | statistic | lines | mean \|committed − 100\| | worst committed |
|---|---|---|---|---|
| 500 ms stall / 10 s | min | 299 | 10.2 | 66 |
| 500 ms stall / 10 s | **median** | 199 | **0.0** | **100** |
| burst5 jitter ±60 | min | 112 | 6.6 | 71 |
| burst5 jitter ±60 | **median** | 71 | **2.8** | 90 |
| clean 10 Hz | either | 0 | 0.0 | 100 |

## Scope of the win — read this before assuming it fixes a user's shot

On the maintainer's machine this is **inert**. All 30 shots in that log report `batched 0% | max burst 1`, and the batched branch is the only consumer of `m_estimatedIntervalMs`. The latch fires at idle, where nothing reads the estimate.

Whether it bites the user who reported the log noise is **unconfirmed** — they are on a BT scale, which does not by itself imply batching (the maintainer is too, at `batched 0%`). The decisive datum is their `De-jitter summary` line's `batched %`. Above 0 means the correctness fix matters there; at 0 it is a log-noise fix and nothing more.

Deliberately **not** in the release notes for that reason.

## Second defect, fixed for free

Under the minimum, `measured` was written into the ring *before* `committed` was computed, so `committed <= measured` always — the line could only ever fire on a window **slower** than the commit. The window that did the damage was the one window that could not speak: the 42 ms window above appears in that log only as somebody else's `committed`. A median removes the asymmetry; both tails now log and the two innocent windows after an outlier go quiet.

## Log volume

- Disagreement line collapsed through `LogCollapse`, 5 s window, **keyed on the measured interval in 50 ms buckets** (capped at 20, per `logcollapse.h`'s rule that a caller keying on measured data must bound its key space). A constant key would collapse an episode to whichever window *opened* it, swallowing a 609 ms starved window sitting behind a milder one — the opposite of the line's purpose. The bucket carries direction too, so it replaces a high/low key pair rather than adding to it. Measured on the field log: 93 → 45 (a constant key gives 39; the 6 lines buy back the worst window).
- The tally is flushed by the first **agreeing** window — an episode's real end, event-based per CLAUDE.md's no-timers rule. Flushing from `resetRateCalibration()` was wrong: only its reconnect caller is a run end, and `startExtraction()` is the *next* run's start, so an idle episode's tally surfaced inside the following shot with a span covering the gap. This file already carries that bug report on `m_constantSampleLog`.
- `LogCollapse::suffixSimilar()` added alongside `suffix()`: with a bucketed key the suppressed lines are alike but not identical, and `"(+N identical)"` would tell a reader the numbers never moved.
- `ProfileManager::uploadProfile`'s `Updated N steps` line and per-frame dump deleted. That function uploads nothing — the BLE write is deferred to editor exit (#557) — so every editor slider commit logged 8 lines describing an in-memory copy that cannot fail. 1440 lines for 25 actual uploads in a submitted log. The real BLE path logs frame **count and ACK order**, not per-frame name/temperature; those are recoverable from the shot record's `profile_json`.

## Tests

`stallCatchUpDoesNotLatchTheCadenceEstimateLow` asserts the estimate directly, via a new `estimatedIntervalMsForTest()`. Not through flow: the estimate only reaches flow via the batched branch, so a flow-watching test would pass on any feed that stopped batching. 1400 ms of stall on purpose — under `kReconnectGapMs` (2000), so calibration is not reset and the latch path is live.

**Red-on-old-code:** independently re-derived by two reviewers, who each reimplemented the window logic and got the trace `100 100 100 100, 240, 42, 100 100` — committed **42 under `min`, 100 under `median`**, against a threshold of 90. Still *derived* rather than observed: nobody reverted the hunk and watched it fail.

`cadenceEstimateDoesNotTrackTheLowTail` still XFAILs, as expected: that fixture has a majority of contaminated windows, the one shape a median cannot reject. The median is **not** a fix for the burst oscillation and the comment says so.

## Unrelated fix carried along

`tst_blegattqueue::asecondFailureInsideTheRetryDelayDoesNotArmASecondRetry` failed during this work's suite run (`issued=1`, expected 2). Its retry is a real `QTimer::singleShot` (`blegattqueue.cpp:267`), not something `advanceQueueClock()` can drive — `m_testClockSkewMs` feeds `nowMs()` for the dispatch-wait log and nothing else. So a fixed `pump(80)` against a 40 ms delay left 40 ms of slack that a full parallel ctest run consumed. Now `QTRY_COMPARE` for the arrival plus a settled `QCOMPARE` for the absence; the two halves want opposite waits and one fixed pump cannot serve both. The neighbouring slot already did it this way.

## Verification

- Build: 0 errors, 0 warnings (Qt 6.11.2, macOS).
- Suite: 117/117.

## Known gaps

- **No flush-wiring test.** `logcollapse.h` records that four of six callers got run-end flushing wrong, so this deserves one — but the fixture's two disagreements land in different buckets, so nothing is suppressed and there is no tally to assert without a second fixture.
- ~~**No lossy-feed test.**~~ **Withdrawn — this was misanalysed, and there is no defect here.** The concern was that the median introduces an error direction the minimum could not produce: packet loss contaminates *upward*, so two lossy windows of three carry the commit up. That is correct behaviour, not a fault. The estimator reconstructs **when samples were taken** so a burst can be spread across sample-time, and when packets are lost the surviving samples genuinely *are* further apart in taken-time. Simulated on a 30% lossy feed at a 100 ms send cadence:

  ```
  true mean gap between SURVIVING samples, in taken-time: 146 ms
  windows measured:  median 144 ms   min 100 ms
  ```

  The median lands on the truth. The **minimum** is the one that is wrong on a lossy feed — it pins the estimate at the pre-loss value, under-spaces the timestamps, compresses sample time and over-reads flow. Same failure as the stall latch, reached from the other direction. So the median fixes both, and there is no defect shape for a test to catch.
- `scripts/check_log_markers.py`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

