### PR TITLE
Stop the shot clock and the scale timer on a mid-shot DE1 disconnect

### DIFF
--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -365,18 +365,16 @@ void MachineState::updatePhase() {
                                         m_phase == Phase::Preinfusion ||
                                         m_phase == Phase::Pouring ||
                                         m_phase == Phase::Ending);
-            // Neither timer stops on its own once the link is gone. Every
-            // stopShotTimer() call sits past this early return, and
-            // onShotTimerTick() has no connectivity guard, so the shot clock
-            // would keep counting every 100 ms with no machine behind it; the
-            // scale is a separate BLE link that is usually still connected, so
-            // its on-device display would keep counting too. Stop the pair
-            // here, as the espresso-exit site below does.
-            stopShotTimer();
-            if (m_scale) {
-                m_scale->stopTimer();
-                qDebug() << "=== SCALE TIMER: Stopped (DE1 disconnected) ===";
-            }
+            // Neither timer stops on its own: both other stop sites sit past
+            // this early return, and onShotTimerTick() has no connectivity
+            // guard. The scale is a separate BLE link and keeps counting on
+            // its own display.
+            //
+            // Gated like the other stop sites, which all require that
+            // something was running: a drop from Idle or Sleep must not send
+            // an unsolicited stop to a scale the user is timing with by hand.
+            if (m_shotTimer->isActive() || wasInEspresso)
+                stopShotAndScaleTimers("DE1 disconnected");
             m_phase = Phase::Disconnected;
             emit phaseChanged();
             if (wasInEspresso)
