### PR TITLE
Fix scale connection retries and clarify pairing

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1778,7 +1778,18 @@ Item {
                         fallback: "Available Devices"
                         color: Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(13)
-                        visible: discoveredDevicesList.count > 0
+                        visible: discoveredDevicesList.visible && discoveredDevicesList.count > 0
+                            && !discoveredDevicesList.needsScaleSelection
+                    }
+
+                    Tr {
+                        Layout.fillWidth: true
+                        key: "settings.bluetooth.selectDiscoveredScale"
+                        fallback: "Scale found, select your scale:"
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(14)
+                        wrapMode: Text.WordWrap
+                        visible: discoveredDevicesList.visible && discoveredDevicesList.needsScaleSelection
                     }
 
                     // Unified discovered devices list (scales + refractometers).
@@ -1793,6 +1804,8 @@ Item {
                                                           Math.min(count, 4) * Theme.scaled(40))
                         clip: true
                         visible: !ScaleDevice || !ScaleDevice.connected || ScaleDevice.isFlowScale || !BLEManager.refractometerConnected
+                        readonly property bool needsScaleSelection: Settings.primaryScaleAddress === ""
+                            && combinedModel.some(function(device) { return device.deviceClass === "scale" })
 
                         // Combine scales + refractometers. The model is rebuilt
                         // explicitly via Connections handlers below — relying on

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1056,16 +1056,23 @@ Item {
                         }
 
                         Tr {
+                            key: "settings.bluetooth.connecting"
+                            fallback: "Connecting..."
+                            visible: !scaleStatusHelper.isConnected && BLEManager.scaleConnecting
+                            color: Theme.textSecondaryColor
+                        }
+
+                        Tr {
                             key: "settings.bluetooth.notFound"
                             fallback: "Not found"
-                            visible: !scaleStatusHelper.isConnected && BLEManager.scaleConnectionFailed
+                            visible: !scaleStatusHelper.isConnected && !BLEManager.scaleConnecting && BLEManager.scaleConnectionFailed
                             color: Theme.errorColor
                         }
 
                         Tr {
                             key: "settings.bluetooth.disconnected"
                             fallback: "Disconnected"
-                            visible: !scaleStatusHelper.isConnected && !BLEManager.scaleConnectionFailed
+                            visible: !scaleStatusHelper.isConnected && !BLEManager.scaleConnecting && !BLEManager.scaleConnectionFailed
                             color: Theme.textSecondaryColor
                         }
 
@@ -1765,6 +1772,15 @@ Item {
                         }
                     }
 
+                    Tr {
+                        Layout.fillWidth: true
+                        key: "settings.bluetooth.availableDevices"
+                        fallback: "Available Devices"
+                        color: Theme.textSecondaryColor
+                        font.pixelSize: Theme.scaled(13)
+                        visible: discoveredDevicesList.count > 0
+                    }
+
                     // Unified discovered devices list (scales + refractometers).
                     // Height scales with the number of items so rows aren't
                     // clipped below the fold (notably the WiFi-scale row when
@@ -1866,12 +1882,7 @@ Item {
                                 ? TranslationManager.translate("connections.refractometer", "Refractometer")
                                 : modelData.deviceType)
                             Accessible.focusable: true
