### PR TITLE
test(ai): install the message filters before the writes they expect to warn

### DIFF
--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -3219,16 +3219,23 @@ private slots:
         const QString prior = QStringLiteral("How did this taste?");
         const QString reply = QStringLiteral("82, actually the roast is dark");
 
+        // Installed BEFORE the producers run, not after. requestUpdateShotMetadata()
+        // posts to a background SerialDbWorker and "No shot with id ... to update"
+        // is emitted from THAT thread, so nothing orders it against the main thread
+        // reaching these lines. With init()'s failOnWarning() in force, losing that
+        // race fails the test with "Received a warning that resulted in a failure"
+        // — which is how it failed on a loaded machine. The sibling test above gets
+        // this order right; this one was the outlier.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No shot with id 8473 to update"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No shot with id 8473 to update"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("did not land"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("did not land"));
+
         mgr.maybePersistRatingFromReply(reply, prior, 8473);
         mgr.maybePersistBeanCorrectionFromReply(reply, prior, 8473);
         // The premise of the refcount, asserted rather than assumed: both
         // producers registered a write against the same shot id.
         QCOMPARE(mgr.m_pendingMetadataWrites.value(8473), 2);
-
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No shot with id 8473 to update"));
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No shot with id 8473 to update"));
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("did not land"));
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("did not land"));
 
         QTRY_COMPARE_WITH_TIMEOUT(failed.count(), 2, 5000);
         QVERIFY(!mgr.m_pendingMetadataWrites.contains(8473));


### PR DESCRIPTION
## What failed

`tst_AIManager::twoWritesToOneShotBothReportTheirOutcome`, during a full-suite run on a loaded machine (83 s wall against the usual 34–42 s):

```
FAIL!  : Received a warning that resulted in a failure:
FAIL!  : Compared values are not the same
   Actual   (failed.count()): 1
   Expected (2)             : 2
   Loc: [tests/tst_aimanager.cpp(3233)]
```

It passed in 2.07 s when re-run alone. That is not grounds to call it flaky, so it was traced.

## Root cause

The test installed its four `QTest::ignoreMessage` filters **after** calling the two producers:

```
3222  mgr.maybePersistRatingFromReply(...)        ← dispatches to the DB thread
3223  mgr.maybePersistBeanCorrectionFromReply(...)
3228  QTest::ignoreMessage("No shot with id 8473 to update")   ← too late
3233  QTRY_COMPARE_WITH_TIMEOUT(failed.count(), 2, 5000)
```

`requestUpdateShotMetadata()` posts to a background `SerialDbWorker`, and `"No shot with id 8473 to update"` is emitted **from that thread** ([shothistorystorage.cpp:3988](src/history/shothistorystorage.cpp:3988)). Nothing orders it against the main thread reaching line 3228. `init()` sets `QTest::failOnWarning()` ([tst_aimanager.cpp:142](tests/tst_aimanager.cpp:142)), so losing that race fails the test — and a saturated machine is exactly where the main thread loses it.

The fix moves the filters above the producers, matching the sibling test 40 lines up, which already had the order right.

## Why the second failure needs no separate fix

`failed.count() == 1` looks like an independent timeout, and it is not. From the Qt 6.11.2 sources:

```
qtestlog.cpp:277    handleFailOnWarning() → QTestResult::addFailure("Received a warning…")
qtestcase.cpp:2778  currentTestResolved() = currentTestFailed() || skipCurrentTest()
qtestcase.h:182     QTRY_LOOP_IMPL: for(… && !(runningTest() && currentTestResolved()) && !(expr) …)
```

The retry loop **stops as soon as the test is already failed**. The warning had resolved the test, so `QTRY_COMPARE_WITH_TIMEOUT` never waited its 5 s — it exited immediately and the trailing `QCOMPARE` read the spy after only one of the two queued callbacks had been delivered. The count mismatch is a consequence of the unfiltered warning.

## Two things deliberately not changed

**The 5 s budget.** There is no evidence it is too tight; the loop never spent it.

**The storage path.** This had the shape of a discarded queued write — the same family as the intermittent `settingsDyeDoseLadder` failure and the un-drained storage workers at shutdown — so it was checked rather than assumed. `runOnDbThread()` posts to a serial FIFO worker; the two requests are independent tasks, each running its own `withTempDb` and each emitting its own `shotMetadataUpdated`; there is no coalescing or dedup; and the only drop path is the `*destroyed` guard, which cannot fire while the storage outlives the assertion on the test's own stack. No write is being lost.

## Scope

The rest of `tests/` was scanned for the same inverted ordering. Every other `ignoreMessage` that sits near an async dispatch already precedes it — `tst_recipestorage`, `tst_coffeebags` and `tst_difluidr2` are all correct. This was the only one.

## Testing

Full suite via Qt Creator: **117 passed, 0 failed** (33.18 s).

Note that a green run does not by itself prove this fix, since the race only loses under load — the argument above is the evidence, and the suite run confirms nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)