### PR TITLE
fix(de1): don't upload the profile into the wake we just triggered

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -3018,7 +3018,7 @@ void MainController::applyAllSettings() {
 
     // 1. Upload current profile (espresso)
     if (m_profileManager->currentProfile().mode() == Profile::Mode::FrameBased) {
-        m_profileManager->uploadCurrentProfile();
+        m_profileManager->uploadCurrentProfileOnConnect();
     }
 
     // 2. Apply steam/hot water/flush settings (unified)

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -113,8 +113,10 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
     , m_steamHeaterPolicy(steamHeaterPolicy)
     , m_profileStorage(profileStorage)
 {
-    // Retry pending profile upload when machine reaches Idle, Ready, Sleep, or
-    // Heating — phases where it's safe to write a new profile to the DE1.
+    // Retry pending profile upload when machine reaches Idle, Ready or Heating
+    // — phases where it's safe to write a new profile to the DE1. Sleep is not
+    // one of them: uploadCurrentProfile() defers there, so listing it would
+    // only bounce the pending upload straight back into deferral.
     if (m_machineState) {
         connect(m_machineState, &MachineState::phaseChanged, this, [this]() {
             if (!m_profileUploadPending) return;
@@ -125,7 +127,7 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 return;
             }
             if (phase == MachineState::Phase::Idle || phase == MachineState::Phase::Ready ||
-                phase == MachineState::Phase::Sleep || phase == MachineState::Phase::Heating) {
+                phase == MachineState::Phase::Heating) {
                 qDebug() << "Retrying pending profile upload now that phase is" << m_machineState->phaseString();
                 uploadCurrentProfile();
             }
@@ -2295,6 +2297,34 @@ void ProfileManager::acknowledgeDe1CommunicationFailure() {
     m_profileUploadRetryAttempts = 0;
     m_lastUploadFailureReason.clear();
     updateProfileUploadRetrying();
+}
+
+void ProfileManager::uploadCurrentProfileOnConnect() {
+    // Sleep is not the hazard — writing INTO a wake we just triggered is.
+    // DE1Device::onTransportConnected() sends requestState(Idle) and this
+    // upload follows ~120 ms later, so the frames land mid-transition: every
+    // frame ACKs and telemetry streams, but the GHC blinks red and never picks
+    // the profile up. Re-uploading with the machine awake clears it, which is
+    // also why restarting the app fixes it (the DE1 is already awake by then).
+    //
+    // That is why only the connect path defers. Picking a profile on a stably
+    // sleeping machine is routine and works — it races nothing — so
+    // uploadCurrentProfile() must stay immediate or the edit is stranded.
+    //
+    // Waiting costs nothing here: the machine has to heat before it can brew,
+    // and the firmware drops cold start requests on a GHC machine anyway.
+    //
+    // Hypothesis, not a reproduction: the blink is weekly and the mechanism was
+    // inferred from it clearing on app restart and on a manual profile change.
+    // If it recurs with the DE1 already AWAKE at app start, this is the wrong
+    // cause and the queue depth at connect is the next suspect.
+    if (m_machineState && m_machineState->phase() == MachineState::Phase::Sleep) {
+        qDebug() << "uploadCurrentProfileOnConnect() deferred: machine asleep, "
+                    "will upload when it wakes";
+        m_profileUploadPending = true;
+        return;
+    }
+    uploadCurrentProfile();
 }
 
 void ProfileManager::uploadCurrentProfile() {

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -508,6 +508,11 @@ public slots:
     bool persistCurrentProfile();  // Save to downloaded folder if not already installed (no re-upload)
     void refreshProfiles();
     Q_INVOKABLE void uploadCurrentProfile();
+
+    // Connect/reconnect variant: defers while the DE1 is still asleep, because
+    // the connect sequence wakes the machine and would otherwise upload into
+    // the wake transition. See the definition for the failure it prevents.
+    void uploadCurrentProfileOnConnect();
     Q_INVOKABLE void uploadProfile(const QVariantMap& profileData);
     Q_INVOKABLE bool saveProfile(const QString& filename);
     Q_INVOKABLE bool saveProfileAs(const QString& filename, const QString& title);

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -707,6 +707,44 @@ private slots:
         QVERIFY(!f.profileManager.isProfileModified());
     }
 
+    // A profile written while the DE1 is still asleep can be lost inside the
+    // wake transition — every frame ACKs but the GHC never picks it up. These
+    // two pin the deferral and the flush; without them the fix is invisible to
+    // the suite, since a lost upload looks identical to a successful one here.
+
+    void uploadDeferredWhileMachineAsleep() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.transport.writes.clear();
+
+        f.machineState.m_phase = MachineState::Phase::Sleep;
+        f.profileManager.uploadCurrentProfileOnConnect();
+
+        QVERIFY(f.writesTo(DE1::Characteristic::HEADER_WRITE).isEmpty());
+        QVERIFY(f.writesTo(DE1::Characteristic::FRAME_WRITE).isEmpty());
+
+        // The narrow gate is the point: a user edit on a sleeping machine
+        // must still upload. Without this the fix could silently widen.
+        f.profileManager.uploadCurrentProfile();
+        QCOMPARE(f.writesTo(DE1::Characteristic::HEADER_WRITE).size(), 1);
+    }
+
+    void deferredUploadRunsOnceMachineLeavesSleep() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.transport.writes.clear();
+
+        f.machineState.m_phase = MachineState::Phase::Sleep;
+        f.profileManager.uploadCurrentProfileOnConnect();
+        QVERIFY(f.writesTo(DE1::Characteristic::HEADER_WRITE).isEmpty());
+
+        f.machineState.m_phase = MachineState::Phase::Idle;
+        emit f.machineState.phaseChanged();
+
+        QCOMPARE(f.writesTo(DE1::Characteristic::HEADER_WRITE).size(), 1);
+        QVERIFY(!f.writesTo(DE1::Characteristic::FRAME_WRITE).isEmpty());
+    }
+
     void loadProfileIsRecipe() {
         McpTestFixture f;
         loadDFlowProfile(f);


### PR DESCRIPTION
## The symptom

About once a week, on a cold start, the GHC blinks red while the app looks completely healthy. From a device log taken while it was blinking:

- `DE1 CONNECTED (BLE)`, 18 characteristics registered
- `DE1 telemetry live: state, shot samples, water level, MMR responses, temperatures, calibration replies` — the ready marker names every stream, so `STATE_INFO` was confirmed enabled
- `Profile upload verified — 7 frame(s) ACKed in order`
- MMR reads answering (`Refill kit: detected`), zero `SettingsDrift`, zero ERROR/FATAL

Two live telemetry reads seconds apart moved (`84.253 → 84.342 °C`), so the link was genuinely streaming, not stale. Decent's own docs attribute a blinking GHC to a lost Bluetooth connection; that is ruled out here by the evidence above.

Changing the active profile and changing it back cleared the blink immediately.

## The mechanism

`DE1Device::onTransportConnected()` sends `requestState(Idle)` to wake the machine, and the connect sequence uploads the profile roughly 120 ms later. From the log of the blinking session:

```
[7.029] ShotSettings write            [uploadCurrentProfile]
[7.044] WARN 40 Bluetooth operations queued at once
[7.149] Sleep → Idle
[8.130] Profile upload verified — 7 frame(s) ACKed in order
```

The frames land inside the wake transition. Everything ACKs — the mainboard takes them — but the GHC does not pick them up.

Three observations line up with this and with nothing else:

| Case | DE1 state | Result |
|---|---|---|
| Cold start | asleep, waking | blinks |
| App restart within the 60 min auto-sleep | already awake | clears |
| Manual profile change | awake and idle | clears |

The failing case is the only one with a wake transition underneath it.

For comparison, de1app gates its equivalent (`later_new_de1_connection_setup`, which contains `de1_send_shot_frames`) on the VERSION characteristic reply arriving, and staggers its tail over 11 seconds — including re-enabling state notifications a second time at `after 11000`. We start earlier, on Qt's `RemoteServiceDiscovered` rather than a DE1 reply, and never repeat. That divergence was deliberate (it fixed a Linux/BlueZ bug where VERSION read fine before characteristics were writable) and is not being reverted here.

## The change

The connect path defers the upload while the machine is still asleep, and the existing `m_profileUploadPending` / `phaseChanged` machinery flushes it when the machine reaches Idle, Ready or Heating. No new mechanism, no timer. `Sleep` leaves that handler's safe list, or a deferred upload would bounce straight back into deferral.

**Only the connect path defers.** Picking a profile on a stably sleeping machine is routine, works today, and races nothing — so `uploadCurrentProfile()` stays immediate for user edits. An earlier revision of this change gated every upload on sleep and broke 15 existing tests, because `DE1Device` defaults to `DE1::State::Sleep`; that was a real defect, not a fixture artifact, and it would have stranded a user's profile edit.

Deferring costs nothing: the machine has to heat before it can brew, and the firmware drops cold start requests on a GHC machine regardless.

## Testing

Full suite via Qt Creator: **117 passed, 0 failed**.

Two slots added to the existing `tests/tst_profilemanager.cpp` (a new test file costs ~1.4 s of build time forever; a slot costs milliseconds):

- `uploadDeferredWhileMachineAsleep` — the connect-path upload writes nothing while asleep, **and** a plain `uploadCurrentProfile()` in the same state still writes. That second assertion is what stops the gate silently widening again.
- `deferredUploadRunsOnceMachineLeavesSleep` — the deferred upload lands on the transition to Idle.

Both were confirmed able to fail: the over-broad first revision turned 15 existing upload tests red.

## What this does not establish

This is a hypothesis, not a reproduction. The mechanism was inferred from the blink clearing under two conditions that both happen with the machine already awake. Confirmation is absence over the next several weeks.

If the blink ever recurs with the DE1 **already awake** at app start, this is the wrong cause and the connect-time queue depth (`40 Bluetooth operations queued at once`, which fires on every single launch) is the next suspect. The code comment records both the hypothesis and that falsifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)