-                            Accessible.onPressAction: {
-                                if (modelData.deviceClass === "refractometer")
-                                    BLEManager.connectToRefractometer(modelData.address)
-                                else
-                                    BLEManager.connectToScale(modelData.address)
-                            }
+                            Accessible.onPressAction: delegate2.clicked()
 
                             contentItem: RowLayout {
                                 Text {
@@ -1923,6 +1934,8 @@ Item {
                             key: "settings.bluetooth.noDevices"
                             fallback: "No devices found"
                             visible: discoveredDevicesList.count === 0
+                                && Settings.knownScales.length === 0
+                                && Settings.savedRefractometerAddress === ""
                             color: Theme.textSecondaryColor
                         }
                     }

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -949,6 +949,11 @@ void BLEManager::connectToScale(const QString& address) {
         } else {
             // A first BLE connection can fail before connectedChanged ever fires.
             // Keep the same timeout/retry path used by saved-scale connections.
+            // Marked manual so a timeout reports failure for THIS pick rather
+            // than entering the saved-WiFi-primary fallback ladder (the two
+            // are unrelated whenever the user is picking a different scale, or
+            // picking BLE for a scale whose saved primary is its WiFi address).
+            m_manualBleConnect = true;
             if (!m_scaleDevice || !m_scaleDevice->isConnected())
                 startScaleConnectionTimer();
             emit scaleDiscovered(entry.device, entry.type);
@@ -1596,7 +1601,12 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
         }
 
         // Scan-based auto-connects need the same deadline as manual selection.
-        if (!m_scaleDevice || !m_scaleDevice->isConnected())
+        // Guarded by scaleConnecting(): doStartScan() clears m_scales on every
+        // scan-cycle restart, so the saved scale re-enters this branch on each
+        // ~15 s cycle it keeps advertising without connecting. Without the
+        // guard, every cycle would push the deadline out by a fresh 20 s and
+        // the overall connection-attempt budget would never expire.
+        if ((!m_scaleDevice || !m_scaleDevice->isConnected()) && !scaleConnecting())
             startScaleConnectionTimer();
         emit scaleDiscovered(device, scaleType);
     }
