### PR TITLE
Re-upload the profile after a cleared queue leaves the DE1 unknown

### DIFF
--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -72,33 +72,51 @@ static constexpr int kUploadRetryBaseMs = 1000;
 static constexpr int kUploadRetryMaxMs = 8000;
 static constexpr int kMaxUploadRetryAttempts = 5;
 
-// Reasons returned by DE1Device::profileUploaded(false, reason) that should
-// NOT trigger an auto-retry. The rest (frame sequence mismatch, ACK timeout)
-// are treated as retryable.
+// How a failed upload must be followed up. Reasons come from
+// DE1Device::profileUploaded(false, reason); matching them in one table keeps
+// the prefixes off the handler, where a second match site would be free to
+// drift from this one.
 //
 // We use startsWith() rather than exact equality so DE1Device can include
 // variable details after a stable prefix — for example "frame sequence
 // mismatch (expected [0x00, 0x01], got [0x00, 0x00])" carries the hex
-// payload in the same string. The exact retryable/non-retryable prefix
-// text is locked down by tst_profileupload.cpp's `.at(1).toString()`
-// assertions, so any future rename of a reason string in
-// finishProfileUpload() will break those tests loudly before it can
-// silently flip classification here.
-static bool isRetryableUploadFailure(const QString& reason) {
+// payload in the same string. The exact prefix text is locked down by
+// tst_profileupload.cpp's `.at(1).toString()` assertions, so any future
+// rename of a reason string in finishProfileUpload() will break those tests
+// loudly before it can silently flip classification here.
+enum class UploadFailureFollowUp {
+    Retry,    // Transient — arm the backoff timer.
+    ReArm,    // What the DE1 now holds is unknown — re-upload at the next safe moment.
+    Defer,    // Another path already owns the re-upload.
+};
+
+static UploadFailureFollowUp classifyUploadFailure(const QString& reason) {
     // Superseded: a newer upload is already in flight — let it own the outcome.
-    if (reason.startsWith(QStringLiteral("superseded"))) return false;
-    // Queue cleared: a shot/steam/hot-water just started, clearing the queue
-    // intentionally. The next uploadCurrentProfile() will re-arm.
-    if (reason.startsWith(QStringLiteral("command queue cleared"))) return false;
+    if (reason.startsWith(QStringLiteral("superseded")))
+        return UploadFailureFollowUp::Defer;
+    // Queue cleared: flow started and cleared the queue mid-upload. A timer
+    // retry would fight the shot, but Defer is wrong too — nothing else
+    // re-uploads, and what the DE1 holds is now unknown. Frames are indexed
+    // slot writes with no commit step (profile.cpp:2298) under a header that
+    // already declared the new frame COUNT (profile.cpp:2276), so an
+    // interrupted batch leaves the machine executing that count over a MIX of
+    // new frames and the previous profile's in the slots that never arrived —
+    // and the group-head button extracts that mix without the app in the loop.
+    // ReArm restores the invariant via phaseChanged, once the machine is
+    // Idle/Ready again: after the flow, never during it.
+    if (reason.startsWith(QStringLiteral("command queue cleared")))
+        return UploadFailureFollowUp::ReArm;
     // BLE disconnect: the reconnect path (initialSettingsComplete ->
     // applyAllSettings -> uploadCurrentProfile) already re-uploads when the
     // link comes back. Retrying on a timer would race with that.
-    if (reason.startsWith(QStringLiteral("BLE disconnect"))) return false;
+    if (reason.startsWith(QStringLiteral("BLE disconnect")))
+        return UploadFailureFollowUp::Defer;
     // Firmware flash: DE1Device dropped the call because a firmware update is in
     // progress. The reconnect path re-uploads once the flash completes and the
     // DE1 reconnects — no timer retry needed, and it would just flood the log.
-    if (reason.startsWith(QStringLiteral("firmware flash"))) return false;
-    return true;
+    if (reason.startsWith(QStringLiteral("firmware flash")))
+        return UploadFailureFollowUp::Defer;
+    return UploadFailureFollowUp::Retry;
 }
 
 
@@ -139,8 +157,8 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
     // with a retryable reason, arm m_profileUploadRetryTimer with exponential
     // backoff (capped at 8s). After kMaxUploadRetryAttempts consecutive
     // failures, give up and set m_de1CommunicationFailure so the UI surfaces
-    // a "power-cycle the DE1" dialog. Success — or any non-retryable reason
-    // like "superseded" — resets the counter.
+    // a "power-cycle the DE1" dialog. Only success resets the counter; a
+    // non-retryable reason returns without touching it.
     m_profileUploadRetryTimer.setSingleShot(true);
     connect(&m_profileUploadRetryTimer, &QTimer::timeout, this, [this]() {
         DIAG_DEBUG(PROFILES, "ProfileManager") << "retrying failed profile upload (attempt"
@@ -177,13 +195,23 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 }
                 return;
             }
-            if (!isRetryableUploadFailure(reason)) {
-                // Not a retry condition — don't bump the counter. The
-                // existing m_profileUploadPending / phaseChanged machinery
-                // handles queue-clear and supersede cases on its own.
-                // The pending upload (if any) will ride the reconnect path.
-                if (hadPending) {
+            const UploadFailureFollowUp followUp = classifyUploadFailure(reason);
+            if (followUp != UploadFailureFollowUp::Retry) {
+                // Not a retry condition — don't bump the counter and don't arm
+                // the timer; it would race a shot, a newer upload, or a
+                // reconnect. A deferred profile change still rides the path
+                // that owns the re-upload.
+                if (hadPending || followUp == UploadFailureFollowUp::ReArm) {
                     m_profileUploadPending = true;
+                }
+                if (followUp == UploadFailureFollowUp::ReArm) {
+                    // The matching WARN is DE1Device's "Profile upload FAILED".
+                    // Say the recovery at a tier the connections views show
+                    // (they default to minLevel INFO), or a reader sees only
+                    // the failure half and concludes it never recovered.
+                    DIAG_INFO(PROFILES, "ProfileManager")
+                        << "profile upload was cleared by the machine; "
+                           "re-queued and will upload when it returns to idle";
                 }
                 return;
             }

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -4592,6 +4592,68 @@ private slots:
         QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
     }
 
+    void queueClearFailureReArmsPendingUpload() {
+        // A cleared queue leaves the DE1 holding an UNKNOWN profile: frames are
+        // indexed slot writes with no commit step, under a header that already
+        // declared the new frame count. The app cannot gate a group-head shot,
+        // so the pending flag is the only thing that restores the invariant.
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("command queue cleared during upload"));
+
+        QVERIFY(f.profileManager.m_profileUploadPending);
+    }
+
+    void supersededFailureDoesNotReArmPendingUpload() {
+        // The counterpart: the newer upload owns the outcome, so re-arming here
+        // would queue a redundant third upload on the next phase change.
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("superseded by a new upload"));
+
+        QVERIFY(!f.profileManager.m_profileUploadPending);
+    }
+
+    void queueClearedUploadRetriesOnceFlowEnds() {
+        // The field sequence from the 2026-09-10 Android log, end to end:
+        // deferred upload on a sleeping machine, wake to Idle, upload starts,
+        // an auto-flush clears the queue mid-batch. Before the ReArm
+        // classification the pending flag was dropped here and the machine kept
+        // whatever it held until the user next touched a profile.
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.transport.writes.clear();
+
+        f.machineState.m_phase = MachineState::Phase::Sleep;
+        f.profileManager.uploadCurrentProfileOnConnect();
+        QVERIFY(f.writesTo(DE1::Characteristic::HEADER_WRITE).isEmpty());
+
+        f.machineState.m_phase = MachineState::Phase::Idle;
+        emit f.machineState.phaseChanged();
+        QCOMPARE(f.writesTo(DE1::Characteristic::HEADER_WRITE).size(), 1);
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("command queue cleared during upload"));
+
+        // Flow is running — nothing may be written at the machine now.
+        f.transport.writes.clear();
+        f.machineState.m_phase = MachineState::Phase::Pouring;
+        emit f.machineState.phaseChanged();
+        QVERIFY(f.writesTo(DE1::Characteristic::HEADER_WRITE).isEmpty());
+
+        // Flow ended: the profile must go back up before the next shot.
+        f.machineState.m_phase = MachineState::Phase::Idle;
+        emit f.machineState.phaseChanged();
+        QCOMPARE(f.writesTo(DE1::Characteristic::HEADER_WRITE).size(), 1);
+        QVERIFY(!f.writesTo(DE1::Characteristic::FRAME_WRITE).isEmpty());
+    }
+
     void transportDisconnectResetsRetryState() {
         McpTestFixture f;
         loadDFlowProfile(f);


### PR DESCRIPTION
## What

A profile upload interrupted by flow starting was classified as non-retryable and then forgotten, leaving the DE1 holding an unknown profile with nothing to correct it. Found by reading 50 hours of Android debug log (2.0.5 build 3590, SM-X210); it occurred once there without reaching a shot.

## The bug

When flow starts, `MachineState` clears the DE1 command queue, which aborts any upload in flight with reason `"command queue cleared during upload"`. That reason is deliberately non-retryable — a timer retry would fight the running shot. But the handler only restored `m_profileUploadPending` when a *newer* profile change had queued behind the upload (`m_uploadPendingAfterInFlight`):

```cpp
if (!isRetryableUploadFailure(reason)) {
    if (hadPending) { m_profileUploadPending = true; }
    return;
}
```

`uploadCurrentProfile()` clears that flag on entry, so in the common case — a deferred upload firing on wake, then an auto-flush clearing the queue — nothing had queued behind it and the flag was lost. The `phaseChanged` handler then dead-ends on its first line (`if (!m_profileUploadPending) return;`), and because the branch returns before `updateProfileUploadRetrying()` and the retry counter, no banner and no dialog appear either. The DE1 keeps whatever it holds until the user next touches a profile.

**Why that matters.** Frames are indexed slot writes (`frame[0] = FrameToWrite`, `profile.cpp:2298`) with no commit step, under a header that already declared the new frame *count* (`profile.cpp:2276`). An interrupted batch can therefore leave the machine executing that count over a **mix of new frames and the previous profile's frames** in the slots that never arrived. The group-head button starts extraction with the app not in the loop, so the app cannot gate the shot — the only defence is the invariant that the DE1 always holds a complete, known profile.

The `"will re-arm"` rationale in the original comment was wrong from the start (added in #748), not something that regressed later.

## The fix

`isRetryableUploadFailure()` becomes `classifyUploadFailure()`, returning `Retry` / `ReArm` / `Defer` from one table of reason prefixes, so the strings are matched in exactly one place rather than at a second site in the handler. `"command queue cleared"` is now `ReArm`: still no timer retry, so it never fights the running shot, but the pending flag is set unconditionally and `phaseChanged` re-uploads once the machine is back to Idle/Ready — after the flow, never during it. Supersede, BLE disconnect and firmware flash stay `Defer`, where another path already owns the re-upload.

The recovery is logged at INFO to pair with the WARN `DE1Device` already emits on the failure. The connections views default to `minLevel INFO`, so a DEBUG line would have shown a reader only the failure half.

Two comments in the same handler corrected while here: the retry counter is reset only on success (not on "any non-retryable reason", as it claimed), and `clearCommandQueue()` is reached from `stopOperationUrgent()` as well as from flow start, so the INFO line no longer says "starting".

## Testing

Three tests added to `tst_profilemanager` (new functions in an existing file, no new target):

- `queueClearFailureReArmsPendingUpload` — the lost invariant.
- `queueClearedUploadRetriesOnceFlowEnds` — the field sequence end to end: asleep, wake to Idle, upload starts, queue cleared, nothing written during Pouring, re-upload on return to Idle.
- `supersededFailureDoesNotReArmPendingUpload` — boundary guard, so a future change cannot widen `ReArm` to every non-retryable reason.

Both new behaviour tests were confirmed to **fail without the fix** (`ReArm` temporarily reverted to `Defer`):

```
FAIL!  : queueClearFailureReArmsPendingUpload() 'm_profileUploadPending' returned FALSE
FAIL!  : queueClearedUploadRetriesOnceFlowEnds() Compared values are not the same
```

With the fix restored: **117/117 test targets pass, 0 failures, 0 skipped, no warnings** (Qt Creator, macOS Debug). All seven `text-invariants.yml` gates pass locally.

## Known, not addressed

`ReArm` arms the pending flag at the start of the flow that cleared the queue, so it stays armed for that whole flow. `Phase::Heating` passes both the `phaseChanged` allow-list and `uploadCurrentProfile()`'s `isActivePhase` block list, and `State::Steam` with a non-flow substate maps to `Phase::Heating` — so in principle a mid-steam substate change could fire an upload during steam.

Deliberately not guarded. The window is pre-existing (`uploadCurrentProfile()` already armed the flag mid-flow when blocked by an active phase), `Heating` cannot leave the allow-list because it is the normal wake path that five of six deferred uploads in the log resolved on, and nobody has shown the DE1 actually emits such a substate mid-steam. Guarding an unobserved state would be speculative. Recorded here so it can be fixed with evidence if it ever shows up in the field.

## Scope note

An earlier revision of this PR also gated the refractometer auto-connect in `blemanager.cpp::onDeviceDiscovered()` on `m_refractometerHunt`, to stop a failed R2 discovery holding the one-at-a-time GATT queue for ~6 s. That has been dropped: every such stall in the 50-hour log landed while the machine was idle, and the gate as written introduced a regression of its own (the duplicate-device `return` runs before the auto-connect decision, so an R2 first seen while the hunt was off stayed locked out for the rest of that scan). Not worth carrying a new regression to fix a stall nothing was waiting on. `blemanager.cpp` is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)