### PR TITLE
Remove the grind picker instrumentation, and fix the comments it left behind

### DIFF
--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -120,11 +120,6 @@ DecenzaDialog {
     property var _rpmRows: []
 
     function _rebuildRows() {
-        // TEMPORARY instrumentation (grind-picker open cost). The reported
-        // symptom is "several seconds" and only ~0.9 s of it is accounted for by
-        // the two history queries, so the split between query, row generation
-        // and view positioning has to be measured rather than guessed. Remove
-        // these four console.info lines once the dominant term is known.
         root._grindRows = root.rowSource
             ? root.rowSource.grindRowsFor(root._pendingGrind) : []
         root._rpmRows = (root.rowSource && root.rowSource.rpmCapable)
@@ -195,55 +190,17 @@ DecenzaDialog {
         // StrictlyEnforceRange re-animates — a visible tug-of-war. Positioned
         // first, the currentIndex assignment is a zero-distance move.
         //
-        // TEMPORARY instrumentation. _centerWheels measured 728 ms on one open
-        // of a Samsung SM-X210 (15 ms on the open before it, same target index),
-        // against 0-5 ms on a Mac — so the Mac cannot see this and the split has
-        // to come off the tablet. The three steps below are timed separately
-        // because they fail differently: a slow pos1 is the view walking from
-        // row 0 to the target, a slow idx is the highlight move the two
-        // assignments above are meant to have disarmed, and a slow pos2 is a
-        // redundant second traversal that could just be dropped. `from` and
-        // `count` are logged so the traversal DISTANCE is on the record rather
-        // than inferred — the 15 ms open and the 728 ms open had the same target.
-        // TEMPORARY probe. The tablet measured `idx` at 629-643 ms across three
-        // opens while pos1 (the 400-row traversal) stayed at 16 ms — so the cost
-        // is this assignment, which is exactly what the two lines above claim to
-        // have disarmed. Read back what they actually achieved:
-        //
-        // The `!== undefined` guards fail SILENTLY. If the resolved view has no
-        // such property the disarm is a no-op and nothing says so, which reads
-        // identical to a disarm that worked and was later undone. Logging the
-        // values after setting them separates those two.
-        //
-        // `view` names what _view() resolved, because Tumbler's internal view is
-        // a ListView or a PathView depending on `wrap`, and they do not honour
-        // these properties the same way.
-        //
-        // The open at t=20s had idx=0ms with the same from/to/count; the slow
-        // ones were an hour in. Whatever differs is not visible from the timings
-        // alone, so this logs state rather than more durations.
-        var _dur = lv ? lv.highlightMoveDuration : undefined
-        var _vel = lv ? lv.highlightMoveVelocity : undefined
-        var _viewType = lv ? (lv.toString().split("(")[0]) : "none"
-        var _from = tumbler.currentIndex
-        var _t0 = Date.now()
+        // The assignment is the expensive line, not the positioning. Timed on a
+        // Samsung SM-X210 it ran 629-643 ms against 16 ms for the traversal, and
+        // the disarm above was confirmed applied and never re-armed
+        // (highlightMoveDuration 0, highlightMoveVelocity -1, read back after the
+        // call). What made it cheap was shrinking the model — see
+        // GrindRowSource.grindWindowSteps. Measure there, not here.
         if (lv)
             lv.positionViewAtIndex(index, ListView.Center)
-        var _tPos1 = Date.now()
         tumbler.currentIndex = index
-        var _tIdx = Date.now()
         if (lv)
             lv.positionViewAtIndex(index, ListView.Center)
-        var _tPos2 = Date.now()
-        console.info("[Equipment] grind picker: _snapTo count=" + tumbler.count
-                     + " from=" + _from + " to=" + index
-                     + " pos1=" + (_tPos1 - _t0) + "ms"
-                     + " idx=" + (_tIdx - _tPos1) + "ms"
-                     + " pos2=" + (_tPos2 - _tIdx) + "ms"
-                     + " view=" + _viewType
-                     + " dur=" + _dur + " vel=" + _vel
-                     + " durNow=" + (lv ? lv.highlightMoveDuration : "n/a")
-                     + " velNow=" + (lv ? lv.highlightMoveVelocity : "n/a"))
     }
 
     // Centre each wheel on its current row. A wheel with no current value (an
@@ -271,10 +228,6 @@ DecenzaDialog {
     // place flicker, no travel. onOpened repeats the (idempotent) snap once
     // in case the ListView finished layout only after showing.
     onAboutToShow: {
-        // TEMPORARY — the one open-path total still worth keeping: it is the
-        // number a fix to _snapTo has to move. Everything else that was timed
-        // here has been answered and removed.
-        var _t0 = Date.now()
         root._rpmTouched = false
         root._rpmSnapIndex = -1
         root._pendingGrind = root.currentGrind
@@ -294,8 +247,6 @@ DecenzaDialog {
         rpmText.text = root._pendingRpm
         if (!root.textMode)
             root._centerWheels()
-        console.info("[Equipment] grind picker: onAboutToShow TOTAL "
-                     + (Date.now() - _t0) + "ms textMode=" + root.textMode)
     }
     onOpened: {
         if (root.textMode)

--- a/qml/components/GrindRowSource.qml
+++ b/qml/components/GrindRowSource.qml
@@ -150,36 +150,28 @@ QtObject {
     // is adjustable on the first tap. Only a seed — nothing written until picked.
     readonly property int rpmDefaultAnchor: 1000
 
-    // Wheel window half-width, in steps. Deliberately far beyond any physical
-    // dial so spinning is effectively unbounded — the user must never have to
-    // close and reopen the picker to keep going (a Niche 9 -> -1 move is 40
-    // steps at 0.25). The REAL limits are semantic and live in the stepper:
-    // click-indexed grinders floor at 0, letters clamp A..Z. Only ~5 rows are
-    // visible at a time, so a wide window costs nothing to LOOK at.
+    // Wheel window half-width, in steps. The number is load-bearing, not taste.
     //
-    // TEMPORARY: 400 -> 200 as a MEASUREMENT, not a proposed change. The tablet
-    // puts 635 ms of a 765 ms open inside `tumbler.currentIndex = index`, and
-    // Qt's own source says why the target's distance might be what costs:
-    // assigning a new array to Tumbler.model replaces the model object, and
+    // Was 400. The wheel's target row is always the window's middle, and
+    // assigning a new array to Tumbler.model replaces the model object —
     // QQuickItemViewPrivate::setModel then forces currentIndex back to 0 and
-    // refills around 0 (qquickitemview.cpp:1163-1169). The target is always the
-    // window's middle, so it sits `grindWindowSteps` rows outside what was just
-    // realised.
+    // refills around 0 (qquickitemview.cpp:1163-1169), so `currentIndex = middle`
+    // has to reach that far outside what was just realised. Measured on a Samsung
+    // SM-X210, three opens each with the grind changed:
     //
-    // Halving the window halves that distance. Read `idx` in the [Equipment]
-    // grind picker log on a Samsung SM-X210, on the SECOND or later open with
-    // the grind CHANGED (the first open of a session is free — Qt takes a
-    // degenerate path while the view is not yet valid, :1813 — and an unchanged
-    // value hits the row memo and never reassigns the model):
+    //   801 rows (±400):  currentIndex= 629/640/633 ms   open 768/770/753 ms
+    //   401 rows (±200):  currentIndex=     0/3/2 ms     open   35/41/38 ms
     //
-    //   ~320 ms -> the cost scales with distance; the window size is the answer
-    //   ~640 ms -> flat; distance is not it, and the cost is inside createItem
-    //              or applyPendingChanges and needs its own instrumentation
+    // A CLIFF, not a slope — halving the rows cut it ~300x, not 2x, so something
+    // between 401 and 801 crosses a threshold in QQuickListView. Where exactly is
+    // NOT established; 200 is on the good side of it with margin. Do not raise it
+    // without re-measuring on a slow tablet. The view TRAVERSAL is not the reason:
+    // positionViewAtIndex crossed 400 rows in 16 ms.
     //
-    // REVERT THIS whichever way it lands. If it scales, the real change is a
-    // deliberate choice of range with the tradeoff stated, not a number halved
-    // to take a reading. pos1 (the view traversal) measured 16 ms across 400
-    // rows and is NOT the reason this is here.
+    // The range given up costs nothing. ±200 steps is ±50 dial units at a 0.25
+    // step — five times the widest real move (a Niche 9 -> -1 is 40 steps) — and
+    // only ~5 rows are visible at a time. The REAL limits are semantic and live in
+    // the stepper: click-indexed grinders floor at 0, letters clamp A..Z.
     readonly property int grindWindowSteps: 200
     readonly property int rpmWindowSteps: 40
 


### PR DESCRIPTION
**Held** pending confirmation from the reporter that the picker is fast on his machine. The instrumentation stays in the beta until then — this is ready to merge the moment he confirms.

## What the probes established

```
801 rows (±400):  currentIndex= 629/640/633 ms   open 768/770/753 ms
401 rows (±200):  currentIndex=     0/3/2 ms     open   35/41/38 ms
```

**765 ms → 38 ms** on the reporter's Samsung SM-X210, on top of the ~918 ms of query the covering indexes removed in #1898.

## Removed

The `_snapTo` three-way split with its highlight-disarm readback, and the `onAboutToShow` total.

Worth noting the real volume: that was **five log lines per open on an RPM-capable grinder** — four `_snapTo` (two wheels, and `_centerWheels` runs twice per open) plus the total. The reporter's DF83V is RPM-capable; the Niche Zero used for local testing is not, so its empty RPM tumbler early-returned at `count <= 0` and the local logs only ever showed two. Easy to under-estimate what shipped.

## Three comments outlived their code

This is the same failure the reviews on #1898 kept finding, so it seemed worth not leaving behind:

1. **`grindWindowSteps`** still read *"TEMPORARY ... REVERT THIS whichever way it lands."* It landed, and it says keep. Left alone, `main` carried an instruction to undo its own fix. Now states the measurement, the fact that it is a **cliff not a slope** (halving the rows cut the cost ~300x, not 2x — so a threshold sits somewhere between 401 and 801 and is **not** established), and why the lost range costs nothing: ±200 steps is ±50 dial units at a 0.25 step, five times the widest real move. It also absorbs the pre-existing header, which repeated three of the same facts a few lines above.

2. **`_rebuildRows`** described "these four `console.info` lines" that no longer exist.

3. **`_snapTo`** described a three-way timing split that no longer exists — replaced with what that split found, since anyone later tempted to optimise the positioning should know the *assignment* was the cost and the traversal was 16 ms.

Local suite: 117 passed, 0 failed. Marker gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
