### PR TITLE
fix(scale): compute the median of three without std::sort

### DIFF
--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -4,7 +4,6 @@
 #include "sawprediction.h"
 #include <QtMath>
 #include <QDebug>
-#include <algorithm>
 #include <chrono>
 
 // Aliases, not copies — see sawlogging.h. This class runs on a worker thread and
@@ -306,12 +305,19 @@ void WeightProcessor::processWeight(double weight)
         m_rateRecent[m_rateRecentNext] = measured;
         m_rateRecentNext = (m_rateRecentNext + 1) % kRateRecentWindows;
         if (m_rateRecentCount < kRateRecentWindows) ++m_rateRecentCount;
+        // Spelled out rather than std::sort over the ring: GCC 13 at -O3 rejects a sort
+        // of a 3-element array under -Werror=array-bounds, because
+        // __final_insertion_sort names `__first + 16` in a branch that a range this
+        // short cannot reach. Clang does not, so it is a Linux-only build break — which
+        // is how it reached CI (run 33570498092). Three elements do not need a sort.
+        //
         // Upper of the two while filling. Pinned so it cannot flip silently, NOT argued
         // as safer: a larger interval under-reads flow, so SAW fires late.
-        int sorted[kRateRecentWindows];
-        std::copy(m_rateRecent, m_rateRecent + m_rateRecentCount, sorted);
-        std::sort(sorted, sorted + m_rateRecentCount);
-        const int committed = sorted[m_rateRecentCount / 2];
+        const int committed =
+            m_rateRecentCount == 1 ? m_rateRecent[0]
+          : m_rateRecentCount == 2 ? qMax(m_rateRecent[0], m_rateRecent[1])
+          : qMax(qMin(m_rateRecent[0], m_rateRecent[1]),
+                 qMin(qMax(m_rateRecent[0], m_rateRecent[1]), m_rateRecent[2]));
 
         // Silent while the estimator is stable. Both tails speak: a starved window and
         // the catch-up window behind it are one episode, and the catch-up one moves


### PR DESCRIPTION
Fixes the red GCC builds on the `v2.0.5` tag.

## The break

GCC 13 at `-O3` rejects `std::sort` over a 3-element array under `-Werror=array-bounds`:

```
error: array subscript 16 is outside array bounds of 'int [3]' [-Werror=array-bounds=]
 1859 |   std::__insertion_sort(__first, __first + int(_S_threshold), __comp);
note: at offset 64 into object 'sorted' of size 12
```

`__final_insertion_sort` names `__first + 16` in a branch a 3-element range cannot reach. The code is correct; the diagnostic fires anyway.

## Why it reached CI

Clang does not emit it. A macOS local build — which is the project's pre-PR gate — cannot catch this class at all. Both GCC targets went red on the tag ([Linux AppImage run 33570498092](https://github.com/Kulitorum/Decenza/actions/runs/33570498092), Linux ARM64); Android, macOS, Windows and iOS all built clean.

## The fix

Three elements do not need a sort:

```cpp
const int committed =
    m_rateRecentCount == 1 ? m_rateRecent[0]
  : m_rateRecentCount == 2 ? qMax(m_rateRecent[0], m_rateRecent[1])
  : qMax(qMin(m_rateRecent[0], m_rateRecent[1]),
         qMin(qMax(m_rateRecent[0], m_rateRecent[1]), m_rateRecent[2]));
```

Behaviour is identical, including the documented upper-of-two while the ring is still filling. Drops the `<algorithm>` include and the copy into a scratch array. Verified by hand against the values from the field trace: `(100, 240, 42)` → 100 and `(240, 42, 100)` → 100, matching what `std::sort` produced.

## Verification status

**Not yet built or tested locally** — opened at the maintainer's explicit instruction while the release is blocked. The local build hit an unrelated stoppage first: a `moc_de1simulator.cpp.json` truncated at exactly 4096 bytes by an interrupted moc earlier in the session, which needed the header touched to regenerate. Build and suite still to run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)