### PR TITLE
Halve the grind wheel window for a beta round: does setCurrentIndex scale with distance?

### DIFF
--- a/qml/components/GrindRowSource.qml
+++ b/qml/components/GrindRowSource.qml
@@ -155,8 +155,32 @@ QtObject {
     // close and reopen the picker to keep going (a Niche 9 -> -1 move is 40
     // steps at 0.25). The REAL limits are semantic and live in the stepper:
     // click-indexed grinders floor at 0, letters clamp A..Z. Only ~5 rows are
-    // visible at a time, so a wide window costs nothing to look at.
-    readonly property int grindWindowSteps: 400
+    // visible at a time, so a wide window costs nothing to LOOK at.
+    //
+    // TEMPORARY: 400 -> 200 as a MEASUREMENT, not a proposed change. The tablet
+    // puts 635 ms of a 765 ms open inside `tumbler.currentIndex = index`, and
+    // Qt's own source says why the target's distance might be what costs:
+    // assigning a new array to Tumbler.model replaces the model object, and
+    // QQuickItemViewPrivate::setModel then forces currentIndex back to 0 and
+    // refills around 0 (qquickitemview.cpp:1163-1169). The target is always the
+    // window's middle, so it sits `grindWindowSteps` rows outside what was just
+    // realised.
+    //
+    // Halving the window halves that distance. Read `idx` in the [Equipment]
+    // grind picker log on a Samsung SM-X210, on the SECOND or later open with
+    // the grind CHANGED (the first open of a session is free — Qt takes a
+    // degenerate path while the view is not yet valid, :1813 — and an unchanged
+    // value hits the row memo and never reassigns the model):
+    //
+    //   ~320 ms -> the cost scales with distance; the window size is the answer
+    //   ~640 ms -> flat; distance is not it, and the cost is inside createItem
+    //              or applyPendingChanges and needs its own instrumentation
+    //
+    // REVERT THIS whichever way it lands. If it scales, the real change is a
+    // deliberate choice of range with the tradeoff stated, not a number halved
+    // to take a reading. pos1 (the view traversal) measured 16 ms across 400
+    // rows and is NOT the reason this is here.
+    readonly property int grindWindowSteps: 200
     readonly property int rpmWindowSteps: 40
 
     // --- Stepping algorithm -------------------------------------------------


### PR DESCRIPTION
Halves the grind wheel's window for a beta round, to settle where 635 ms goes.

## The question

The tablet puts **635 ms of a 765 ms picker open inside `tumbler.currentIndex = index`**:

```
_snapTo count=801 from=0 to=400  pos1=16ms  idx=640ms  pos2=85ms   view=QQuickListView dur=0 vel=-1 durNow=0 velNow=-1
```

`pos1` — the view traversal across 400 rows — is 16 ms, so the row count is not a rendering problem. And `dur=0 vel=-1 durNow=0 velNow=-1` confirms the highlight disarm in `_snapTo` applies and is never re-armed, so that mitigation works and the cost is elsewhere inside `setCurrentIndex`.

## Why distance is the suspect

`QQuickItemViewPrivate::setModel` (`qquickitemview.cpp:1163-1169`):

```cpp
if (q->isComponentComplete()) {
    updateSectionCriteria();
    refill();
    currentIndex = -2;
    q->setCurrentIndex(instanceModel->count() > 0 ? 0 : -1);
```

Assigning a new array to `Tumbler.model` replaces the model object. Qt then forces `currentIndex` back to 0 and **refills around index 0** — while our target is always the window's middle, `grindWindowSteps` rows outside what was just realised. `updateCurrent` then has to `createItem()` out there and reconcile the jump (`:1837`, `:1847`).

## What ships

`grindWindowSteps` 400 → 200. Target index 400 → 200, rows 801 → 401. Nothing else changes.

Safe for a beta: ±200 steps is ±50 dial units at a 0.25 step, still five times the widest real move the existing comment cites (a Niche 9 → -1 is 40 steps at 0.25), and only ~5 rows are visible at a time.

Read `idx` on the **second or later** open **with the grind changed**:

- **~320 ms** → scales with distance. The window size is the answer, and the follow-up is a deliberate choice of range with its tradeoff stated rather than a number halved to take a reading.
- **~640 ms** → flat. Distance is not it; the cost is inside `createItem`/`applyPendingChanges` and needs its own probe.

Two samples that say nothing: the **first** open of a session (free — Qt takes the degenerate path at `:1813` while the view is not yet valid), and any open where the grind **did not change** (hits the row memo, never reassigns the model, early-outs at `:324`).

## Also recorded here

This reading killed the fix I was about to write. Setting `currentIndex` early to catch Qt's cheap path cannot work — the model assignment resets it afterwards. Found by reading the source rather than by shipping it.

Local suite: 117 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