@@ -722,12 +720,7 @@ void MachineState::updatePhase() {
         } else if (!isFlowing() && wasFlowing) {
             // Don't stop timer during espresso Ending phase - let it run until cycle ends
             if (!isInEspresso) {
-                stopShotTimer();
-                // Stop scale timer when flow ends
-                if (m_scale) {
-                    m_scale->stopTimer();
-                    qDebug() << "=== SCALE TIMER: Stopped (flow ended) ===";
-                }
+                stopShotAndScaleTimers("flow ended");
                 // Steam left the Steaming phase. Two cases reach this: a manual
                 // stop straight out of flowing steam (the pending flag emits
                 // here), or the Steaming->Idle exit AFTER an auto-stop —
@@ -881,11 +874,7 @@ void MachineState::updatePhase() {
             qDebug().noquote() << QString("MachineState: steam flow stopped via substate change (substate=%1)")
                 .arg(DE1::subStateToString(m_device->subState()));
         }
-        stopShotTimer();
-        if (m_scale) {
-            m_scale->stopTimer();
-            qDebug() << "=== SCALE TIMER: Stopped (substate change) ===";
-        }
+        stopShotAndScaleTimers("substate change");
         // Steam auto-stop path: substate left Steaming (Puffing/Ending) while
         // the phase stays Steaming. This emission marks the actual end of flow;
         // consuming the pending flag here keeps the later Steaming->Idle
@@ -1285,6 +1274,15 @@ void MachineState::startShotTimer() {
 
 void MachineState::stopShotTimer() {
     m_shotTimer->stop();
+}
+
+void MachineState::stopShotAndScaleTimers(const char* reason) {
+    stopShotTimer();
+    if (m_scale) {
+        m_scale->stopTimer();
+        qDebug().noquote()
+            << QStringLiteral("=== SCALE TIMER: Stopped (%1) ===").arg(QLatin1String(reason));
+    }
 }
 
 void MachineState::onShotTimerTick() {

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -365,6 +365,18 @@ void MachineState::updatePhase() {
                                         m_phase == Phase::Preinfusion ||
                                         m_phase == Phase::Pouring ||
                                         m_phase == Phase::Ending);
+            // Neither timer stops on its own once the link is gone. Every
+            // stopShotTimer() call sits past this early return, and
+            // onShotTimerTick() has no connectivity guard, so the shot clock
+            // would keep counting every 100 ms with no machine behind it; the
+            // scale is a separate BLE link that is usually still connected, so
+            // its on-device display would keep counting too. Stop the pair
+            // here, as the espresso-exit site below does.
+            stopShotTimer();
+            if (m_scale) {
+                m_scale->stopTimer();
+                qDebug() << "=== SCALE TIMER: Stopped (DE1 disconnected) ===";
+            }
             m_phase = Phase::Disconnected;
             emit phaseChanged();
             if (wasInEspresso)

--- a/src/machine/machinestate.h
+++ b/src/machine/machinestate.h
@@ -210,6 +210,10 @@ private:
     void updatePhase();
     void startShotTimer();
     void stopShotTimer();
+    // The app's shot clock and the scale's on-device timer are stopped together
+    // at every site that stops either one mid-flow. `reason` names the site in
+    // the log, which is the only thing that differed between the copies.
+    void stopShotAndScaleTimers(const char* reason);
     void checkStopAtWeightHotWater(double weight);
     void checkStopAtVolume();
     void checkStopAtVolumeHotWater();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1696,10 +1696,10 @@ int main(int argc, char *argv[])
     // Ordering — twice written wrong here, so it is sourced. Release runs BEFORE
     // the save path, on every shot, and what guarantees it is the delivery mode,
     // not settling: espressoCycleEnded is emitted SYNCHRONOUSLY on the phase
-    // transition (machinestate.cpp:724), while shotEnded — which reaches
+    // transition (machinestate.cpp:806), while shotEnded — which reaches
     // onShotEnded via ShotTimingController::endShot() -> shotProcessingReady —
     // is emitted inside a Qt::QueuedConnection invokeMethod
-    // (machinestate.cpp:772-784). So the release is always at least one event
+    // (machinestate.cpp:854-866). So the release is always at least one event
     // loop turn ahead.
     //
     // Stop-at-weight settling widens that gap to ~1.4 s when it runs, but does

--- a/tests/mocks/MockScaleDevice.h
+++ b/tests/mocks/MockScaleDevice.h
@@ -12,6 +12,7 @@ public:
     // Pure virtual implementations (no-ops)
     void connectToDevice(const QBluetoothDeviceInfo&) override {}
     void tare() override { ++m_tareCount; }
+    void stopTimer() override { ++m_stopTimerCount; }
 
     // Configurable behavior
     bool isFlowScale() const override { return m_isFlowScale; }
@@ -25,6 +26,9 @@ public:
     // need to assert on "no tare was sent", which no signal can express.
     int tareCount() const { return m_tareCount; }
     void resetTareCount() { m_tareCount = 0; }
+    // Number of stopTimer() commands issued — the scale's on-device clock is not
+    // otherwise observable from the app side.
+    int stopTimerCount() const { return m_stopTimerCount; }
 
     // Test configuration
     void setIsFlowScale(bool flow) { m_isFlowScale = flow; }
@@ -36,5 +40,6 @@ public:
 private:
     bool m_isFlowScale = false;
     int m_tareCount = 0;
+    int m_stopTimerCount = 0;
     QString m_type = QStringLiteral("mock");
 };

--- a/tests/mocks/MockScaleDevice.h
+++ b/tests/mocks/MockScaleDevice.h
@@ -3,16 +3,22 @@
 #include "ble/scaledevice.h"
 
 // Minimal concrete ScaleDevice for testing.
-// Exposes protected setters as public and implements pure virtuals as no-ops.
+// Exposes protected setters as public; implements connectToDevice() as a no-op
+// and counts the commands whose delivery a caller has no other way to observe.
 class MockScaleDevice : public ScaleDevice {
     Q_OBJECT
 public:
     explicit MockScaleDevice(QObject* parent = nullptr) : ScaleDevice(parent) {}
 
-    // Pure virtual implementations (no-ops)
+    // Pure virtuals
     void connectToDevice(const QBluetoothDeviceInfo&) override {}
     void tare() override { ++m_tareCount; }
+
+    // Base overrides with a default body, not pure virtuals.
     void stopTimer() override { ++m_stopTimerCount; }
+    // The mock records timer commands, so it must not report a scale that has
+    // no timer — tst_scaleprotocol pins that pairing for the real drivers.
+    bool supportsTimer() const override { return true; }
 
     // Configurable behavior
     bool isFlowScale() const override { return m_isFlowScale; }

--- a/tests/tst_machinestate.cpp
+++ b/tests/tst_machinestate.cpp
@@ -395,6 +395,42 @@ private slots:
         QCOMPARE(f.state.phase(), MachineState::Phase::Disconnected);
     }
 
+    // A drop mid-shot has to stop both clocks. Neither stops on its own: the
+    // disconnected branch returns before every stopShotTimer() site, and the
+    // scale is a separate BLE link that is still connected and would keep
+    // counting on its own display.
+    void midShotDisconnectStopsBothTimers() {
+        TestFixture f;
+        f.scale.mockSetConnected(true);
+        f.setDE1State(DE1::State::Espresso, DE1::SubState::Pouring);
+        QVERIFY(f.state.m_shotTimer->isActive());
+        const int stopsBefore = f.scale.stopTimerCount();
+
+        f.device.m_simulationMode = false;
+        f.state.onDE1StateChanged();
+
+        QCOMPARE(f.state.phase(), MachineState::Phase::Disconnected);
+        QVERIFY(!f.state.m_shotTimer->isActive());
+        QCOMPARE(f.scale.stopTimerCount(), stopsBefore + 1);
+    }
+
+    // The stop is a transition, not a state: updatePhase() runs again on every
+    // DE1 signal while the link is down, and a stopTimer() per call would be a
+    // BLE command stream at the scale for as long as the machine stays away.
+    void repeatedDisconnectedUpdatesSendOneScaleStop() {
+        TestFixture f;
+        f.scale.mockSetConnected(true);
+        f.setDE1State(DE1::State::Espresso, DE1::SubState::Pouring);
+        const int stopsBefore = f.scale.stopTimerCount();
+
+        f.device.m_simulationMode = false;
+        f.state.onDE1StateChanged();
+        f.state.onDE1StateChanged();
+        f.state.onDE1StateChanged();
+
+        QCOMPARE(f.scale.stopTimerCount(), stopsBefore + 1);
+    }
+
     // ==========================================
     // Standby switch (Error_NoAC) — de1app commit 04d3b02e
     // ==========================================

--- a/tests/tst_machinestate.cpp
+++ b/tests/tst_machinestate.cpp
@@ -395,40 +395,58 @@ private slots:
         QCOMPARE(f.state.phase(), MachineState::Phase::Disconnected);
     }
 
-    // A drop mid-shot has to stop both clocks. Neither stops on its own: the
-    // disconnected branch returns before every stopShotTimer() site, and the
-    // scale is a separate BLE link that is still connected and would keep
-    // counting on its own display.
-    void midShotDisconnectStopsBothTimers() {
+    void midFlowDisconnectStopsBothTimersOnce_data() {
+        QTest::addColumn<int>("de1State");
+        QTest::addColumn<int>("de1SubState");
+        // Espresso and steam start both timers down different branches of
+        // updatePhase(), and the stop is deliberately not gated on the espresso
+        // predicate. Without the steam row, moving the stop under the
+        // wasInEspresso gate seven lines below leaves the suite green.
+        QTest::newRow("espresso") << int(DE1::State::Espresso) << int(DE1::SubState::Pouring);
+        QTest::newRow("steam") << int(DE1::State::Steam) << int(DE1::SubState::Steaming);
+    }
+
+    // A drop mid-flow has to stop both clocks, and stop them once: updatePhase()
+    // runs again on every DE1 signal while the link is down, so a stop that is
+    // not latched by the phase would put repeated BLE writes on a scale that is
+    // already stopped.
+    void midFlowDisconnectStopsBothTimersOnce() {
+        QFETCH(int, de1State);
+        QFETCH(int, de1SubState);
+
         TestFixture f;
         f.scale.mockSetConnected(true);
-        f.setDE1State(DE1::State::Espresso, DE1::SubState::Pouring);
+        f.setDE1State(static_cast<DE1::State>(de1State),
+                      static_cast<DE1::SubState>(de1SubState));
         QVERIFY(f.state.m_shotTimer->isActive());
-        const int stopsBefore = f.scale.stopTimerCount();
+        QCOMPARE(f.scale.stopTimerCount(), 0);
 
         f.device.m_simulationMode = false;
         f.state.onDE1StateChanged();
 
         QCOMPARE(f.state.phase(), MachineState::Phase::Disconnected);
         QVERIFY(!f.state.m_shotTimer->isActive());
-        QCOMPARE(f.scale.stopTimerCount(), stopsBefore + 1);
+        QCOMPARE(f.scale.stopTimerCount(), 1);
+
+        f.state.onDE1StateChanged();
+        f.state.onDE1StateChanged();
+        QCOMPARE(f.scale.stopTimerCount(), 1);
     }
 
-    // The stop is a transition, not a state: updatePhase() runs again on every
-    // DE1 signal while the link is down, and a stopTimer() per call would be a
-    // BLE command stream at the scale for as long as the machine stays away.
-    void repeatedDisconnectedUpdatesSendOneScaleStop() {
+    // The gate that keeps the stop off a scale nobody was timing with. A drop
+    // from Idle has no clock to stop, and the scale's own button is the other
+    // way its timer starts.
+    void disconnectFromIdleSendsNoScaleStop() {
         TestFixture f;
         f.scale.mockSetConnected(true);
-        f.setDE1State(DE1::State::Espresso, DE1::SubState::Pouring);
-        const int stopsBefore = f.scale.stopTimerCount();
+        f.setDE1State(DE1::State::Idle, DE1::SubState::Ready);
+        QVERIFY(!f.state.m_shotTimer->isActive());
 
         f.device.m_simulationMode = false;
         f.state.onDE1StateChanged();
-        f.state.onDE1StateChanged();
-        f.state.onDE1StateChanged();
 
-        QCOMPARE(f.scale.stopTimerCount(), stopsBefore + 1);
+        QCOMPARE(f.state.phase(), MachineState::Phase::Disconnected);
+        QCOMPARE(f.scale.stopTimerCount(), 0);
     }
 
     // ==========================================


### PR DESCRIPTION
Fixes #1918.

## What was wrong

When the DE1's BLE link dropped mid-shot, `MachineState::updatePhase()` took its disconnected early return. That branch set `m_phase = Phase::Disconnected` and emitted `espressoCycleEnded()`, but stopped neither timer:

- **The shot clock kept running.** Every `stopShotTimer()` call sits past the early return, and `onShotTimerTick()` has no connectivity guard, so it went on computing elapsed time and emitting `shotTimeChanged()` every 100 ms with no machine behind it.
- **The scale's on-device timer kept running.** The scale is a separate BLE link and is usually still connected, so its display counted up until something else reset it.

`stopShotTimer()` is paired with stopping the scale's timer at all three other sites in the file (flow ended, espresso-cycle exit, substate change while not flowing), so a fix for only one half would leave the file inconsistent about a pairing it documents three times.

## The fix

Stop both in the transition into `Phase::Disconnected`, before the phase emits — `shotTime()` computes live off `m_shotTimer->isActive()`, so stopping first is what makes every `phaseChanged` and `espressoCycleEnded` slot read a frozen clock rather than an advancing one.

The pair is now `stopShotAndScaleTimers(reason)`. It was hand-written at three sites; CLAUDE.md asks for the extraction on the second copy and for collapsing existing copies in the pass that touches them. The espresso-exit site keeps its own scale-only stop, which is deliberate.

Two decisions worth calling out:

**Not gated on `wasInEspresso`.** The shot timer starts for every flow, so a steam or flush drop leaves it running too — and the suite now pins that with a steam row.

**But gated on something having run** (`m_shotTimer->isActive() || wasInEspresso`). Ungated, this fired on every transition out of `Disconnected`, including from Ready, Sleep and Idle: a machine switched off at the wall would send an unsolicited stop to a scale that was not timing, and could stop a timer the user started with the scale's own button. Every other stop site in the file requires that something was running.

**The glitch-recovery path is unaffected**, which the issue asked to verify. Its `else if (!m_shotTimer->isActive())` test sits inside the `wasInEspresso` arm, and a reconnect has `oldPhase == Disconnected`, so `wasInEspresso` is false and the fresh-start branch runs instead. Stopping the timer cannot reroute anything there.

## Tests

Two slots in the existing `tst_machinestate.cpp` — no new test file, so the build cost is milliseconds rather than the ~1.4 s a new TU carries:

- `midFlowDisconnectStopsBothTimersOnce`, parameterised over espresso and steam — assert both timers running, disconnect, assert both stopped and exactly one scale command sent, then two further `onDE1StateChanged()` calls send no more.
- `disconnectFromIdleSendsNoScaleStop` — the gate.

`MockScaleDevice` gains a `stopTimer()` override and a `stopTimerCount()`, since the scale's on-device clock is not otherwise observable from the app side, plus `supportsTimer() == true` to stay consistent with the invariant `tst_scaleprotocol` pins for the real drivers.

**Each assertion was confirmed falsifiable, and independently so**, by three mutations:

| Mutation | What failed |
|---|---|
| Fix reverted | both timer assertions |
| Gate changed to `wasInEspresso` only | the **steam row only** — the espresso row stayed green, which is the whole argument for the row existing |
| Gate removed entirely | `disconnectFromIdleSendsNoScaleStop` alone |

## What this does not touch

**Reconnect is unchanged, and provably so.** A reconnect into an espresso phase has `oldPhase == Disconnected`, so `wasInEspresso` is false: `espressoCycleStarted` fires, `ShotTimingController::startShot()` resets its display base, and `startShotTimer()` restarts the local clock. That happened before this change too, which is why no reconnect assertion was added — it would pass against both branches.

**`ShotTimingController` still leaks past a drop** (pre-existing, filed separately). `shotEnded` is emitted only from the queued block the disconnected branch returns before reaching, so `endShot()` never runs and `m_shotActive` stays true with its 50 ms display timer going. Not user-visible in the timer, since `MachineState::shotTime()` delegates to the controller only for espresso phases and a reconnect into one resets it — but the timer and the sample processing keep running until the next shot.

## Verification

Full local suite through Qt Creator: 117 passed, 0 failed. `check_log_markers.py` and `check_test_source_duplication.py` both clean.

No manual entry: a disconnect not leaving a phantom running clock is not a feature a user has to be told exists.

## Age

Pre-existing, not introduced by #1915 — both `stopShotTimer()` sites predate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
