### PR TITLE
Decode the original Decent Scale's 10-byte v1.2 weight frames

### DIFF
--- a/src/ble/protocol/decentscaleprotocol.h
+++ b/src/ble/protocol/decentscaleprotocol.h
@@ -112,6 +112,25 @@ inline bool checksumMatches(const QByteArray& data, qsizetype frameLen) {
     return static_cast<uint8_t>(frame[frameLen - 1]) == calculateXor(frame);
 }
 
+// Offset of the first valid 7-byte weight packet in `data`, or -1.
+//
+// This SCANS rather than frames, because its callers -- the USB probes, which
+// identify a scale by seeing one weight packet -- open a port mid-stream and so
+// start at an arbitrary byte. A framer that assumed data[0] began a frame would
+// miss the scale entirely on a port that happened to be mid-packet.
+inline qsizetype indexOfWeightPacket(const QByteArray& data) {
+    for (qsizetype i = 0; i + StandardFrameLength <= data.size(); i++) {
+        if (static_cast<uint8_t>(data[i]) != static_cast<uint8_t>(PacketHeader))
+            continue;
+        const uint8_t type = static_cast<uint8_t>(data[i + 1]);
+        if (type != TypeWeight && type != TypeWeightAlt)
+            continue;
+        if (checksumMatches(data.sliced(i, StandardFrameLength), StandardFrameLength))
+            return i;
+    }
+    return -1;
+}
+
 // HDS LED responses carry the firmware triple in their last two bytes: the
 // major version is BCD packed and the minor and patch values occupy one nibble
 // each. Keep this transport-neutral because USB and Bluetooth receive the same

--- a/src/ble/protocol/decentscaleprotocol.h
+++ b/src/ble/protocol/decentscaleprotocol.h
@@ -25,8 +25,20 @@ inline constexpr char PacketHeader = 0x03;
 inline constexpr uint8_t TypeLedResponse = 0x0A;
 inline constexpr uint8_t TypeAdsDebug = 0x25;  // 41 bytes, checksum in byte 40
 
+// Weight frame types. 0xCE is what the firmware notifies; 0xCA is accepted too
+// because de1app has always accepted both (binary.tcl:1437).
+inline constexpr uint8_t TypeWeight = 0xCE;
+inline constexpr uint8_t TypeWeightAlt = 0xCA;
+
 inline constexpr qsizetype StandardFrameLength = 7;
 inline constexpr qsizetype AdsDebugFrameLength = 41;