@@ -1859,6 +1869,7 @@ void BLEManager::onScaleConnectedChanged() {
         const bool wasWifiFallbackConnect = m_wifiFallbackToBleActive;
         m_wifiFallbackToBleActive = false;  // Reset for the next saved-scale cycle
         m_manualWifiConnect = false;        // Manual WiFi add resolved (connected)
+        m_manualBleConnect = false;         // Manual BLE pick resolved (connected)
         m_lastScanErrorShown.clear();       // Healthy state — allow a future fresh scan error to pop again
         m_anyBleSuccessThisSession = true;  // Permission proven good (WiFi scales hit this too — see note below)
         m_flowScaleFallbackEmitted = false;  // Allow dialog again if scale disconnects and reconnect fails
@@ -1956,13 +1967,24 @@ void BLEManager::abortScaleDirectConnectIfPending(const QString& reason) {
 
     // The previous scan may already have cached this scale. Start a fresh cycle
     // so duplicate filtering cannot hide it after the parked attempt is closed.
+    // stopScan() also clears m_userInitiatedScaleScan; restore it so aborting
+    // this background attempt cannot silently demote a scan the user started
+    // (see the identical restore in scanForDevices()).
+    const bool wasUserInitiated = m_userInitiatedScaleScan;
     if (m_scanning)
         stopScan();
     m_scanningForScales = true;
+    m_userInitiatedScaleScan = wasUserInitiated;
     startScan();
 }
 
 void BLEManager::onScaleConnectionTimeout() {
+    // Direct emit, not stopScaleConnectionTimer(): m_scaleConnectionTimer is
+    // single-shot, and Qt stops a single-shot QTimer BEFORE emitting timeout()
+    // (qtbase/src/corelib/kernel/qtimer.cpp, timerEvent()), so scaleConnecting()
+    // already reads false here — stopScaleConnectionTimer()'s own "already
+    // inactive" guard would silently swallow this emit and leave the
+    // "Connecting..." UI stuck.
     emit scaleConnectingChanged();
     m_scaleDirectAbortTimer->stop();
 
@@ -2016,6 +2038,12 @@ void BLEManager::onScaleConnectionTimeout() {
     const bool manualWifiAttempt = m_manualWifiConnect;
     const QString manualHost = m_pendingWifiHostname;
     m_manualWifiConnect = false;
+    // Consume the manual-BLE-pick marker: the user chose this specific BLE row
+    // (possibly for a scale whose saved primary is a WiFi address), so a
+    // timeout here must not be mistaken for the saved WiFi primary's own
+    // reconnect failing.
+    const bool manualBleAttempt = m_manualBleConnect;
+    m_manualBleConnect = false;
 
     scaleRepeatFailure(QStringLiteral("Scale connection timeout — not found"));
 
@@ -2045,7 +2073,7 @@ void BLEManager::onScaleConnectionTimeout() {
     // fallback once per saved-scale cycle (the `!m_wifiFallbackToBleActive`
     // guard prevents a second fallback if the BLE scan itself times out). A
     // manual "Add WiFi Scale" attempt opts out — it surfaces "Not found" instead.
-    if (!manualWifiAttempt
+    if (!manualWifiAttempt && !manualBleAttempt
             && m_savedScaleAddress.startsWith(QStringLiteral("wifi:"), Qt::CaseInsensitive)) {
         // The direct attempt for the saved WiFi scale has now definitively
         // failed. Browse HERE, at the failure, rather than arming a flag for the
@@ -2322,12 +2350,19 @@ void BLEManager::resetScaleConnectionState() {
 void BLEManager::clearSavedScale() {
     scaleInfo(QStringLiteral("Forgetting scale %1 (%2)").arg(m_savedScaleName, m_savedScaleAddress));
     resetScaleConnectionState();
+    // Cancel every pending attempt tied to the address being forgotten — a
+    // deferred GATT-queue release, an in-flight WiFi fallback, or a manual
+    // WiFi/BLE connect — so none of them can land against a scale the user
+    // just discarded.
     m_scaleConnectDeferred = false;
     m_wifiFallbackToBleActive = false;
     m_manualWifiConnect = false;
-    m_savedScaleAddress.clear();
-    m_savedScaleType.clear();
-    m_savedScaleName.clear();
+    m_manualBleConnect = false;
+    // Route through the one funnel every saved-address change goes through
+    // (see its own comment) so the reconnect-browse state —
+    // m_wifiDirectAttemptFailed, m_browsedPrimaryIp — is reset here too,
+    // instead of surviving into whatever scale gets saved next.
+    setSavedScaleAddress(QString(), QString(), QString());
     m_scaleConnectionFailed = false;
     m_flowScaleFallbackEmitted = false;
     emit scaleConnectionFailedChanged();
@@ -3042,9 +3077,11 @@ void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
         return;
     }
 
-    // This is a saved-scale (re)connect, not a manual "Add WiFi Scale" attempt —
-    // so a timeout here should take the normal WiFi→BLE fallback path.
+    // This is a saved-scale (re)connect, not a manual "Add WiFi Scale" or manual
+    // BLE-row attempt — so a timeout here should take the normal WiFi→BLE
+    // fallback path.
     m_manualWifiConnect = false;
+    m_manualBleConnect = false;
 
     // Try the saved address alongside a scan. A scan result must not interrupt
     // an active connection; a stalled direct attempt is aborted before retrying.

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -839,7 +839,7 @@ void BLEManager::setScaleSimulated(bool simulated) {
     if (m_scaleSimulated) {
         // A simulated scale is taking over the weight stream — stand the real
         // one down so the two don't both drive weight.
-        m_scaleConnectionTimer->stop();
+        stopScaleConnectionTimer();
         emit disconnectScaleRequested();
     }
     scaleDebug(QStringLiteral("real-scale connects") + QStringLiteral(" ") + QString("%1").arg((simulated ? "blocked (simulated scale active)" : "allowed")));
@@ -938,7 +938,7 @@ void BLEManager::connectToScale(const QString& address) {
             // timer nothing emits either, so a scale that dropped into
             // power-save between the scan and the tap fails with no retry, no
             // dialog and no user-visible trace at all.
-            m_scaleConnectionTimer->start();
+            startScaleConnectionTimer();
             // Strip the "wifi:" prefix to get the bare hostname.
             setPendingWifiConnect(address.mid(QStringLiteral("wifi:").size()),
                                   entry.resolvedIp, entry.wsPort, entry.wsPath);
@@ -947,6 +947,10 @@ void BLEManager::connectToScale(const QString& address) {
             // advertised over DNS-SD (firmware defaults for a fallback hit).
             emit scaleDiscovered(QBluetoothDeviceInfo{}, entry.type);
         } else {
+            // A first BLE connection can fail before connectedChanged ever fires.
+            // Keep the same timeout/retry path used by saved-scale connections.
+            if (!m_scaleDevice || !m_scaleDevice->isConnected())
+                startScaleConnectionTimer();
             emit scaleDiscovered(entry.device, entry.type);
         }
         return;
@@ -1071,7 +1075,7 @@ void BLEManager::connectToWifiScale(const QString& hostnameOrIp, const QString& 
     // connect starts (as with any scale connect — not gated on connect success).
     m_manualWifiConnect = true;
     m_wifiFallbackToBleActive = false;
-    m_scaleConnectionTimer->start();
+    startScaleConnectionTimer();
     setPendingWifiConnect(host, resolvedIp);
     // Callers with a fresh mDNS resolution in hand (the "Add WiFi Scale"
     // dialog's suggested-scale "Use" button) pass it along so main.cpp can
@@ -1515,13 +1519,18 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
         // way to know the other half existed.
         scaleInfo(QString("Found %1: %2 (%3)").arg(scaleType).arg(device.name()).arg(getDeviceIdentifier(device)));
 
-        // If we're doing a direct wake and this is our saved scale found via scan,
-        // log it and clear the direct connect state. The scan-discovered device has
-        // proper BLE metadata which may help with connection.
+        // Discovery is not connection success. Keep the direct-attempt deadline
+        // while its transport is busy, and do not reset the driver's setup state.
         if (m_directConnectInProgress && deviceIdentifiersMatch(device, m_directConnectAddress)) {
-            scaleDebug("Direct wake: found saved scale in scan, using scanned device");
+            auto* transport = m_scaleDevice ? m_scaleDevice->bleTransport() : nullptr;
+            if (transport && (transport->isConnecting() || transport->isConnected())) {
+                scaleDebug("Direct wake: saved scale found in scan; waiting for the current connection attempt");
+                return;
+            }
+            scaleDebug("Direct wake: connecting to the scanned scale");
             m_directConnectInProgress = false;
             m_directConnectAddress.clear();
+            m_scaleDirectAbortTimer->stop();
         }
 
         // WiFi-to-BLE fallback: when the saved scale is a WiFi address but
@@ -1586,9 +1595,9 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
                            .arg(device.name(), getDeviceIdentifier(device)));
         }
 
-        // Auto-reconnect to the saved primary, or the WiFi-fallback Decent BLE
-        // candidate. (User-scan discoveries returned above; manual selection
-        // emits scaleDiscovered via connectToScale().)
+        // Scan-based auto-connects need the same deadline as manual selection.
+        if (!m_scaleDevice || !m_scaleDevice->isConnected())
+            startScaleConnectionTimer();
         emit scaleDiscovered(device, scaleType);
     }
 }
@@ -1840,7 +1849,7 @@ void BLEManager::setScaleDevice(ScaleDevice* scale) {
 void BLEManager::onScaleConnectedChanged() {
     if (m_scaleDevice && m_scaleDevice->isConnected()) {
         // Scale connected - stop timers, clear failure flag, clear direct connect state
-        m_scaleConnectionTimer->stop();
+        stopScaleConnectionTimer();
         m_scaleDirectAbortTimer->stop();
         m_directConnectInProgress = false;
         m_directConnectAddress.clear();
@@ -1924,7 +1933,13 @@ void BLEManager::abortScaleDirectConnectIfPending(const QString& reason) {
     if (!m_directConnectInProgress) return;
     if (m_scaleDevice && m_scaleDevice->isConnected()) return;  // connect raced in
 
-    scaleWarn(QString("Direct connect not established (%1) — aborting, scan continues").arg(reason));
+    auto* transport = m_scaleDevice ? m_scaleDevice->bleTransport() : nullptr;
+    if (transport && transport->isConnected()) {
+        // The link is up; service discovery keeps the overall setup deadline.
+        return;
+    }
+
+    scaleWarn(QString("Direct connect not established (%1) — aborting and restarting scan").arg(reason));
     m_directConnectInProgress = false;
     m_directConnectAddress.clear();
 
@@ -1935,19 +1950,20 @@ void BLEManager::abortScaleDirectConnectIfPending(const QString& reason) {
     // ScaleBleTransport::disconnectFromDevice() severs the controller's signals
     // before teardown, so this fires no spurious disconnected() cascade, and the
     // connecting→disconnected transition doesn't flip connectedChanged.
-    if (auto* transport = m_scaleDevice ? m_scaleDevice->bleTransport() : nullptr) {
+    if (transport) {
         transport->disconnectFromDevice();
     }
 
-    // Keep hunting passively — a present scale auto-connects via
-    // onDeviceDiscovered the instant it's seen advertising.
+    // The previous scan may already have cached this scale. Start a fresh cycle
+    // so duplicate filtering cannot hide it after the parked attempt is closed.
+    if (m_scanning)
+        stopScan();
     m_scanningForScales = true;
-    if (!m_scanning) {
-        startScan();
-    }
+    startScan();
 }
 
 void BLEManager::onScaleConnectionTimeout() {
+    emit scaleConnectingChanged();
     m_scaleDirectAbortTimer->stop();
 
     // A transport still holding anything at the overall timeout is stuck and
@@ -2111,7 +2127,7 @@ void BLEManager::beginWifiFallbackToBleScan() {
     // time budget — onScaleConnectionTimeout trips the FlowScale fallback
     // on the second timeout (the m_wifiFallbackToBleActive guard prevents
     // looping back into another WiFi-fallback cycle).
-    m_scaleConnectionTimer->start();
+    startScaleConnectionTimer();
 
     // Start scanning for BLE devices. onDeviceDiscovered sees a Decent BLE
     // scale, observes m_wifiFallbackToBleActive, and emits scaleDiscovered
@@ -2247,7 +2263,7 @@ void BLEManager::switchToWifiPrimary() {
     // the scale stranded on FlowScale; FlowScale is reached only if that BLE
     // scan also times out.
     m_wifiFallbackToBleActive = false;
-    m_scaleConnectionTimer->start();
+    startScaleConnectionTimer();
     emit disconnectScaleRequested();
     // Two callers, two kinds of evidence that the primary is back:
     //  - probeWifiPrimaryReachable() validated the PERSISTED cache, so there is
@@ -2278,6 +2294,19 @@ void BLEManager::setSavedScaleAddress(const QString& address, const QString& typ
     m_browsedPrimaryIp.clear();
 }
 
+void BLEManager::startScaleConnectionTimer() {
+    const bool wasConnecting = scaleConnecting();
+    m_scaleConnectionTimer->start();
+    if (!wasConnecting)
+        emit scaleConnectingChanged();
+}
+
+void BLEManager::stopScaleConnectionTimer() {
+    if (!scaleConnecting()) return;
+    m_scaleConnectionTimer->stop();
+    emit scaleConnectingChanged();
+}
+
 void BLEManager::resetScaleConnectionState() {
     // Only reset direct-connect state so a fresh attempt can proceed.
     // Do NOT reset m_scaleConnectionFailed or m_flowScaleFallbackEmitted here:
@@ -2286,16 +2315,20 @@ void BLEManager::resetScaleConnectionState() {
     // Both are reset when the scale actually connects (onScaleConnectedChanged).
     m_directConnectInProgress = false;
     m_directConnectAddress.clear();
-    m_scaleConnectionTimer->stop();
+    stopScaleConnectionTimer();
     m_scaleDirectAbortTimer->stop();
 }
 
 void BLEManager::clearSavedScale() {
+    scaleInfo(QStringLiteral("Forgetting scale %1 (%2)").arg(m_savedScaleName, m_savedScaleAddress));
+    resetScaleConnectionState();
+    m_scaleConnectDeferred = false;
+    m_wifiFallbackToBleActive = false;
+    m_manualWifiConnect = false;
     m_savedScaleAddress.clear();
     m_savedScaleType.clear();
     m_savedScaleName.clear();
     m_scaleConnectionFailed = false;
-    m_scaleConnectionTimer->stop();
     m_flowScaleFallbackEmitted = false;
     emit scaleConnectionFailedChanged();
     // Stop any pending auto-reconnect timer in main.cpp
@@ -3013,13 +3046,8 @@ void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
     // so a timeout here should take the normal WiFi→BLE fallback path.
     m_manualWifiConnect = false;
 
-    // Direct wake strategy:
-    // 1. Try direct connection to saved address (may wake sleeping scales that respond to connect requests)
-    // 2. Also start scanning in parallel (finds scales that are actively advertising)
-    // 3. Whichever succeeds first wins - we don't skip scan results even if direct connect is in progress
-    //
-    // de1app does both: ble connect + scanning, and calls ble_connect_to_scale again when
-    // the device appears in scan results (bluetooth.tcl lines 2032 and 2252-2256)
+    // Try the saved address alongside a scan. A scan result must not interrupt
+    // an active connection; a stalled direct attempt is aborted before retrying.
 
     QString deviceName = m_savedScaleName.isEmpty() ? m_savedScaleType : m_savedScaleName;
 
@@ -3051,7 +3079,7 @@ void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
         // 20 s connection timer still arms the WiFi->BLE fallback if the cached
         // IP is genuinely unreachable (onScaleConnectionTimeout).
         m_wifiFallbackToBleActive = false;          // Reset per attempt
-        m_scaleConnectionTimer->start();            // Fires onScaleConnectionTimeout if WiFi doesn't connect
+        startScaleConnectionTimer();
         // Alongside the direct attempt, once a previous one has failed.
         //
         // The direct A-query the driver falls back to can enter a state where it
@@ -3111,7 +3139,7 @@ void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
         // 1000-entry ring buffer, so the perpetual 60s ladder can't grow it
         // without bound.
         scaleInfo("Auto-reconnect: scanning for saved scale (no direct-connect)");
-        m_scaleConnectionTimer->start();   // bounded budget; arms WiFi/FlowScale fallback + retry ladder
+        startScaleConnectionTimer();
         m_scanningForScales = true;
         if (!m_scanning) {
             startScan();
@@ -3136,7 +3164,7 @@ void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
         m_directConnectAddress = m_savedScaleAddress;  // UUID
 
         // Start timeout timer
-        m_scaleConnectionTimer->start();
+        startScaleConnectionTimer();
 
         m_scanningForScales = true;
         if (!m_scanning) {
@@ -3182,19 +3210,17 @@ void BLEManager::tryDirectConnectToScale(bool allowDirectConnect) {
                                        : (m_de1Connected ? QStringLiteral("connected")
                                                          : QStringLiteral("down"))));
 
-    // Mark that we're doing a direct connect - but we won't skip scan results
-    // Instead, onDeviceDiscovered will check if scale is already connected
+    // Keep discovery from starting a duplicate connection while this one is busy.
     m_directConnectInProgress = true;
     m_directConnectAddress = upperAddress;
 
     // Start timeout timer
-    m_scaleConnectionTimer->start();
+    startScaleConnectionTimer();
 
     // Try direct connection - this may wake the scale
     emit scaleDiscovered(deviceInfo, m_savedScaleType);
 
-    // Also start scanning in parallel - if the scale is advertising, we'll find it
-    // and connect via the scan path (which has a real QBluetoothDeviceInfo)
+    // Scan alongside the direct attempt to list nearby devices.
     m_scanningForScales = true;
     if (!m_scanning) {
         startScan();

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -1135,8 +1135,16 @@ private:
     // report "Not found" directly instead of starting a WiFi→BLE fallback scan —
     // the user asked for a specific WiFi address, so we don't silently switch
     // transports. Set when the attempt starts; cleared on connect success, on
-    // timeout (consumed), and reset when a non-manual reconnect begins.
+    // timeout (consumed), reset when a non-manual reconnect begins, and cleared
+    // when the saved scale is forgotten (clearSavedScale).
     bool m_manualWifiConnect = false;
+    // True while a manually-tapped BLE scale row (connectToScale) connect
+    // attempt is pending. Tells onScaleConnectionTimeout not to treat a timeout
+    // as the saved WiFi primary's own reconnect failing — the user explicitly
+    // picked this BLE row, possibly for a scale whose saved primary is a WiFi
+    // address, so a WiFi→BLE fallback here would be mislabeled. Cleared on the
+    // same four occasions as m_manualWifiConnect above.
+    bool m_manualBleConnect = false;
     // Debounces user-visible scan-error popups. Without this, repeated scan
     // attempts (refractometer auto-reconnect ticks, scale reconnect retries)
     // would re-fire the same error toast indefinitely. We pop a given error

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -67,6 +67,7 @@ class BLEManager : public QObject {
     Q_PROPERTY(QVariantList discoveredDevices READ discoveredDevices NOTIFY devicesChanged)
     Q_PROPERTY(QVariantList discoveredScales READ discoveredScales NOTIFY scalesChanged)
     Q_PROPERTY(bool scaleConnectionFailed READ scaleConnectionFailed NOTIFY scaleConnectionFailedChanged)
+    Q_PROPERTY(bool scaleConnecting READ scaleConnecting NOTIFY scaleConnectingChanged)
     Q_PROPERTY(QVariantList discoveredRefractometers READ discoveredRefractometers NOTIFY refractometersChanged)
     Q_PROPERTY(bool refractometerConnected READ isRefractometerConnected NOTIFY refractometerConnectedChanged)
     Q_PROPERTY(bool hasSavedDE1 READ hasSavedDE1 CONSTANT)
@@ -106,6 +107,7 @@ public:
     QVariantList discoveredDevices() const;
     QVariantList discoveredScales() const;
     bool scaleConnectionFailed() const { return m_scaleConnectionFailed; }
+    bool scaleConnecting() const { return m_scaleConnectionTimer->isActive(); }
     bool hasSavedScale() const { return !m_savedScaleAddress.isEmpty(); }
     // True when the saved primary is the debug simulator's synthetic entry
     // ("sim:..."), which main.cpp promotes to primary when no real scale has
@@ -779,6 +781,7 @@ signals:
     void devicesChanged();
     void scalesChanged();
     void scaleConnectionFailedChanged();
+    void scaleConnectingChanged();
     void de1Discovered(const QBluetoothDeviceInfo& device);
     // For BLE entries `device` carries the real QBluetoothDeviceInfo. For
     // WiFi entries (type == "decent-wifi") `device` is default-constructed
@@ -866,6 +869,8 @@ private slots:
 
 private:
     bool isDE1Device(const QBluetoothDeviceInfo& device) const;
+    void startScaleConnectionTimer();
+    void stopScaleConnectionTimer();
     QString getScaleType(const QBluetoothDeviceInfo& device) const;
     void requestBluetoothPermission();
     void doStartScan();


### PR DESCRIPTION
Discovered scales could look disconnected or still remembered after Forget because the list did not explain that selection was required. Connections now shows **Scale found, select your scale:** above unpaired scales, labels other discoveries **Available Devices**, and shows **Connecting...** during an active attempt. Selection remains explicit so Forget cannot immediately pair the same scale again.

P80X logs also exposed connection attempts losing their short abort deadline when a scan rediscovered the saved scale. Preserve that deadline without re-entering driver setup, restart discovery after aborting a stalled attempt, and apply the existing overall timeout/retry path to manual and scan-based BLE connections. Established links retain time for service discovery. Forget cancels pending direct and deferred attempts.

Validation:
- [Android build](https://github.com/Kulitorum/Decenza/actions/runs/34210094929) passed; the APK is installed on the P80X.
- [Linux build and full suite](https://github.com/Kulitorum/Decenza/actions/runs/34210299270) passed: 115/115, with no test retries. Both runs tested `544f0b3b`. These use the documented branch workflows because Qt Creator MCP was unavailable.
- Source checks passed for translations, rich text, fonts, logging, MCP budget, test-source duplication, and whitespace.
- On the P80X, selecting SKALE connected in about 1.4 seconds; Forget remained cleared after restart. The four-second abort and automatic retry path were observed while the scale was unavailable. A final saved-scale startup test with the scale confirmed awake remains to be verified; the DE1 was out of range during testing.

The companion [wiki manual update](https://github.com/Kulitorum/Decenza/wiki/Manual#connecting-a-scale) documents selection, automatic reconnection, and Forget.