### PR TITLE
chore: bump libtailscale pin to decenza-v1.94.1-6

### DIFF
--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -13,7 +13,7 @@
 
 # The tag this source tree expects. Not a cache variable: it is the pin, and a
 # stale build directory must not be able to silently disagree with it.
-set(_TSNET_EXPECTED_TAG "decenza-v1.94.1-5")
+set(_TSNET_EXPECTED_TAG "decenza-v1.94.1-6")
 
 set(TSNET_TAG "${_TSNET_EXPECTED_TAG}" CACHE STRING "libtailscale prebuilt release tag")
 
@@ -47,13 +47,13 @@ set(TSNET_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/tsnet-${TSNET_TAG}")
 # Per-platform artifact + expected SHA-256 (from manifest.json).
 if(IOS)
     set(_tsnet_zip "libtailscale-ios.zip")
-    set(_tsnet_sha "706cbbd25d60dce49f5935018931a500e48cd4d498847294eeafdc6efbb0b739")
+    set(_tsnet_sha "df405336afb4844f5fd9140c03b4c9ee52bb2edff14a3d899c3fc32021fa6ffc")
 elseif(ANDROID)
     set(_tsnet_zip "libtailscale-android.zip")
-    set(_tsnet_sha "80331572de0565b0be2465b67d8839efb564008281776393430b19d85cbdb3e0")
+    set(_tsnet_sha "83d8d2c13766d3fcfba2b9f1cc69f89dac71637f3e036b9e2f5e925c0f7256e1")
 elseif(APPLE)
     set(_tsnet_zip "libtailscale-macos.zip")
-    set(_tsnet_sha "9e6b42c895a7cd660c1233aead0c693417033a431b93450b79af9c0aeafc3582")
+    set(_tsnet_sha "8a4fb393215273f4eb1f8c46d7d4b6a52e1529fcdc511d48ae23ab0caffe82dd")
 else()
     message(FATAL_ERROR "ENABLE_TSNET: no prebuilt libtailscale artifact for this platform yet "
                         "(supported: macOS, Android, iOS). Use Mode C (BYO URL) instead.")


### PR DESCRIPTION
Adopts the new prebuilt libtailscale release from `skialpine/libtailscale`, replacing `decenza-v1.94.1-5`.

`cmake/tsnet.cmake` treats the tag and the three per-artifact SHA-256s as one unit, so all four move together.

## Hash provenance

The three hashes come from the release `manifest.json` and were independently confirmed against three other sources — all four agree:

| Artifact | SHA-256 |
|---|---|
| `libtailscale-macos.zip` | `8a4fb393215273f4eb1f8c46d7d4b6a52e1529fcdc511d48ae23ab0caffe82dd` |
| `libtailscale-ios.zip` | `df405336afb4844f5fd9140c03b4c9ee52bb2edff14a3d899c3fc32021fa6ffc` |
| `libtailscale-android.zip` | `83d8d2c13766d3fcfba2b9f1cc69f89dac71637f3e036b9e2f5e925c0f7256e1` |

Checked against `manifest.json`, `SHA256SUMS.txt`, the GitHub API asset digests, and a local `shasum -a 256` of each downloaded zip.

## Archive layout unchanged

Every path `tsnet.cmake` asserts still resolves:

- `libtailscale-macos/include/tailscale.h`, `libtailscale-macos/libtailscale.a`
- `libtailscale.xcframework/ios-arm64/Headers/tailscale.h`, `.../libtailscale_ios.a`
- `libtailscale-android/include/tailscale.h`, `libtailscale-android/jniLibs/<abi>/libtailscale.so` for `arm64-v8a`, `armeabi-v7a`, `x86_64`

## Header diff

`tailscale.h` is purely additive against -5 — one new function, nothing changed or removed:

```c
extern int tailscale_status_json(tailscale sd, char** json_out);
```

It reads backend status through tsnet's in-memory LocalAPI listener rather than the loopback HTTP server, because the loopback address goes permanently stale when iOS reclaims the listener from a suspended process. Decenza does not currently read status over loopback (no `tailscale_loopback` / localapi / `/status` reference in `src/`), so this PR needs no source change. Adopting the new call is left to whoever picks up the iOS suspend-resume case.

## Verification

macOS Debug configure + build: the -6 archive downloads, passes its `EXPECTED_HASH`, and the app links against it. 0 errors; the single warning is the pre-existing `__eh_frame` linker noise.

Not covered locally: iOS and Android link only in their own workflows. The layout check above is what stands in for them until a platform build runs.

No OpenSpec change — this is a dependency pin bump with no spec surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)