### PR TITLE
fix(ui): let ValueInput carry the value when a consumer cannot echo it

### DIFF
--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -120,11 +120,6 @@ DecenzaDialog {
     property var _rpmRows: []
 
     function _rebuildRows() {
-        // TEMPORARY instrumentation (grind-picker open cost). The reported
-        // symptom is "several seconds" and only ~0.9 s of it is accounted for by
-        // the two history queries, so the split between query, row generation
-        // and view positioning has to be measured rather than guessed. Remove
-        // these four console.info lines once the dominant term is known.
         root._grindRows = root.rowSource
             ? root.rowSource.grindRowsFor(root._pendingGrind) : []
         root._rpmRows = (root.rowSource && root.rowSource.rpmCapable)
@@ -195,55 +190,17 @@ DecenzaDialog {
         // StrictlyEnforceRange re-animates — a visible tug-of-war. Positioned
         // first, the currentIndex assignment is a zero-distance move.
         //
-        // TEMPORARY instrumentation. _centerWheels measured 728 ms on one open
-        // of a Samsung SM-X210 (15 ms on the open before it, same target index),
-        // against 0-5 ms on a Mac — so the Mac cannot see this and the split has
-        // to come off the tablet. The three steps below are timed separately
-        // because they fail differently: a slow pos1 is the view walking from
-        // row 0 to the target, a slow idx is the highlight move the two
-        // assignments above are meant to have disarmed, and a slow pos2 is a
-        // redundant second traversal that could just be dropped. `from` and
-        // `count` are logged so the traversal DISTANCE is on the record rather
-        // than inferred — the 15 ms open and the 728 ms open had the same target.
-        // TEMPORARY probe. The tablet measured `idx` at 629-643 ms across three
-        // opens while pos1 (the 400-row traversal) stayed at 16 ms — so the cost
-        // is this assignment, which is exactly what the two lines above claim to
-        // have disarmed. Read back what they actually achieved:
-        //
-        // The `!== undefined` guards fail SILENTLY. If the resolved view has no
-        // such property the disarm is a no-op and nothing says so, which reads
-        // identical to a disarm that worked and was later undone. Logging the
-        // values after setting them separates those two.
-        //
-        // `view` names what _view() resolved, because Tumbler's internal view is
-        // a ListView or a PathView depending on `wrap`, and they do not honour
-        // these properties the same way.
-        //
-        // The open at t=20s had idx=0ms with the same from/to/count; the slow
-        // ones were an hour in. Whatever differs is not visible from the timings
-        // alone, so this logs state rather than more durations.
-        var _dur = lv ? lv.highlightMoveDuration : undefined
-        var _vel = lv ? lv.highlightMoveVelocity : undefined
-        var _viewType = lv ? (lv.toString().split("(")[0]) : "none"
-        var _from = tumbler.currentIndex
-        var _t0 = Date.now()
+        // The assignment is the expensive line, not the positioning. Timed on a
+        // Samsung SM-X210 it ran 629-643 ms against 16 ms for the traversal, and
+        // the disarm above was confirmed applied and never re-armed
+        // (highlightMoveDuration 0, highlightMoveVelocity -1, read back after the
+        // call). What made it cheap was shrinking the model — see
+        // GrindRowSource.grindWindowSteps. Measure there, not here.
         if (lv)
             lv.positionViewAtIndex(index, ListView.Center)
-        var _tPos1 = Date.now()
         tumbler.currentIndex = index
-        var _tIdx = Date.now()
         if (lv)
             lv.positionViewAtIndex(index, ListView.Center)
-        var _tPos2 = Date.now()
-        console.info("[Equipment] grind picker: _snapTo count=" + tumbler.count
-                     + " from=" + _from + " to=" + index
-                     + " pos1=" + (_tPos1 - _t0) + "ms"
-                     + " idx=" + (_tIdx - _tPos1) + "ms"
-                     + " pos2=" + (_tPos2 - _tIdx) + "ms"
-                     + " view=" + _viewType
-                     + " dur=" + _dur + " vel=" + _vel
-                     + " durNow=" + (lv ? lv.highlightMoveDuration : "n/a")
-                     + " velNow=" + (lv ? lv.highlightMoveVelocity : "n/a"))
     }
 
     // Centre each wheel on its current row. A wheel with no current value (an
@@ -271,10 +228,6 @@ DecenzaDialog {
     // place flicker, no travel. onOpened repeats the (idempotent) snap once
     // in case the ListView finished layout only after showing.
     onAboutToShow: {
-        // TEMPORARY — the one open-path total still worth keeping: it is the
-        // number a fix to _snapTo has to move. Everything else that was timed
-        // here has been answered and removed.
-        var _t0 = Date.now()
         root._rpmTouched = false
         root._rpmSnapIndex = -1
         root._pendingGrind = root.currentGrind
@@ -294,8 +247,6 @@ DecenzaDialog {
         rpmText.text = root._pendingRpm
         if (!root.textMode)
             root._centerWheels()
-        console.info("[Equipment] grind picker: onAboutToShow TOTAL "
-                     + (Date.now() - _t0) + "ms textMode=" + root.textMode)
     }
     onOpened: {
         if (root.textMode)

--- a/qml/components/GrindRowSource.qml
+++ b/qml/components/GrindRowSource.qml
@@ -150,36 +150,28 @@ QtObject {
     // is adjustable on the first tap. Only a seed — nothing written until picked.
     readonly property int rpmDefaultAnchor: 1000
 
-    // Wheel window half-width, in steps. Deliberately far beyond any physical
-    // dial so spinning is effectively unbounded — the user must never have to
-    // close and reopen the picker to keep going (a Niche 9 -> -1 move is 40
-    // steps at 0.25). The REAL limits are semantic and live in the stepper:
-    // click-indexed grinders floor at 0, letters clamp A..Z. Only ~5 rows are
-    // visible at a time, so a wide window costs nothing to LOOK at.
+    // Wheel window half-width, in steps. The number is load-bearing, not taste.
     //
-    // TEMPORARY: 400 -> 200 as a MEASUREMENT, not a proposed change. The tablet
-    // puts 635 ms of a 765 ms open inside `tumbler.currentIndex = index`, and
-    // Qt's own source says why the target's distance might be what costs:
-    // assigning a new array to Tumbler.model replaces the model object, and
+    // Was 400. The wheel's target row is always the window's middle, and
+    // assigning a new array to Tumbler.model replaces the model object —
     // QQuickItemViewPrivate::setModel then forces currentIndex back to 0 and
-    // refills around 0 (qquickitemview.cpp:1163-1169). The target is always the
-    // window's middle, so it sits `grindWindowSteps` rows outside what was just
-    // realised.
+    // refills around 0 (qquickitemview.cpp:1163-1169), so `currentIndex = middle`
+    // has to reach that far outside what was just realised. Measured on a Samsung
+    // SM-X210, three opens each with the grind changed:
     //
-    // Halving the window halves that distance. Read `idx` in the [Equipment]
-    // grind picker log on a Samsung SM-X210, on the SECOND or later open with
-    // the grind CHANGED (the first open of a session is free — Qt takes a
-    // degenerate path while the view is not yet valid, :1813 — and an unchanged
-    // value hits the row memo and never reassigns the model):
+    //   801 rows (±400):  currentIndex= 629/640/633 ms   open 768/770/753 ms
+    //   401 rows (±200):  currentIndex=     0/3/2 ms     open   35/41/38 ms
     //
-    //   ~320 ms -> the cost scales with distance; the window size is the answer
-    //   ~640 ms -> flat; distance is not it, and the cost is inside createItem
-    //              or applyPendingChanges and needs its own instrumentation
+    // A CLIFF, not a slope — halving the rows cut it ~300x, not 2x, so something
+    // between 401 and 801 crosses a threshold in QQuickListView. Where exactly is
+    // NOT established; 200 is on the good side of it with margin. Do not raise it
+    // without re-measuring on a slow tablet. The view TRAVERSAL is not the reason:
+    // positionViewAtIndex crossed 400 rows in 16 ms.
     //
-    // REVERT THIS whichever way it lands. If it scales, the real change is a
-    // deliberate choice of range with the tradeoff stated, not a number halved
-    // to take a reading. pos1 (the view traversal) measured 16 ms across 400
-    // rows and is NOT the reason this is here.
+    // The range given up costs nothing. ±200 steps is ±50 dial units at a 0.25
+    // step — five times the widest real move (a Niche 9 -> -1 is 40 steps) — and
+    // only ~5 rows are visible at a time. The REAL limits are semantic and live in
+    // the stepper: click-indexed grinders floor at 0, letters clamp A..Z.
     readonly property int grindWindowSteps: 200
     readonly property int rpmWindowSteps: 40
 

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -35,6 +35,14 @@ Item {
     // that is the value we asked for or a different one it clamped to.
     onValueChanged: _hasPending = false
 
+    // Hand authority back to `value`. Called wherever an interaction starts or
+    // ends — press, popup open, commit, and every cancel. A cancel neither
+    // commits nor rolls back (valueModified has no undo), so all it can do is
+    // stop carrying a number the consumer was never told to keep.
+    function _dropPending() {
+        _hasPending = false
+    }
+
     property real from: 0
     property real to: 100
     property real stepSize: 1
@@ -120,7 +128,7 @@ Item {
         // Interaction over — `value` is authoritative again, so whatever the
         // consumer actually stored shows through instead of the widget going on
         // displaying a number nobody kept.
-        _hasPending = false
+        _dropPending()
     }
 
     // Enable keyboard focus
@@ -253,7 +261,7 @@ Item {
                             root.commitValue()
                         }
                     }
-                    onCanceled: decrementTimer.stop()
+                    onCanceled: { decrementTimer.stop(); root._dropPending() }
                 }
 
                 Timer {
@@ -307,9 +315,7 @@ Item {
                         dragReady = false
                         hasMoved = false
                         currentGear = 0
-                        // Start from what the consumer holds. A canceled gesture
-                        // never commits, so this is where its leftovers go.
-                        root._hasPending = false
+                        root._dropPending()
 
                         // Announce parameter name when touched (accessibility)
                         if (root.accessibleName && typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
@@ -400,6 +406,7 @@ Item {
                         isDragging = false
                         dragReady = false
                         hasMoved = false
+                        root._dropPending()
                     }
                 }
 
@@ -566,7 +573,7 @@ Item {
                             root.commitValue()
                         }
                     }
-                    onCanceled: incrementTimer.stop()
+                    onCanceled: { incrementTimer.stop(); root._dropPending() }
                 }
 
                 Timer {
@@ -594,7 +601,7 @@ Item {
         padding: 0
 
         onOpened: {
-            root._hasPending = false
+            root._dropPending()
             popupContent.currentGear = 0
             popupContent.editMode = false
             popupValueContainer.forceActiveFocus()
@@ -682,7 +689,7 @@ Item {
                                     root.commitValue()
                                 }
                             }
-                            onCanceled: popupDecrementTimer.stop()
+                            onCanceled: { popupDecrementTimer.stop(); root._dropPending() }
                         }
 
                         Timer {
@@ -813,7 +820,7 @@ Item {
                                 // gear=-1 → mouse.y+50 (because -(-1)*50 = +50).
                                 startY = mouse.y - popupContent.currentGear * root.sc(50)
                                 isDragging = false
-                                root._hasPending = false
+                                root._dropPending()
 
                                 // Announce parameter name when bubble appears (accessibility)
                                 if (root.accessibleName && typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
@@ -862,6 +869,7 @@ Item {
 
                             onCanceled: {
                                 isDragging = false
+                                root._dropPending()
                             }
 
                             onDoubleClicked: {
@@ -995,7 +1003,7 @@ Item {
                                     root.commitValue()
                                 }
                             }
-                            onCanceled: popupIncrementTimer.stop()
+                            onCanceled: { popupIncrementTimer.stop(); root._dropPending() }
                         }
 
                         Timer {

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -10,6 +10,31 @@ Item {
 
     // Value properties
     property real value: 0
+
+    // The value this widget displays and steps from, which is `value` except
+    // while an interaction is outrunning the consumer.
+    //
+    // Nothing here ever assigns `value` — that would destroy the consumer's
+    // binding — so an adjustment is a REQUEST: valueModified is emitted and the
+    // consumer is expected to write the new value back through its binding.
+    // Consumers bound to non-notifying data cannot do that synchronously: a
+    // plain JS object, or a C++ value behind a manual version bump, leaves
+    // `value` frozen for the whole gesture. Every drag step then recomputed
+    // frozenValue + one step and overwrote the last, so a drag of ANY length
+    // moved the value exactly one step (#1894, the frame fields in
+    // ProfileEditorPage). Holding +/- froze the same way, less visibly.
+    //
+    // So the widget carries the value itself until the consumer catches up. An
+    // echo clears the flag in onValueChanged, which is why a consumer that does
+    // echo — BrewDialog and most others — behaves exactly as it did before.
+    property real _pendingValue: 0
+    property bool _hasPending: false
+    readonly property real effectiveValue: _hasPending ? _pendingValue : value
+
+    // Authority returns to `value` the moment the consumer reports one, whether
+    // that is the value we asked for or a different one it clamped to.
+    onValueChanged: _hasPending = false
+
     property real from: 0
     property real to: 100
     property real stepSize: 1
@@ -23,6 +48,16 @@ Item {
     // Display
     property string suffix: ""
     property string displayText: ""  // Optional override for value display
+
+    // displayText is computed by the consumer FROM `value` — a unit conversion
+    // ("2.4 mL/s" for an internal 24), or a sentinel label ("off" at 0). Either
+    // way it describes `value`, so it is only usable while `value` is what the
+    // widget is showing. While _hasPending it is describing a number the user
+    // has already dragged away from, which is how a field sitting at "off" went
+    // on reading "off" for the whole gesture. Falling back to the raw number
+    // costs an echoing consumer nothing: its echo clears _hasPending inside the
+    // emit, so displayText is in force at every repaint.
+    readonly property string effectiveDisplayText: _hasPending ? "" : displayText
     property string rangeText: ""   // Optional override for range display in popup
     property string accessibleName: ""  // Optional override for accessibility announcement
     property color valueColor: Theme.textColor
@@ -66,6 +101,10 @@ Item {
     // Internal helper used in place of raw root.valueModified() emission so
     // the dirty flag is kept consistent.
     function _emitValueModified(newVal) {
+        // Take the value BEFORE emitting, so an echoing consumer's write lands
+        // on top of it (onValueChanged clears the flag) rather than racing it.
+        _pendingValue = newVal
+        _hasPending = true
         root.valueModified(newVal)
         _dirtySinceCommit = true
     }
@@ -76,8 +115,12 @@ Item {
     function commitValue() {
         if (_dirtySinceCommit) {
             _dirtySinceCommit = false
-            root.valueCommitted(root.value)
+            root.valueCommitted(root.effectiveValue)
         }
+        // Interaction over — `value` is authoritative again, so whatever the
+        // consumer actually stored shows through instead of the widget going on
+        // displaying a number nobody kept.
+        _hasPending = false
     }
 
     // Enable keyboard focus
@@ -87,7 +130,7 @@ Item {
     // Accessibility - expose as a slider with contextual label
     Accessible.role: Accessible.Slider
     Accessible.name: (root.accessibleName ? root.accessibleName + " " : "") +
-                     (root.displayText || (root.value.toFixed(root.decimals) + root.suffix))
+                     (root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix))
     Accessible.description: TranslationManager.translate("valueinput.accessibility.description", "Use plus and minus buttons to adjust. Tap center for full-screen editor. Double-tap value to type a number.")
     Accessible.focusable: true
 
@@ -130,7 +173,7 @@ Item {
     // Announce value when focused (for accessibility)
     onActiveFocusChanged: {
         if (activeFocus && typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
-            var text = root.accessibleName || root.displayText || (root.value.toFixed(root.decimals) + " " + root.suffix)
+            var text = root.accessibleName || root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + " " + root.suffix)
             AccessibilityManager.announce(text)
         }
     }
@@ -145,7 +188,7 @@ Item {
         id: textMetrics
         font.pixelSize: root.valueFontPixelSize
         font.bold: true
-        text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
+        text: root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix)
     }
 
     // Focus indicator around the entire control
@@ -191,7 +234,7 @@ Item {
                     text: "\u2212"
                     font.pixelSize: root.valueFontPixelSize
                     font.bold: true
-                    color: root.value <= root.from ? Theme.textSecondaryColor : Theme.textColor
+                    color: root.effectiveValue <= root.from ? Theme.textSecondaryColor : Theme.textColor
                     Accessible.ignored: true
                 }
 
@@ -233,7 +276,7 @@ Item {
                     anchors.centerIn: parent
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
-                    text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
+                    text: root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix)
                     font.pixelSize: root.valueFontPixelSize
                     font.bold: true
                     color: root.valueColor
@@ -264,10 +307,13 @@ Item {
                         dragReady = false
                         hasMoved = false
                         currentGear = 0
+                        // Start from what the consumer holds. A canceled gesture
+                        // never commits, so this is where its leftovers go.
+                        root._hasPending = false
 
                         // Announce parameter name when touched (accessibility)
                         if (root.accessibleName && typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
-                            var valueStr = root.displayText || (root.value.toFixed(root.decimals) + " " + root.suffix.trim())
+                            var valueStr = root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + " " + root.suffix.trim())
                             AccessibilityManager.announce(root.accessibleName + ": " + valueStr)
                         }
                     }
@@ -415,7 +461,7 @@ Item {
                             Text {
                                 id: bubbleText
                                 anchors.centerIn: parent
-                                text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
+                                text: root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix)
                                 font.pixelSize: root.sc(30)
                                 font.bold: true
                                 color: speechBubble.getContrastColor(root.valueColor)
@@ -505,7 +551,7 @@ Item {
                     text: "+"
                     font.pixelSize: root.valueFontPixelSize
                     font.bold: true
-                    color: root.value >= root.to ? Theme.textSecondaryColor : Theme.textColor
+                    color: root.effectiveValue >= root.to ? Theme.textSecondaryColor : Theme.textColor
                     Accessible.ignored: true
                 }
 
@@ -548,12 +594,13 @@ Item {
         padding: 0
 
         onOpened: {
+            root._hasPending = false
             popupContent.currentGear = 0
             popupContent.editMode = false
             popupValueContainer.forceActiveFocus()
             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
                 var announcement = root.accessibleName ? root.accessibleName + ". " : ""
-                var valueStr = root.displayText || (root.value.toFixed(root.decimals) + " " + root.suffix.trim())
+                var valueStr = root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + " " + root.suffix.trim())
                 announcement += TranslationManager.translate("valueinput.editor.announce", "Value editor. Current value:") + " " + valueStr
                 AccessibilityManager.announce(announcement, true)
             }
@@ -620,7 +667,7 @@ Item {
                             text: "\u2212"
                             font.pixelSize: root.sc(32)
                             font.bold: true
-                            color: root.value <= root.from ? Theme.textSecondaryColor : Theme.textColor
+                            color: root.effectiveValue <= root.from ? Theme.textSecondaryColor : Theme.textColor
                             Accessible.ignored: true
                         }
 
@@ -654,7 +701,7 @@ Item {
                         focus: !popupContent.editMode
 
                         Accessible.role: Accessible.Slider
-                        Accessible.name: root.accessibleName || (root.displayText || (root.value.toFixed(root.decimals) + root.suffix))
+                        Accessible.name: root.accessibleName || (root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix))
                         Accessible.description: TranslationManager.translate("valueinput.popup.hint", "Double-tap to type a number.")
                         Accessible.focusable: true
 
@@ -681,7 +728,7 @@ Item {
                         Text {
                             anchors.centerIn: parent
                             visible: !popupContent.editMode
-                            text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
+                            text: root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix)
                             font.pixelSize: root.sc(40)
                             font.bold: true
                             color: root.valueColor
@@ -709,7 +756,7 @@ Item {
                                     parsed = Math.max(root.from, Math.min(root.to, parsed))
                                     var roundTo = root.hasFineGear ? root.fineStepSize : root.stepSize
                                     parsed = Math.round(parsed / roundTo) * roundTo
-                                    if (parsed !== root.value) {
+                                    if (parsed !== root.effectiveValue) {
                                         root._emitValueModified(parsed)
                                     }
                                     // Typing a number is a deliberate, final adjustment.
@@ -718,7 +765,7 @@ Item {
                                     // the same number back is a no-op.
                                     root.commitValue()
                                     if (typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
-                                        AccessibilityManager.announce(root.displayText || (parsed.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
+                                        AccessibilityManager.announce(root.effectiveDisplayText || (parsed.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
                                     }
                                 }
                                 popupContent.editMode = false
@@ -766,10 +813,11 @@ Item {
                                 // gear=-1 → mouse.y+50 (because -(-1)*50 = +50).
                                 startY = mouse.y - popupContent.currentGear * root.sc(50)
                                 isDragging = false
+                                root._hasPending = false
 
                                 // Announce parameter name when bubble appears (accessibility)
                                 if (root.accessibleName && typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
-                                    var valueStr = root.displayText || (root.value.toFixed(root.decimals) + " " + root.suffix.trim())
+                                    var valueStr = root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + " " + root.suffix.trim())
                                     AccessibilityManager.announce(root.accessibleName + ": " + valueStr)
                                 }
                             }
@@ -818,7 +866,7 @@ Item {
 
                             onDoubleClicked: {
                                 popupContent.editMode = true
-                                popupTextInput.text = root.value.toFixed(root.decimals)
+                                popupTextInput.text = root.effectiveValue.toFixed(root.decimals)
                                 popupTextInput.forceActiveFocus()
                                 popupTextInput.selectAll()
                             }
@@ -878,7 +926,7 @@ Item {
                                     Text {
                                         id: popupBubbleText
                                         anchors.centerIn: parent
-                                        text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
+                                        text: root.effectiveDisplayText || (root.effectiveValue.toFixed(root.decimals) + root.suffix)
                                         font.pixelSize: root.sc(30)
                                         font.bold: true
                                         color: dragBubble.getContrastColor(root.valueColor)
@@ -932,7 +980,7 @@ Item {
                             text: "+"
                             font.pixelSize: root.sc(32)
                             font.bold: true
-                            color: root.value >= root.to ? Theme.textSecondaryColor : Theme.textColor
+                            color: root.effectiveValue >= root.to ? Theme.textSecondaryColor : Theme.textColor
                             Accessible.ignored: true
                         }
 
@@ -1084,16 +1132,16 @@ Item {
     }
 
     function adjustValueWithStep(steps, effectiveStep) {
-        var newVal = root.value + (steps * effectiveStep)
+        var newVal = root.effectiveValue + (steps * effectiveStep)
         newVal = Math.max(root.from, Math.min(root.to, newVal))
         // Round to fineStepSize if available (allows sub-stepSize precision),
         // otherwise round to stepSize
         var roundTo = root.hasFineGear ? root.fineStepSize : root.stepSize
         newVal = Math.round(newVal / roundTo) * roundTo
-        if (newVal !== root.value) {
+        if (newVal !== root.effectiveValue) {
             _emitValueModified(newVal)
             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled) {
-                AccessibilityManager.announce(root.displayText || (newVal.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
+                AccessibilityManager.announce(root.effectiveDisplayText || (newVal.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
             }
         }
     }


### PR DESCRIPTION
Fixes #1894.

## The defect

`ValueInput` never assigns its own `value` — that would destroy the consumer's binding — so every adjustment is a *request*: `valueModified` is emitted and the consumer is expected to write the new value back through its binding. The component then reads `value` as both its display source and its arithmetic base.

That is only sound if the consumer echoes synchronously. Consumers bound to non-notifying data cannot: `ProfileEditorPage`'s frame fields bind to `stepEditorScroll.step.<field>` — a plain JS object — gated on a `stepVersion` counter that is only bumped by `uploadProfile()`, which is wired to `onValueCommitted`. During a drag nothing commits, so `value` is frozen for the whole gesture.

With a frozen base, each drag step recomputed `frozenValue + 1 step` and overwrote the last (the handler resets `startX` per step). A drag of *any* length moved the value exactly one step. At the default gear that step is 0.01 and reads as "nothing happens"; at ×10/×100 the value jumps once and dies, which is how it was reported. Holding `+`/`−` froze identically. Single clicks looked fine only because each one commits, and the commit refreshes the binding.

## The fix

Central, in the component, because the hole is in its contract — not in the 95 `onValueModified` handlers across the tree, any one of which could forget a version bump with nothing failing.

- `effectiveValue` = `_hasPending ? _pendingValue : value`. All 20 internal `root.value` reads move to it: display text, bubble, `+`/`−` dimming, accessibility announcements, the arithmetic base, the `valueCommitted` payload.
- `_emitValueModified()` takes the value **before** emitting. An echoing consumer's write clears `_hasPending` in `onValueChanged` during that same emit, so echoing call sites are bit-identical to before.
- `effectiveDisplayText` = `""` while pending, else `displayText`. Same bug's other half: `displayText` is computed by the consumer *from* `value`, so the advanced editor's `"off"`-at-zero fields (max duration, volume, weight, flow limit) kept reading "off" for the whole gesture after the number had moved. Unit-converting `displayText` users (HotWaterPage, SteamPage, SensorCalibrationPage, SimpleProfileEditorPage, BrewDialog) echo synchronously, so their flag is false at every repaint and they keep their formatting.
- One `_dropPending()` hands authority back, called from press, popup-open, commit, and all six cancel paths. Second commit: a canceled gesture (finger off a `+`/`−` button, grab stolen mid-drag) runs `onCanceled` and never commits, so without this it kept displaying a value the consumer was never told to keep.

No call-site changes, no `stepVersion` bumps, no new setting.

Known and unchanged: cancel does not roll back the per-tick `valueModified` writes that already reached the consumer — `valueModified` has no undo — so a canceled drag can leave the consumer holding a value the widget no longer shows. That predates this work.

## Verification

- Full suite via Qt Creator: **117 passed, 0 failed, 0 skipped**, no test warnings.
- qmllint gate after the final build: **241/241 clean**, whole module.
- Confirmed by hand in the advanced profile editor: drag at ×10 now tracks the finger instead of jumping one step.

## No new test, deliberately

The defect lives in binding and signal ordering, not arithmetic, so the affordable option — a QJSEngine test over extracted pure functions, the `tst_theme` / `RecipeSearch.js` precedent — would still pass with the frozen base. Catching it needs the component instantiated, and test binaries cannot `import Decenza`: the QML module is built into the app executable, so there is no importable module for a test engine. That is the same constraint that makes `tst_qmlregistration` read build artifacts rather than exercise registration. Making the module importable from tests is a real change and a larger one than this fix.