### PR TITLE
fix(usb): route a shared CH9102 id to both managers, not just the DE1

### DIFF
--- a/android/res/xml/device_filter.xml
+++ b/android/res/xml/device_filter.xml
@@ -2,10 +2,12 @@
 <resources>
     <!-- Adding an id here is not enough on its own. A SCALE id must also be added to
          kUsbScalePid* in src/usb/usbhotplug.h, or hotplug routes that scale to the
-         DE1 manager, and to AndroidUsbScale.PRODUCT_ID_SCALE_* or findDevice() will
-         not see it. tst_usbdecentscale.cpp fails on the first of those; nothing
+         right predicate, and to AndroidUsbScale.PRODUCT_ID_SCALE_* or findDevice()
+         will not see it. tst_usbdecentscale.cpp fails on the first of those; nothing
          catches the second. -->
-    <!-- DE1 espresso machine: WCH CH9102 (VID 0x1A86 = 6790, PID 0x55D3 = 21971) -->
+    <!-- WCH CH9102 (VID 0x1A86 = 6790, PID 0x55D3 = 21971). SHARED: the DE1 and the
+         Half Decent Scale both use this bridge chip, so this id identifies neither on
+         its own — see usbPidMayBe* in src/usb/usbhotplug.h. -->
     <usb-device vendor-id="6790" product-id="21971" />
     <!-- Half Decent Scale: WCH CH340 (VID 0x1A86 = 6790, PID 0x7522 or 0x7523) -->
     <usb-device vendor-id="6790" product-id="29986" />