+// Decent Scale v1.2 firmware notifies weight in TEN bytes, not seven: the
+// 7-byte layout with minutes/seconds/milliseconds inserted after the weight
+// short, two unused bytes, and the XOR moved to byte 9. Weight stays at bytes
+// 2-3, so only the frame length and the checksum position differ.
+// (de1app decent_scale_weight_read_spec_v12, binary.tcl:350-364, dispatched at
+// :1422-1427.) The original scale has no USB, so this length is notified only.
+inline constexpr qsizetype V12WeightFrameLength = 10;
 
 // XOR checksum: XOR of all bytes except the last (byte 6 in a 7-byte packet).
 inline uint8_t calculateXor(const QByteArray& data) {
@@ -60,6 +72,25 @@ inline qsizetype notifiedFrameLength(uint8_t command, qsizetype available) {
     const qsizetype expected =
         (command == TypeAdsDebug) ? AdsDebugFrameLength : StandardFrameLength;
     return available >= expected ? expected : 0;
+}
+
+// The same question for a caller holding exactly one frame: a notification. It
+// returns `len` when that is a length this command is notified at, and 0 when
+// it is not -- which notifiedFrameLength() cannot express, since a stream
+// framer's buffer legitimately holds more than one frame.
+//
+// Only weight is accepted at ten bytes. de1app unpacks any 10-byte frame with
+// the v1.2 layout but decodes only weight from it (binary.tcl:1437-1460), and
+// the 7-byte LED response's battery and firmware bytes have no known v1.2
+// position -- so a 10-byte frame of another type is logged, not guessed at.
+inline qsizetype notifiedFrameLengthExact(uint8_t command, qsizetype len) {
+    if (command == TypeAdsDebug)
+        return len == AdsDebugFrameLength ? len : 0;
+    if (len == StandardFrameLength)
+        return len;
+    if (len == V12WeightFrameLength && (command == TypeWeight || command == TypeWeightAlt))
+        return len;
+    return 0;
 }
 
 // True when the trailing XOR byte of the first `frameLen` bytes matches.

--- a/src/ble/protocol/decentscaleprotocol.h
+++ b/src/ble/protocol/decentscaleprotocol.h
@@ -6,8 +6,9 @@
 #include "core/hdsfirmwarecatalog.h"
 #include <cstdint>
 
-// Decent Scale 7-byte binary packet protocol, shared by BLE and USB paths.
-// Packet format: [PacketHeader, type, data0, data1, data2, data3, XOR]
+// Decent Scale binary packet protocol, shared by BLE and USB paths.
+// Packet format: [PacketHeader, type, data0, data1, data2, data3, XOR] -- plus
+// the 10-byte v1.2 weight frame and the 41-byte ADS debug frame below.
 namespace DecentScaleProtocol {
 
 // Every frame this protocol sends or receives opens with it, and the USB
@@ -26,7 +27,7 @@ inline constexpr uint8_t TypeLedResponse = 0x0A;
 inline constexpr uint8_t TypeAdsDebug = 0x25;  // 41 bytes, checksum in byte 40
 
 // Weight frame types. 0xCE is what the firmware notifies; 0xCA is accepted too
-// because de1app has always accepted both (binary.tcl:1437).
+// because de1app has always accepted both (binary.tcl:1438).
 inline constexpr uint8_t TypeWeight = 0xCE;
 inline constexpr uint8_t TypeWeightAlt = 0xCA;
 
@@ -37,7 +38,7 @@ inline constexpr qsizetype AdsDebugFrameLength = 41;
 // short, two unused bytes, and the XOR moved to byte 9. Weight stays at bytes
 // 2-3, so only the frame length and the checksum position differ.
 // (de1app decent_scale_weight_read_spec_v12, binary.tcl:350-364, dispatched at
-// :1422-1427.) The original scale has no USB, so this length is notified only.
+// :1424-1427.) The original scale has no USB, so this length is notified only.
 inline constexpr qsizetype V12WeightFrameLength = 10;
 
 // XOR checksum: XOR of all bytes except the last (byte 6 in a 7-byte packet).
@@ -51,9 +52,11 @@ inline uint8_t calculateXor(const QByteArray& data) {
 
 // How many bytes the frame for `command` needs, or 0 when fewer than that have
 // arrived. It is a MINIMUM check: every type but 0x25 maps to 7, so an unknown
-// type is not rejected here. A packet-oriented caller that wants exactness must
-// compare the result against its own frame size; a stream framer must not,
-// since its buffer legitimately holds more than one frame.
+// type is not rejected here. For a stream framer that is the right question --
+// its buffer legitimately holds more than one frame. A caller that wants
+// exactness must use notifiedFrameLengthExact() and NOT compare this result
+// against its own frame size: this one never returns 10, so that comparison
+// rejects a v1.2 weight frame.
 //
 // Sourced from the firmware, not inferred: every openscale notify goes through
 // bleNotifyReadPacket() (openscale include/ble.h:535) and there are exactly
@@ -80,9 +83,10 @@ inline qsizetype notifiedFrameLength(uint8_t command, qsizetype available) {
 // framer's buffer legitimately holds more than one frame.
 //
 // Only weight is accepted at ten bytes. de1app unpacks any 10-byte frame with
-// the v1.2 layout but decodes only weight from it (binary.tcl:1437-1460), and
-// the 7-byte LED response's battery and firmware bytes have no known v1.2
-// position -- so a 10-byte frame of another type is logged, not guessed at.
+// the v1.2 layout (binary.tcl:1424-1427) but decodes only weight from it
+// (:1438-1462), and the 7-byte LED response's battery and firmware bytes have
+// no known v1.2 position -- so a 10-byte frame of another type is logged, not
+// guessed at.
 inline qsizetype notifiedFrameLengthExact(uint8_t command, qsizetype len) {
     if (command == TypeAdsDebug)
         return len == AdsDebugFrameLength ? len : 0;

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -355,16 +355,16 @@ bool DecentScale::parseWeightData(const QByteArray& data) {
 
     uint8_t command = d[1];
 
-    // Dispatch on LENGTH before checksum, so a frame that is not a 7-byte packet
+    // Dispatch on LENGTH before checksum, so a frame this driver cannot decode
     // never reaches the v1 auto-disable counter below.
     //
-    // The exactness is enforced here, not by notifiedFrameLength(), which asks
-    // only whether enough bytes have arrived -- the right question for the USB
-    // stream framer, the wrong one for a notification, which carries exactly one
-    // frame. Without this a 12-byte frame of any other type would be read as a
-    // 7-byte packet and spend the auto-disable budget.
-    const qsizetype frameLen = DecentScaleProtocol::notifiedFrameLength(command, data.size());
-    if (frameLen != data.size()) {
+    // A notification carries exactly one frame, so the length is known and the
+    // exact form of the question is the right one -- notifiedFrameLength() asks
+    // only whether enough bytes have arrived, which suits the USB stream framer.
+    // Without this a 12-byte frame of any type would be read as a 7-byte packet
+    // and spend the auto-disable budget.
+    const qsizetype frameLen = DecentScaleProtocol::notifiedFrameLengthExact(command, data.size());
+    if (frameLen == 0) {
         logFrameShapeOnce(QString("Undecodable frame, type 0x%1, %2 bytes")
                               .arg(command, 2, 16, QChar('0'))
                               .arg(data.size()),
@@ -403,7 +403,7 @@ bool DecentScale::parseWeightData(const QByteArray& data) {
         }
     }
 
-    if (command == 0xCE || command == 0xCA) {
+    if (command == DecentScaleProtocol::TypeWeight || command == DecentScaleProtocol::TypeWeightAlt) {
         // Weight data
         int16_t weightRaw = (static_cast<int16_t>(d[2]) << 8) | d[3];
         double weight = weightRaw / 10.0;  // Weight in grams

--- a/src/usb/usbdecentscale.cpp
+++ b/src/usb/usbdecentscale.cpp
@@ -385,7 +385,7 @@ void UsbDecentScale::processPacket(const QByteArray& packet)
         int16_t weightRaw = (static_cast<int16_t>(d[2]) << 8) | d[3];
         double weight = weightRaw / 10.0;
         setWeight(weight);
-    } else if (command == 0x0A) {
+    } else if (command == DecentScaleProtocol::TypeLedResponse) {
         // LED response packet (openscale/HDS format):
         // [0]=0x03 header, [1]=0x0A type, [2-3]=weight, [4]=battery, [5-6]=firmware version
         // Battery: 0-100 = percentage, 0xFF = charging.

--- a/src/usb/usbdecentscale.cpp
+++ b/src/usb/usbdecentscale.cpp
@@ -380,7 +380,7 @@ void UsbDecentScale::processPacket(const QByteArray& packet)
     const uint8_t* d = reinterpret_cast<const uint8_t*>(packet.constData());
     uint8_t command = d[1];
 
-    if (command == 0xCE || command == 0xCA) {
+    if (command == DecentScaleProtocol::TypeWeight || command == DecentScaleProtocol::TypeWeightAlt) {
         // Weight data: bytes 2-3 are big-endian signed int16, divide by 10 for grams
         int16_t weightRaw = (static_cast<int16_t>(d[2]) << 8) | d[3];
         double weight = weightRaw / 10.0;

--- a/src/usb/usbscalemanager.cpp
+++ b/src/usb/usbscalemanager.cpp
@@ -1,5 +1,6 @@
 #include "usb/usbscalemanager.h"
 #include "usb/usbdecentscale.h"
+#include "ble/protocol/decentscaleprotocol.h"
 
 #include "ble/scales/scalelogging.h"
 
@@ -439,31 +440,18 @@ void UsbScaleManager::onAndroidProbeRead()
 
     m_probeBuffer.append(data);
 
-    // Look for a valid weight packet: 0x03 followed by 0xCE or 0xCA
-    for (int i = 0; i <= m_probeBuffer.size() - 7; i++) {
-        uint8_t b0 = static_cast<uint8_t>(m_probeBuffer[i]);
-        uint8_t b1 = static_cast<uint8_t>(m_probeBuffer[i + 1]);
+    if (DecentScaleProtocol::indexOfWeightPacket(m_probeBuffer) < 0)
+        return;
 
-        if (b0 == 0x03 && (b1 == 0xCE || b1 == 0xCA)) {
-            // Validate XOR checksum
-            uint8_t xorVal = 0;
-            for (int j = i; j < i + 6; j++) {
-                xorVal ^= static_cast<uint8_t>(m_probeBuffer[j]);
-            }
-            if (xorVal == static_cast<uint8_t>(m_probeBuffer[i + 6])) {
-                info(QStringLiteral("Half Decent Scale confirmed (weight packet received)"));
+    info(QStringLiteral("Half Decent Scale confirmed (weight packet received)"));
 
-                // Stop probe timers but DON'T close — connectToScale() reuses
-                // the JNI connection when the user selects the USB entry.
-                cleanupAndroidProbe(false);
+    // Stop probe timers but DON'T close — connectToScale() reuses the JNI
+    // connection when the user selects the USB entry.
+    cleanupAndroidProbe(false);
 
-                // Record availability only — do NOT auto-connect. main.cpp lists
-                // it as selectable and connects on selection / saved-primary.
-                setScaleAvailable(true);
-                return;
-            }
-        }
-    }
+    // Record availability only — do NOT auto-connect. main.cpp lists it as
+    // selectable and connects on selection / saved-primary.
+    setScaleAvailable(true);
 }
 
 void UsbScaleManager::onAndroidProbeTimeout()
@@ -653,32 +641,20 @@ void UsbScaleManager::onProbeReadyRead()
         return;
     }
 
-    // Look for valid weight packet: 0x03, 0xCE/0xCA, ..., XOR
-    for (int i = 0; i <= m_probeBuffer.size() - 7; i++) {
-        uint8_t b0 = static_cast<uint8_t>(m_probeBuffer[i]);
-        uint8_t b1 = static_cast<uint8_t>(m_probeBuffer[i + 1]);
+    if (DecentScaleProtocol::indexOfWeightPacket(m_probeBuffer) < 0)
+        return;
 
-        if (b0 == 0x03 && (b1 == 0xCE || b1 == 0xCA)) {
-            uint8_t xorVal = 0;
-            for (int j = i; j < i + 6; j++) {
-                xorVal ^= static_cast<uint8_t>(m_probeBuffer[j]);
-            }
-            if (xorVal == static_cast<uint8_t>(m_probeBuffer[i + 6])) {
-                QString confirmedPort = m_probingPortInfo.portName();
-                info(QStringLiteral("Half Decent Scale found on %1 (binary weight packet)")
-                        .arg(confirmedPort));
+    const QString confirmedPort = m_probingPortInfo.portName();
+    info(QStringLiteral("Half Decent Scale found on %1 (binary weight packet)")
+            .arg(confirmedPort));
 
-                // Close the probe port — connectToScale() reopens it on demand.
-                cleanupProbe();
+    // Close the probe port — connectToScale() reopens it on demand.
+    cleanupProbe();
 
-                // Record availability only — do NOT auto-connect. main.cpp lists
-                // it as selectable and connects on selection / saved-primary.
-                m_confirmedPortName = confirmedPort;
-                setScaleAvailable(true);
-                return;
-            }
-        }
-    }
+    // Record availability only — do NOT auto-connect. main.cpp lists it as
+    // selectable and connects on selection / saved-primary.
+    m_confirmedPortName = confirmedPort;
+    setScaleAvailable(true);
 }
 
 void UsbScaleManager::onProbeTimeout()

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -695,6 +695,20 @@ private slots:
         QCOMPARE(capture.count(QStringLiteral("Undecodable frame, type 0x0a, 10 bytes")), 1);
     }
 
+    void decentWeightPacketFoundAtAnOffset() {
+        // The USB probes open a port mid-stream, so the packet that identifies
+        // the scale rarely starts at byte 0 -- and a run of leading bytes must
+        // not be mistaken for one.
+        const QByteArray packet = buildDecentWeightPacket(42.0);
+        QCOMPARE(DecentScaleProtocol::indexOfWeightPacket(packet), 0);
+        QCOMPARE(DecentScaleProtocol::indexOfWeightPacket(QByteArray("noise") + packet), 5);
+        QCOMPARE(DecentScaleProtocol::indexOfWeightPacket(QByteArray("noise")), qsizetype(-1));
+
+        QByteArray corrupt = packet;
+        corrupt[6] = static_cast<char>(static_cast<uint8_t>(corrupt[6]) ^ 0xFF);
+        QCOMPARE(DecentScaleProtocol::indexOfWeightPacket(corrupt), qsizetype(-1));
+    }
+
     void decentUndecodedFrameLoggedOnceWithItsBytes() {
         // One line per shape, carrying the hex, and nothing on repeats — the
         // payload here changes every frame, which is exactly what defeats a

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -630,6 +630,71 @@ private slots:
         QCOMPARE(spy.count(), 0);
     }
 
+    // Build the 10-byte weight frame the original Decent Scale's v1.2 firmware
+    // notifies: the 7-byte layout with minutes/seconds/milliseconds after the
+    // weight short, two unused bytes, and the XOR in byte 9 (de1app
+    // decent_scale_weight_read_spec_v12, binary.tcl:350-364).
+    static QByteArray buildDecentV12WeightFrame(double grams) {
+        const int16_t raw = static_cast<int16_t>(qRound(grams * 10.0));
+        QByteArray pkt(10, 0);
+        pkt[0] = 0x03;
+        pkt[1] = static_cast<char>(0xCE);
+        pkt[2] = static_cast<char>((raw >> 8) & 0xFF);
+        pkt[3] = static_cast<char>(raw & 0xFF);
+        pkt[4] = 0x01;  // minutes
+        pkt[5] = 0x1E;  // seconds
+        pkt[6] = 0x05;  // milliseconds — the byte a 7-byte frame checksums on
+        uint8_t xorSum = 0;
+        for (int i = 0; i < 9; i++)
+            xorSum ^= static_cast<uint8_t>(pkt[i]);
+        pkt[9] = static_cast<char>(xorSum);
+        return pkt;
+    }
+
+    void decentV12TenByteWeightFrameDecodes() {
+        // #1891 dispatched every non-0x25 notification at exactly 7 bytes, so a
+        // v1.2 scale's 10-byte weight frames became undecodable: no weight, and
+        // — because the watchdog is now fed only by a decoded frame — ten
+        // "no initial weight data" retries and a disconnect loop.
+        DecentScale scale(nullptr);
+        QSignalSpy spy(&scale, &ScaleDevice::weightChanged);
+
+        scale.onCharacteristicChanged(Scale::Decent::READ, buildDecentV12WeightFrame(42.0));
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.last().at(0).toDouble(), 42.0);
+    }
+
+    void decentV12FrameChecksumIsReadAtByteNine() {
+        // The checksum must be evaluated over the frame's own length. Checked at
+        // byte 6 the frame reads as corrupt, which spends the v1 auto-disable
+        // budget and retires checksum validation for the session.
+        DecentScale scale(nullptr);
+        MessageCapture capture;
+        QSignalSpy spy(&scale, &ScaleDevice::weightChanged);
+
+        for (int i = 0; i < DecentScale::kChecksumFailureThreshold + 2; i++)
+            scale.onCharacteristicChanged(Scale::Decent::READ, buildDecentV12WeightFrame(10.0 + i));
+
+        QCOMPARE(capture.count(QStringLiteral("Checksum validation disabled")), 0);
+        QCOMPARE(capture.count(QStringLiteral("Invalid checksum")), 0);
+        QCOMPARE(spy.count(), DecentScale::kChecksumFailureThreshold + 2);
+    }
+
+    void decentTenByteFrameOfAnotherTypeStaysUndecodable() {
+        // Only weight is decoded at ten bytes: the LED response's battery and
+        // firmware bytes have no known v1.2 position, so guessing at them would
+        // report a wrong battery level rather than nothing.
+        DecentScale scale(nullptr);
+        MessageCapture capture;
+
+        QByteArray led = buildDecentV12WeightFrame(42.0);
+        led[1] = 0x0A;
+        scale.onCharacteristicChanged(Scale::Decent::READ, led);
+
+        QCOMPARE(capture.count(QStringLiteral("Undecodable frame, type 0x0a, 10 bytes")), 1);
+    }
+
     void decentUndecodedFrameLoggedOnceWithItsBytes() {
         // One line per shape, carrying the hex, and nothing on repeats — the
         // payload here changes every frame, which is exactly what defeats a


### PR DESCRIPTION
## The report

Build 3582: an original Decent Scale (not HDS) spins `watchdog: no initial weight data` ten times, disconnects, reconnects, and repeats. Ten is exactly `kWatchdogMaxRetries`.

## Cause

#1891 made two changes that combine badly on a v1.2 scale:

1. `DecentScale::parseWeightData()` now requires a non-`0x25` notification to be **exactly 7 bytes**, else it logs "Undecodable frame" and returns false.
2. `handleData()` now tickles the watchdog **only when a frame decoded** — previously it tickled on any READ notification.

The original Decent Scale's v1.2 firmware notifies weight in **ten** bytes. de1app has dispatched on that length since forever: `decent_scale_weight_read_spec_v12` (`de1plus/binary.tcl:350-364`), selected at `:1422-1427`. The layout is the 7-byte one with minutes/seconds/milliseconds inserted after the weight short, two unused bytes, and the XOR moved to byte 9. Weight stays at bytes 2-3.

So every weight frame is now dropped: no weight, nothing feeds the watchdog, ten retries, disconnect loop.

Before #1891 it worked by accident. The guard was `data.size() < 7`, so the weight parsed out of bytes 2-3; the checksum compared byte 6 and failed; five consecutive failures tripped the v1 auto-disable (#630); and the watchdog was fed by every notification regardless of what it contained.

Decaid never hit this — `lib/src/models/device/impl/decent_scale/scale.dart` has no length check and no checksum validation, and its notification watchdog resets on any notification.

## Fix

- `notifiedFrameLengthExact(command, len)` answers the question a notification can actually ask: it carries exactly one frame, so the length is known. 7 always, 41 for `0x25`, and 10 **for weight types only**.
  - Weight only, because de1app decodes nothing else from the v1.2 layout, and the 7-byte LED response's battery and firmware bytes have no known v1.2 position — guessing would report a wrong battery level rather than nothing.
- `notifiedFrameLength()` is unchanged for the USB stream framer, where a buffer legitimately holds more than one frame so the length is ambiguous — and where the original scale cannot appear at all, having no USB.
- Bounding the checksum to the frame's own length also stops a good v1.2 frame spending the v1 auto-disable budget: byte 9 is checked, not byte 6.
- `0xCE` / `0xCA` are now named constants shared by both transports.

## Tests

Three added to `tst_scaleprotocol.cpp`:

- a 10-byte v1.2 weight frame decodes to the right grams
- its checksum is read at byte 9 — seven such frames produce no "Invalid checksum" and no auto-disable
- a 10-byte frame of another type stays undecodable

Full suite: 117 passed, 0 failed.

Not verified on hardware — I have no original Decent Scale. The reporter's log would confirm the 10-byte shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)