### PR TITLE
Split _snapTo's three steps so the tablet can say where 728 ms goes

### DIFF
--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -208,11 +208,33 @@ DecenzaDialog {
         // animation toward a far row; repositioning then fights it and
         // StrictlyEnforceRange re-animates — a visible tug-of-war. Positioned
         // first, the currentIndex assignment is a zero-distance move.
+        //
+        // TEMPORARY instrumentation. _centerWheels measured 728 ms on one open
+        // of a Samsung SM-X210 (15 ms on the open before it, same target index),
+        // against 0-5 ms on a Mac — so the Mac cannot see this and the split has
+        // to come off the tablet. The three steps below are timed separately
+        // because they fail differently: a slow pos1 is the view walking from
+        // row 0 to the target, a slow idx is the highlight move the two
+        // assignments above are meant to have disarmed, and a slow pos2 is a
+        // redundant second traversal that could just be dropped. `from` and
+        // `count` are logged so the traversal DISTANCE is on the record rather
+        // than inferred — the 15 ms open and the 728 ms open had the same target.
+        var _from = tumbler.currentIndex
+        var _t0 = Date.now()
         if (lv)
             lv.positionViewAtIndex(index, ListView.Center)
+        var _tPos1 = Date.now()
         tumbler.currentIndex = index
+        var _tIdx = Date.now()
         if (lv)
             lv.positionViewAtIndex(index, ListView.Center)
+        var _tPos2 = Date.now()
+        console.info("[Equipment] grind picker: _snapTo count=" + tumbler.count
+                     + " from=" + _from + " to=" + index
+                     + " pos1=" + (_tPos1 - _t0) + "ms"
+                     + " idx=" + (_tIdx - _tPos1) + "ms"
+                     + " pos2=" + (_tPos2 - _tIdx) + "ms"
+                     + " view=" + (lv ? "yes" : "NO"))
     }
 
     // Centre each wheel on its current row. A wheel with no current value (an


### PR DESCRIPTION
Follow-up to #1898. Instrumentation only — no behaviour change.

## Why

#1898 fixed the query (measured on the reporter's tablet: **435/483 ms → 3/6 ms**, confirmed by his log) and cut row generation. But the instrumentation it shipped then found the real remaining cost, which is not any of the things that PR optimised:

```
open 1:  step-query 6   build 14  assign 12  _centerWheels  15ms   TOTAL  45ms
open 2:  step-query 3   build 17  assign 15  _centerWheels 728ms   TOTAL 765ms
```

**728 ms in `_centerWheels`.** Everything #1898 touched sums to ~35 ms of that open.

Worth stating plainly: I had explicitly ruled this out. Mac measurements put `_centerWheels` at 0–5 ms, and I wrote off the `positionViewAtIndex` theory on that basis. The Mac cannot see it.

## What this adds

`_snapTo` does three things that fail differently, and the aggregate can't tell them apart:

```qml
lv.positionViewAtIndex(index, ListView.Center)   // pos1
tumbler.currentIndex = index                     // idx
lv.positionViewAtIndex(index, ListView.Center)   // pos2
```

- slow **pos1** — the view walking from row 0, where a freshly assigned model leaves it, to the centred target. Then the row count (`grindWindowSteps: 400`) is the lever.
- slow **idx** — the velocity-limited highlight move the two lines above it are meant to have disarmed. That would mean the existing mitigation isn't working.
- slow **pos2** — a redundant repeat traversal. Cheapest fix of the three: delete the line.

Also logs `from`, `to` and `count`, so the traversal **distance** is recorded rather than inferred. That matters specifically here: the 15 ms open and the 728 ms open had the same target index and the same 801 rows, so "distance" is a hypothesis with nothing behind it yet.

## Notes

- At INFO deliberately, so it reaches the connections view and a submitted log — the tablet is the only machine that reproduces this.
- Temporary, paired with the instrumentation already on the open path from #1898. All of it comes out together once the cause is named.
- Local suite: 117 passed, 0 failed. `text-invariants` gates pass.
- The wheel already opens centred on the current value (`isCurrent` is the `n === 0` row, index ~400 of 801) — so this is not about *choosing* the middle, it is about how the view gets there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