--- a/android/src/io/github/kulitorum/decenza_de1/AndroidUsbScale.java
+++ b/android/src/io/github/kulitorum/decenza_de1/AndroidUsbScale.java
@@ -34,6 +34,11 @@ public class AndroidUsbScale {
     private static final int VENDOR_ID_WCH = 0x1A86;
     private static final int PRODUCT_ID_SCALE_1 = 0x7522;  // CH340 variant — Half Decent Scale
     private static final int PRODUCT_ID_SCALE_2 = 0x7523;  // CH340 variant — Half Decent Scale
+    // SHARED with the DE1: an HDS on an ESP32-S3 board enumerates through a CH9102,
+    // the same bridge the DE1 uses. Matching it here means findDevice() can return a
+    // DE1, which is why the caller must still probe: only the scale answers the scale
+    // handshake. Observed as vid=0x1a86 pid=0x55d3 serial HDS-900910.
+    private static final int PRODUCT_ID_SHARED_CH9102 = 0x55D3;
     // Owned by UsbHotplugReceiver, which is what listens for the result.
     private static final String PERMISSION_ACTION = UsbHotplugReceiver.SCALE_PERMISSION_ACTION;
 
@@ -77,7 +82,8 @@ public class AndroidUsbScale {
         for (UsbDevice device : deviceList.values()) {
             if (device.getVendorId() == VENDOR_ID_WCH
                     && (device.getProductId() == PRODUCT_ID_SCALE_1
-                        || device.getProductId() == PRODUCT_ID_SCALE_2)) {
+                        || device.getProductId() == PRODUCT_ID_SCALE_2
+                        || device.getProductId() == PRODUCT_ID_SHARED_CH9102)) {
                 return device;
             }
         }

--- a/src/usb/usbhotplug.cpp
+++ b/src/usb/usbhotplug.cpp
@@ -37,20 +37,19 @@ void nativeOnUsbDeviceChanged(JNIEnv*, jclass, jint vendorId, jint productId, jb
     const bool isAttach = (attached == JNI_TRUE);
 
     QMetaObject::invokeMethod(qApp, [vid, pid, isAttach]() {
-        const bool isScale = (usbDeviceKindForPid(pid) == UsbDeviceKind::Scale);
-        // Marker follows the DEVICE, not this file: one shared receiver does not
-        // make the DE1's cable a scale event.
         const QString what = QStringLiteral("Hotplug: %1 (vid=0x%2 pid=0x%3)")
                                  .arg(isAttach ? QStringLiteral("attached")
                                                : QStringLiteral("detached"),
                                       QString::number(vid, 16), QString::number(pid, 16));
-        if (isScale) HOTPLUG_INFO(what);
-        else         DE1_INFO_STDERR_TAGGED("USB", what);
-
-        if (isScale) {
-            if (s_scaleManager) s_scaleManager->onHotplugEvent();
-        } else {
+        // Both, when the id is ambiguous. A manager whose device did not answer its
+        // probe gives up on its own; the cost of asking is one handshake.
+        if (usbPidMayBeDe1(pid)) {
+            DE1_INFO_STDERR_TAGGED("USB", what);
             if (s_de1Manager) s_de1Manager->onHotplugEvent();
+        }
+        if (usbPidMayBeScale(pid)) {
+            HOTPLUG_INFO(what);
+            if (s_scaleManager) s_scaleManager->onHotplugEvent();
         }
     }, Qt::QueuedConnection);
 }

--- a/src/usb/usbhotplug.h
+++ b/src/usb/usbhotplug.h
@@ -5,19 +5,27 @@
 class UsbScaleManager;
 class USBManager;
 
-// Anything not a scale id is assumed to be the DE1, so a scale id added to
-// device_filter.xml but not here is silently routed to the wrong manager.
-// tst_usbdecentscale.cpp's deviceFilterIdsRouteToTheRightManager binds the two.
-enum class UsbDeviceKind { Scale, De1 };
+// Which manager(s) a hotplug event belongs to. NOT either/or: the Half Decent
+// Scale ships with a CH9102 (0x55D3), the same bridge chip the DE1 uses, so that
+// id alone cannot tell them apart. Observed on hardware — an HDS attached as
+// vid=0x1a86 pid=0x55d3 (serial HDS-900910), was routed to the DE1 manager, and
+// timed out on the DE1's <+M> probe while never reaching the scale manager.
+//
+// So an ambiguous id notifies both, and the protocol probes decide: each manager's
+// pass gives up on a device that does not answer its own handshake.
+constexpr int kUsbScalePidCh340a = 0x7522;
+constexpr int kUsbScalePidCh340b = 0x7523;
+constexpr int kUsbSharedPidCh9102 = 0x55D3;   // DE1 *and* HDS
 
-constexpr int kUsbScalePid1 = 0x7522;
-constexpr int kUsbScalePid2 = 0x7523;
-
-constexpr UsbDeviceKind usbDeviceKindForPid(int productId)
+constexpr bool usbPidMayBeScale(int pid)
 {
-    return (productId == kUsbScalePid1 || productId == kUsbScalePid2)
-               ? UsbDeviceKind::Scale
-               : UsbDeviceKind::De1;
+    return pid == kUsbScalePidCh340a || pid == kUsbScalePidCh340b
+        || pid == kUsbSharedPidCh9102;
+}
+
+constexpr bool usbPidMayBeDe1(int pid)
+{
+    return pid == kUsbSharedPidCh9102;
 }
 
 /**

--- a/src/usb/usbscalemanager.h
+++ b/src/usb/usbscalemanager.h
@@ -174,10 +174,6 @@ private:
 #endif
     static constexpr int PROBE_TIMEOUT_MS = 3000;
     static constexpr uint16_t VENDOR_ID_WCH = 0x1A86;
-    // Ids live in usbhotplug.h — one declaration, since its classifier treats
-    // anything unlisted as the DE1.
-    static bool isScalePid(uint16_t pid)
-    {
-        return usbDeviceKindForPid(static_cast<int>(pid)) == UsbDeviceKind::Scale;
-    }
+    // Ids live in usbhotplug.h — one declaration.
+    static bool isScalePid(uint16_t pid) { return usbPidMayBeScale(static_cast<int>(pid)); }
 };

--- a/tests/tst_usbdecentscale.cpp
+++ b/tests/tst_usbdecentscale.cpp
@@ -99,51 +99,48 @@ private slots:
 
     // --- USB hotplug dispatch ------------------------------------------------
     //
-    // device_filter.xml is the single list of USB ids the app supports: the
-    // manifest's launch intent-filter uses it, and the hotplug receiver filters
-    // against it. usbDeviceKindForPid() then decides which manager an event goes
-    // to, from the product id alone.
+    // device_filter.xml is the single list of ids the app supports; these predicates
+    // decide which manager(s) an event reaches.
     //
-    // The defect shape no other test catches: a scale product id present in the XML
-    // but not in the C++ scale list. Nothing fails — the id is still "supported"
-    // and the receiver still forwards it — but every event for that scale routes to
-    // the DE1 manager, which probes for a DE1, finds none, and does nothing. A
-    // silent dead scale, from an edit that looked complete.
+    // The ids do NOT partition. The Half Decent Scale ships with a CH9102 (0x55D3),
+    // the same bridge chip the DE1 uses, so that id must reach both managers and the
+    // protocol probes decide. An earlier version routed 0x55D3 to the DE1 alone; on
+    // hardware an HDS then timed out on the DE1's <+M> probe and never reached the
+    // scale manager at all.
     //
-    // THE EXPECTED IDS ARE LITERALS HERE, DELIBERATELY. The first version of this
-    // test compared usbDeviceKindForPid() against kUsbScalePid1/kUsbScalePid2 —
-    // the same constants the function itself reads — so changing a constant moved
-    // both sides and the test passed. Verified by breaking it: with
-    // kUsbScalePid2 set to 0x9999 the whole suite still went green. A test that
-    // cannot fail is a comment that compiles; these literals are what give it teeth.
+    // EXPECTATIONS ARE LITERALS, DELIBERATELY. Comparing against the kUsb* constants
+    // moves both sides at once: with one changed to 0x9999 the suite stayed green.
+    // Do not "tidy" these into the constants.
 private:
-    // ONE table drives both slots below. It was two independent literal lists, and
-    // that made the pair satisfiable by the careless repair it exists to prevent:
-    // add a scale id to device_filter.xml, watch the XML slot go red, append the id
-    // to that slot's own `expected` list — green, with no routing row and no C++
-    // change, and the new scale silently routed to the DE1 manager. Now the only
-    // repair is a row here, and a row must state a kind.
-    struct SupportedId { int pid; UsbDeviceKind kind; const char* name; };
+    // One table drives both slots. Two independent lists made the pair satisfiable
+    // by the careless repair it exists to prevent — add an id to the XML, append it
+    // to the other slot's list, green, with no routing row.
+    struct SupportedId { int pid; bool mayBeScale; bool mayBeDe1; const char* name; };
     static QList<SupportedId> supportedIds() {
         return {
-            {0x7522, UsbDeviceKind::Scale, "scale CH340 0x7522"},
-            {0x7523, UsbDeviceKind::Scale, "scale CH340 0x7523"},
-            {0x55D3, UsbDeviceKind::De1,   "DE1 CH9102 0x55D3"},
+            {0x7522, true,  false, "scale CH340 0x7522"},
+            {0x7523, true,  false, "scale CH340 0x7523"},
+            {0x55D3, true,  true,  "shared CH9102 0x55D3 (DE1 and HDS)"},
         };
     }
 
 private slots:
     void deviceFilterIdsRouteToTheRightManager_data() {
         QTest::addColumn<int>("productId");
-        QTest::addColumn<int>("expectedKind");
+        QTest::addColumn<bool>("mayBeScale");
+        QTest::addColumn<bool>("mayBeDe1");
         for (const auto& id : supportedIds())
-            QTest::newRow(id.name) << id.pid << int(id.kind);
+            QTest::newRow(id.name) << id.pid << id.mayBeScale << id.mayBeDe1;
     }
 
     void deviceFilterIdsRouteToTheRightManager() {
         QFETCH(int, productId);
-        QFETCH(int, expectedKind);
-        QCOMPARE(int(usbDeviceKindForPid(productId)), expectedKind);
+        QFETCH(bool, mayBeScale);
+        QFETCH(bool, mayBeDe1);
+        QCOMPARE(usbPidMayBeScale(productId), mayBeScale);
+        QCOMPARE(usbPidMayBeDe1(productId), mayBeDe1);
+        // Every supported id must reach at least one manager, or its events vanish.
+        QVERIFY(mayBeScale || mayBeDe1);
     }
 
     // The rows above are only meaningful while they ARE the supported ids. This
@@ -164,7 +161,7 @@ private slots:
         std::sort(found.begin(), found.end());
 
         // From the routing table, not a second literal list — that is what makes an
-        // id added to the XML reach usbDeviceKindForPid() rather than stopping here.
+        // id added to the XML reach the predicates rather than stopping here.
         QList<int> expected;
         for (const auto& id : supportedIds()) expected.append(id.pid);
         std::sort(expected.begin(), expected.end());


### PR DESCRIPTION
Found on hardware after #1905/#1906 shipped, from the tablet log:

```
[68.280] [DE1][USB] Hotplug: attached (vid=0x1a86 pid=0x55d3)
[68.376] [DE1][USB] Android USB device found: 6790:21971:HDS-900910
[78.151] WARN  Android USB probe timeout — DE1 did not answer <+M>
```

`HDS-900910` is a **Half Decent Scale**, being probed as a DE1.

## Why

It enumerates as `0x1A86:0x55D3` — a WCH CH9102, **the same bridge chip the DE1 uses**. The HDS board is an ESP32-S3 devkit and those ids belong to the board; `openscale` pins no VID/PID of its own (`platformio.ini`: `board = esp32-s3-devkitc-1`).

So the supported ids do not partition into "scale" and "DE1", which was `usbDeviceKindForPid()`'s premise. The scale was routed to the DE1 manager, probed with `<+M>`, timed out, and the scale manager never saw it. Twice, on both plug-ins in that session.

## The fix

The either/or enum becomes two overlapping predicates, `usbPidMayBeScale()` / `usbPidMayBeDe1()`. An ambiguous id notifies **both** managers and the protocol probes decide — each gives up on a device that does not answer its own handshake. The DE1 timeout above is exactly that mechanism working; it costs one exchange.

`AndroidUsbScale.findDevice()` also had to learn the id. It matched only the two CH340 pids, so routing alone would have reached a scale manager whose `hasDevice()` still said no.

## Test

The table now carries two booleans per id rather than one kind, and asserts **every supported id reaches at least one manager** — an id that reaches neither is an event that vanishes with nothing failing. `device_filter.xml` no longer claims 0x55D3 is the DE1.

## Worth noting

Everything else from those two PRs is confirmed working on hardware in the same log: `Hotplug armed for 3 supported device id(s)`, attach, detach, the startup probe pass, and `USB permission dialog closed` — the #1906 fix firing. The permission bug was real and is fixed.

Build clean, 117/117. The Android half is still only compiled by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)