### PR TITLE
fix(usb): use the _STDERR log macros in usbhotplug's free functions

### DIFF
--- a/src/usb/usbhotplug.cpp
+++ b/src/usb/usbhotplug.cpp
@@ -12,6 +12,8 @@
 #include <QPointer>
 #endif
 
+// _STDERR forms throughout: everything here is a free function, and the non-STDERR
+// macros expand to `emit logMessage(...)`.
 #define HOTPLUG_INFO(msg) SCALE_INFO_STDERR_TAGGED("USB Scale", msg)
 #define HOTPLUG_WARN(msg) SCALE_WARN_STDERR_TAGGED("USB Scale", msg)
 
@@ -43,7 +45,7 @@ void nativeOnUsbDeviceChanged(JNIEnv*, jclass, jint vendorId, jint productId, jb
                                                : QStringLiteral("detached"),
                                       QString::number(vid, 16), QString::number(pid, 16));
         if (isScale) HOTPLUG_INFO(what);
-        else         DE1_INFO_TAGGED("USB", what);
+        else         DE1_INFO_STDERR_TAGGED("USB", what);
 
         if (isScale) {
             if (s_scaleManager) s_scaleManager->onHotplugEvent();
@@ -68,7 +70,7 @@ void nativeOnUsbPermissionResult(JNIEnv*, jclass, jboolean isScale)
             HOTPLUG_INFO(what);
             if (s_scaleManager) s_scaleManager->onPermissionResult();
         } else {
-            DE1_INFO_TAGGED("USB", what);
+            DE1_INFO_STDERR_TAGGED("USB", what);
             if (s_de1Manager) s_de1Manager->onPermissionResult();
         }
     }, Qt::QueuedConnection);


### PR DESCRIPTION
Fixes the red Android build on the `v2.0.5` tag ([run 33583164289](https://github.com/Kulitorum/Decenza/actions/runs/33583164289)).

```
usbhotplug.cpp:46:22: error: use of undeclared identifier 'logMessage'
usbhotplug.cpp:71:13: error: use of undeclared identifier 'logMessage'
```

Both were `DE1_INFO_TAGGED`. The non-`_STDERR` macros expand to `emit logMessage(...)`, which needs a QObject carrying that signal — and everything in `usbhotplug.cpp` is a free function in an anonymous namespace. The scale arm right beside it already used `SCALE_INFO_STDERR_TAGGED`; the DE1 arm was added later, in the commit that split the marker by device kind, and reached for the wrong half of the pair.

## Why the local build missed it

The whole branch is inside `#ifdef Q_OS_ANDROID`, so the macOS build compiles none of it — it only ever sees the `#else` stub. This is the third Android-only change in this area and the first one CI has actually compiled; the class of error was predicted but not preventable locally.

`de1logging.h:67` already states the constraint. The note is now also at the macro definitions in `usbhotplug.cpp`, which is where the next free function added to that file will look.

## Also checked, since the same blindness applies

- `USB_WARN` in `USBManager::onPermissionResult()` is the signal-emitting form and is **correct** — it is a member of a class that has `logMessage`.
- `AndroidUsbHelper::hasPermission()` and `AndroidUsbScaleHelper::hasPermission()` both exist, and both headers are included in the files that call them.
- No other non-`_STDERR` subsystem macro remains in `usbhotplug.cpp`.

## Verification

Local build clean — which proves nothing about the fix, for the reason above. **CI on the next tag push is the verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)